### PR TITLE
feat: add Skill UI extension system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CLAUDE.md
 *.gem
 .DS_Store
 .history
+dev

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ CLAUDE.md
 *.gem
 .DS_Store
 .history
-dev

--- a/lib/clacky.rb
+++ b/lib/clacky.rb
@@ -62,6 +62,9 @@ require_relative "clacky/server/web_ui_controller"
 require_relative "clacky/server/browser_manager"
 require_relative "clacky/cli"
 
+# Skill UI extension system — loaded last to avoid upstream conflict surface area
+require_relative "clacky/ui_extension_loader"
+
 module Clacky
   class AgentInterrupted < Exception; end  # Inherit from Exception to bypass rescue StandardError
   class AgentError < StandardError; end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -13,6 +13,7 @@ require_relative "session_registry"
 require_relative "web_ui_controller"
 require_relative "scheduler"
 require_relative "../brand_config"
+require_relative "skill_ui_routes"
 require_relative "channel"
 require_relative "../banner"
 require_relative "../utils/file_processor"
@@ -85,6 +86,8 @@ module Clacky
     #   *    /api/*                  → JSON REST API (sessions, tasks, schedules)
     #   GET  /**                     → static files served from lib/clacky/web/ directory
     class HttpServer
+      include Clacky::SkillUiRoutes
+
       WEB_ROOT = File.expand_path("../web", __dir__)
 
       # Default SOUL.md written when the user skips the onboard conversation.
@@ -165,6 +168,8 @@ module Clacky
         )
         @browser_manager = Clacky::BrowserManager.instance
         @skill_loader    = Clacky::SkillLoader.new(working_dir: nil, brand_config: Clacky::BrandConfig.load)
+        # Load skill UI route handlers from each skill's ui/routes.rb (if present).
+        load_skill_ui_routes
       end
 
       def start
@@ -308,8 +313,16 @@ module Clacky
         when ["GET",    "/api/version"]           then api_get_version(res)
         when ["POST",   "/api/version/upgrade"]   then api_upgrade_version(req, res)
         when ["POST",   "/api/restart"]           then api_restart(req, res)
+        when ["GET",    "/api/ui-extensions"]     then api_list_skill_uis(res)
         else
-          if method == "POST" && path.match?(%r{^/api/channels/[^/]+/test$})
+          if method == "GET" && path.match?(%r{^/api/ui-extensions/[^/]+/assets/[^/]+$})
+            parts    = path.split("/")
+            skill_id = URI.decode_www_form_component(parts[3])
+            filename = URI.decode_www_form_component(parts[5])
+            api_skill_ui_asset(skill_id, filename, res)
+          elsif (handler = match_skill_ui_route(method, path))
+            handler.call(req, res)
+          elsif method == "POST" && path.match?(%r{^/api/channels/[^/]+/test$})
             platform = path.sub("/api/channels/", "").sub("/test", "")
             api_test_channel(platform, req, res)
           elsif method == "POST" && path.start_with?("/api/channels/")

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1813,9 +1813,9 @@ module Clacky
       # @param working_dir [String] working directory for the agent
       # @param permission_mode [Symbol] :confirm_all (default, human present) or
       #   :auto_approve (unattended — suppresses request_user_feedback waits)
-      def build_session(name:, working_dir:, permission_mode: :confirm_all, profile: "general", source: :manual, hidden: false)
+      def build_session(name:, working_dir:, permission_mode: :confirm_all, profile: "general", source: :manual)
         session_id = Clacky::SessionManager.generate_id
-        @registry.create(session_id: session_id, hidden: hidden)
+        @registry.create(session_id: session_id)
 
         client = @client_factory.call
         config = @agent_config.deep_copy

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1813,9 +1813,9 @@ module Clacky
       # @param working_dir [String] working directory for the agent
       # @param permission_mode [Symbol] :confirm_all (default, human present) or
       #   :auto_approve (unattended — suppresses request_user_feedback waits)
-      def build_session(name:, working_dir:, permission_mode: :confirm_all, profile: "general", source: :manual)
+      def build_session(name:, working_dir:, permission_mode: :confirm_all, profile: "general", source: :manual, hidden: false)
         session_id = Clacky::SessionManager.generate_id
-        @registry.create(session_id: session_id)
+        @registry.create(session_id: session_id, hidden: hidden)
 
         client = @client_factory.call
         config = @agent_config.deep_copy

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1843,7 +1843,7 @@ module Clacky
       # Restore a persisted session from saved session_data (from SessionManager).
       # The agent keeps its original session_id so the frontend URL hash stays valid
       # across server restarts.
-      def build_session_from_data(session_data, permission_mode: :confirm_all)
+      def build_session_from_data(session_data, permission_mode: :confirm_all, profile: nil)
         original_id = session_data[:session_id]
 
         # Skip if this session is already registered (e.g., restored by a previous call)
@@ -1857,11 +1857,11 @@ module Clacky
         config.permission_mode = permission_mode
         broadcaster = method(:broadcast)
         ui = WebUIController.new(original_id, broadcaster)
-        # Restore the agent profile from the persisted session; fall back to "general"
-        # for sessions saved before the agent_profile field was introduced.
-        profile = session_data[:agent_profile].to_s
-        profile = "general" if profile.empty?
-        agent = Clacky::Agent.from_session(client, config, session_data, ui: ui, profile: profile)
+        # Use explicit profile if given; otherwise restore from persisted session data;
+        # fall back to "general" for sessions saved before the agent_profile field was introduced.
+        resolved_profile = profile || session_data[:agent_profile].to_s
+        resolved_profile = "general" if resolved_profile.empty?
+        agent = Clacky::Agent.from_session(client, config, session_data, ui: ui, profile: resolved_profile)
         idle_timer = build_idle_timer(original_id, agent)
 
         @registry.with_session(original_id) do |s|

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -149,35 +149,6 @@ module Clacky
         end
       end
 
-      # Return a summary hash for a single session by id.
-      # Used by broadcast_session_update and Skill UI plugins to fetch session metadata
-      # directly by id without going through the public list.
-      # Returns nil if the session does not exist in memory.
-      def session_summary(session_id)
-        session = @mutex.synchronize { @sessions[session_id] }
-        return nil unless session
-
-        agent = session[:agent]
-        return nil unless agent
-
-        model_info = agent.current_model_info
-        {
-          id:              session[:id],
-          name:            agent.name,
-          working_dir:     agent.working_dir,
-          status:          session[:status],
-          created_at:      agent.created_at,
-          updated_at:      session[:updated_at].iso8601,
-          total_tasks:     agent.total_tasks || 0,
-          total_cost:      agent.total_cost  || 0.0,
-          error:           session[:error],
-          model:           model_info&.dig(:model),
-          permission_mode: agent.permission_mode,
-          source:          agent.source.to_s,
-          agent_profile:   agent.agent_profile.name,
-        }
-      end
-
       private
 
       # Normalize source field from a disk session hash.

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -29,7 +29,13 @@ module Clacky
 
       # Create a new (empty) session entry and return its id.
       # agent/ui/thread are set later via with_session once they are constructed.
-      def create(session_id:)
+      #
+      # Pass hidden: true for Skill UI plugin sessions that should not appear in
+      # the user-facing session list (e.g. a background session used internally by
+      # a skill to run sub-tasks without polluting the conversation list).
+      # IM channel sessions (Feishu, WeCom) are NOT hidden — they should be visible
+      # in the UI so users can view history and continue the conversation in the browser.
+      def create(session_id:, hidden: false)
         raise ArgumentError, "session_id is required" if session_id.nil? || session_id.empty?
 
         session = {
@@ -37,6 +43,7 @@ module Clacky
           status:               :idle,
           error:                nil,
           updated_at:           Time.now,
+          hidden:               hidden,  # true = exclude from UI session list (Skill UI plugin use only)
           agent:                nil,
           ui:                   nil,
           thread:               nil,
@@ -115,10 +122,13 @@ module Clacky
         return [] unless @session_manager
 
         live = @mutex.synchronize do
-          @sessions.transform_values { |s| { status: s[:status], error: s[:error] } }
+          @sessions.transform_values { |s| { status: s[:status], error: s[:error], hidden: s[:hidden] } }
         end
 
         all = @session_manager.all_sessions  # already sorted newest-first
+
+        # Exclude hidden sessions (Skill UI plugin background sessions)
+        all = all.reject { |s| live[s[:session_id]]&.dig(:hidden) }
 
         # ── source filter ────────────────────────────────────────────────────
         all = all.select { |s| s_source(s) == source } if source
@@ -147,6 +157,48 @@ module Clacky
             total_cost:    s.dig(:stats, :total_cost_usd) || 0.0,
           }
         end
+      end
+
+      # Return all session ids (including hidden ones) whose raw session hash
+      # satisfies the given block. Used internally by ChannelManager to locate
+      # channel-bound sessions that are hidden from the UI list.
+      # @yieldparam session [Hash] raw session hash (read only inside block)
+      # @return [Array<String>] matching session ids
+      def find_ids(&block)
+        @mutex.synchronize do
+          @sessions.each_with_object([]) do |(id, session), ids|
+            ids << id if block.call(session)
+          end
+        end
+      end
+
+      # Return a summary hash for a single session by id (includes hidden sessions).
+      # Used by broadcast_session_update and Skill UI plugins to fetch session metadata
+      # directly by id without going through the public list.
+      # Returns nil if the session does not exist in memory.
+      def session_summary(session_id)
+        session = @mutex.synchronize { @sessions[session_id] }
+        return nil unless session
+
+        agent = session[:agent]
+        return nil unless agent
+
+        model_info = agent.current_model_info
+        {
+          id:              session[:id],
+          name:            agent.name,
+          working_dir:     agent.working_dir,
+          status:          session[:status],
+          created_at:      agent.created_at,
+          updated_at:      session[:updated_at].iso8601,
+          total_tasks:     agent.total_tasks || 0,
+          total_cost:      agent.total_cost  || 0.0,
+          error:           session[:error],
+          model:           model_info&.dig(:model),
+          permission_mode: agent.permission_mode,
+          source:          agent.source.to_s,
+          agent_profile:   agent.agent_profile.name,
+        }
       end
 
       private

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -29,13 +29,7 @@ module Clacky
 
       # Create a new (empty) session entry and return its id.
       # agent/ui/thread are set later via with_session once they are constructed.
-      #
-      # Pass hidden: true for Skill UI plugin sessions that should not appear in
-      # the user-facing session list (e.g. a background session used internally by
-      # a skill to run sub-tasks without polluting the conversation list).
-      # IM channel sessions (Feishu, WeCom) are NOT hidden — they should be visible
-      # in the UI so users can view history and continue the conversation in the browser.
-      def create(session_id:, hidden: false)
+      def create(session_id:)
         raise ArgumentError, "session_id is required" if session_id.nil? || session_id.empty?
 
         session = {
@@ -43,7 +37,6 @@ module Clacky
           status:               :idle,
           error:                nil,
           updated_at:           Time.now,
-          hidden:               hidden,  # true = exclude from UI session list (Skill UI plugin use only)
           agent:                nil,
           ui:                   nil,
           thread:               nil,
@@ -122,13 +115,10 @@ module Clacky
         return [] unless @session_manager
 
         live = @mutex.synchronize do
-          @sessions.transform_values { |s| { status: s[:status], error: s[:error], hidden: s[:hidden] } }
+          @sessions.transform_values { |s| { status: s[:status], error: s[:error] } }
         end
 
         all = @session_manager.all_sessions  # already sorted newest-first
-
-        # Exclude hidden sessions (Skill UI plugin background sessions)
-        all = all.reject { |s| live[s[:session_id]]&.dig(:hidden) }
 
         # ── source filter ────────────────────────────────────────────────────
         all = all.select { |s| s_source(s) == source } if source
@@ -159,9 +149,8 @@ module Clacky
         end
       end
 
-      # Return all session ids (including hidden ones) whose raw session hash
-      # satisfies the given block. Used internally by ChannelManager to locate
-      # channel-bound sessions that are hidden from the UI list.
+      # Return all session ids whose raw session hash satisfies the given block.
+      # Used internally by ChannelManager to locate channel-bound sessions.
       # @yieldparam session [Hash] raw session hash (read only inside block)
       # @return [Array<String>] matching session ids
       def find_ids(&block)
@@ -172,7 +161,7 @@ module Clacky
         end
       end
 
-      # Return a summary hash for a single session by id (includes hidden sessions).
+      # Return a summary hash for a single session by id.
       # Used by broadcast_session_update and Skill UI plugins to fetch session metadata
       # directly by id without going through the public list.
       # Returns nil if the session does not exist in memory.

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -149,18 +149,6 @@ module Clacky
         end
       end
 
-      # Return all session ids whose raw session hash satisfies the given block.
-      # Used internally by ChannelManager to locate channel-bound sessions.
-      # @yieldparam session [Hash] raw session hash (read only inside block)
-      # @return [Array<String>] matching session ids
-      def find_ids(&block)
-        @mutex.synchronize do
-          @sessions.each_with_object([]) do |(id, session), ids|
-            ids << id if block.call(session)
-          end
-        end
-      end
-
       # Return a summary hash for a single session by id.
       # Used by broadcast_session_update and Skill UI plugins to fetch session metadata
       # directly by id without going through the public list.

--- a/lib/clacky/server/skill_ui_routes.rb
+++ b/lib/clacky/server/skill_ui_routes.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Clacky
+  # SkillUiRouter — DSL used by skill UI routes.rb files to register API routes.
+  #
+  # Each skill's ui/routes.rb is evaluated via instance_eval on a SkillUiRouter instance.
+  # Registered routes are stored in the HttpServer's _skill_ui_routes table and matched
+  # on every incoming request after the built-in routes fail to match.
+  #
+  # Usage in skill's ui/routes.rb:
+  #   get("/api/my-skill/items") { |req, res, _| ... }
+  #   post("/api/my-skill/items") { |req, res, _| ... }
+  #   get(%r{^/api/my-skill/items/([^/]+)$}) { |req, res, captures| id = captures[0]; ... }
+  #
+  # The handler block is instance_exec'd on the HttpServer, giving access to all
+  # server helpers: json_response, parse_json_body, build_session, @registry, etc.
+  class SkillUiRouter
+    def initialize(server)
+      @server = server
+    end
+
+    def get(pattern, &block)    = _register("GET",    pattern, block)
+    def post(pattern, &block)   = _register("POST",   pattern, block)
+    def delete(pattern, &block) = _register("DELETE", pattern, block)
+    def patch(pattern, &block)  = _register("PATCH",  pattern, block)
+    def put(pattern, &block)    = _register("PUT",    pattern, block)
+
+    private def _register(method, pattern, block)
+      server = @server
+      # Wrap the block so it is always instance_exec'd on the HttpServer,
+      # regardless of the lexical self where the block was defined.
+      wrapped = proc { |req, res, captures| server.instance_exec(req, res, captures, &block) }
+      @server._skill_ui_routes << { method: method, pattern: pattern, handler: wrapped }
+    end
+  end
+
+  # SkillUiRoutes — mixin included into HttpServer to add skill UI extension support.
+  #
+  # Provides:
+  #   - GET  /api/ui-extensions               → list all skill UIs
+  #   - GET  /api/ui-extensions/:id/assets/:f → serve asset files
+  #   - Dynamic routes registered via each skill's ui/routes.rb
+  #
+  # Included as a module so changes here never conflict with upstream http_server.rb edits.
+  module SkillUiRoutes
+    # Asset filenames that may be served from a skill UI directory.
+    # Anything outside this list is blocked for security.
+    SKILL_UI_ASSET_ALLOWED = %w[sidebar.html panel.html index.js].freeze
+
+    # Called once on server boot to load routes from all skill ui/routes.rb files.
+    # Invoke this from HttpServer#initialize after the registry is ready.
+    def load_skill_ui_routes
+      loader = Clacky::UiExtensionLoader.new
+      loader.load_all.each do |ext|
+        routes_path = File.join(ext[:dir], "routes.rb")
+        next unless File.exist?(routes_path)
+
+        router = Clacky::SkillUiRouter.new(self)
+        begin
+          routes_code = File.read(routes_path)
+          router.instance_eval(routes_code, routes_path)
+        rescue StandardError => e
+          warn "[SkillUiRouter] Failed to load routes for '#{ext[:id]}': #{e.message}"
+        end
+      end
+    end
+
+    # Registered skill UI route table: [{ method:, pattern:, handler: }]
+    # Must be public so SkillUiRouter can append routes from outside.
+    def _skill_ui_routes
+      @_skill_ui_routes ||= []
+    end
+
+    # Match an incoming request against registered skill UI routes.
+    # Returns a callable lambda if matched, nil otherwise.
+    def match_skill_ui_route(method, path)
+      _skill_ui_routes.each do |route|
+        next unless route[:method] == method
+
+        captures = case route[:pattern]
+                   when String then route[:pattern] == path ? [] : nil
+                   when Regexp
+                     m = path.match(route[:pattern])
+                     m ? m.captures : nil
+                   end
+        return ->(req, res) { route[:handler].call(req, res, captures) } if captures
+      end
+      nil
+    end
+
+    # GET /api/ui-extensions
+    # Returns all UI extensions found in ~/.clacky/skills/*/ui/.
+    # Skills without a ui/manifest.yml are skipped.
+    def api_list_skill_uis(res)
+      loader    = Clacky::UiExtensionLoader.new
+      skill_uis = loader.load_all.map { |p| p.reject { |k, _| k == :dir } }
+      json_response(res, 200, { ui_extensions: skill_uis })
+    end
+
+    # GET /api/ui-extensions/:id/assets/:filename
+    # Serve a UI extension asset (sidebar.html, panel.html, index.js).
+    def api_skill_ui_asset(skill_id, filename, res)
+      unless SKILL_UI_ASSET_ALLOWED.include?(filename)
+        res.status = 403
+        res.body   = "Forbidden"
+        return
+      end
+
+      loader = Clacky::UiExtensionLoader.new
+      ext    = loader.load_all.find { |e| e[:id] == skill_id }
+      unless ext
+        res.status = 404
+        res.body   = "Skill UI not found"
+        return
+      end
+
+      filepath = File.join(ext[:dir], filename)
+      unless File.exist?(filepath)
+        res.status = 404
+        res.body   = "Asset not found"
+        return
+      end
+
+      content_type = filename.end_with?(".js") ? "application/javascript; charset=utf-8" \
+                                               : "text/html; charset=utf-8"
+      res.status           = 200
+      res["Content-Type"]  = content_type
+      res["Cache-Control"] = "no-store"
+      res.body             = File.read(filepath)
+    end
+  end
+end

--- a/lib/clacky/ui_extension_loader.rb
+++ b/lib/clacky/ui_extension_loader.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "fileutils"
+require "json"
+
+module Clacky
+  # UiExtensionLoader scans ~/.clacky/skills/*/ui/ and loads UI extensions bundled
+  # inside skills. A skill that ships a UI places its assets under a `ui/`
+  # subdirectory inside the skill directory:
+  #
+  #   ~/.clacky/skills/
+  #   └── <skill-name>/
+  #       ├── SKILL.md      ← Agent instructions (handled by SkillLoader)
+  #       └── ui/           ← UI extension (handled by UiExtensionLoader)
+  #           ├── manifest.yml  ← required: metadata (id, name, icon, etc.)
+  #           ├── sidebar.html  ← optional: sidebar nav entry HTML fragment
+  #           ├── panel.html    ← optional: main panel HTML fragment
+  #           ├── index.js      ← optional: UI JavaScript logic
+  #           └── routes.rb     ← optional: custom API routes (SkillUiRouter DSL)
+  #
+  # manifest.yml schema:
+  #   id: "coding-agent"
+  #   name: "Coding Agent"         # string OR {en: "...", zh: "..."}
+  #   version: "0.1.0"
+  #   author: "Your Name"
+  #   description: "..."           # string OR {en: "...", zh: "..."}
+  #   icon: "💻"                   ← emoji or URL
+  #   sidebar: true                ← whether to inject a sidebar entry (default: true)
+  #   sidebar_divider: "Projects"  # optional; string OR {en: "...", zh: "..."}
+  #
+  # UI extensions are loaded at server startup and served via GET /api/ui-extensions.
+  # The frontend dynamically injects sidebar entries and panels on boot.
+  class UiExtensionLoader
+    SKILLS_DIR = File.join(Dir.home, ".clacky", "skills")
+
+    def initialize(skills_dir = SKILLS_DIR)
+      @skills_dir = skills_dir
+    end
+
+    # Scan all skill ui/ subdirectories and return a list of loaded UI extension descriptors.
+    # Each descriptor is a Hash ready to be serialized as JSON.
+    # Skills without a ui/ directory, or with missing/invalid skill_ui.yml, are skipped.
+    def load_all
+      return [] unless Dir.exist?(@skills_dir)
+
+      Dir.entries(@skills_dir)
+         .select { |entry| skill_dir?(entry) }
+         .map    { |entry| load_extension(entry) }
+         .compact
+    end
+
+    # Read an asset file from a skill's ui/ directory. Returns nil if missing.
+    def read_asset(skill_id, filename)
+      path = File.join(@skills_dir, skill_id, "ui", filename)
+      return nil unless File.exist?(path)
+
+      File.read(path)
+    rescue StandardError
+      nil
+    end
+
+    private
+
+    # Check if an entry is a valid skill directory (not . or ..)
+    private def skill_dir?(entry)
+      return false if entry.start_with?(".")
+
+      dir_path = File.join(@skills_dir, entry)
+      Dir.exist?(dir_path)
+    end
+
+    # Load a single UI extension from a skill's ui/ subdirectory. Returns nil if absent/invalid.
+    private def load_extension(skill_name)
+      ui_dir      = File.join(@skills_dir, skill_name, "ui")
+      config_path = File.join(ui_dir, "manifest.yml")
+
+      # Skip skills that have no ui/ directory or no config file
+      return nil unless Dir.exist?(ui_dir)
+      return nil unless File.exist?(config_path)
+
+      config = YAML.safe_load(File.read(config_path)) || {}
+      return nil unless config.is_a?(Hash)
+
+      # Build the UI extension descriptor.
+      # name / description / sidebar_divider support two formats:
+      #   - String:   "Coding Agent"
+      #   - Hash (i18n): { "en" => "Coding Agent", "zh" => "编程助手" }
+      # The hash is passed through as-is; the frontend resolves the active language.
+      {
+        id:               config["id"]              || skill_name,
+        name:             config["name"]            || skill_name,
+        version:          config["version"]         || "0.0.1",
+        author:           config["author"]          || "",
+        description:      config["description"]     || "",
+        icon:             config["icon"]            || "🧩",
+        sidebar:          config.fetch("sidebar", true),
+        sidebar_divider:  config["sidebar_divider"] || nil,
+        dir:              ui_dir,
+        # Flags indicating which optional asset files are present
+        has_sidebar_html: File.exist?(File.join(ui_dir, "sidebar.html")),
+        has_panel_html:   File.exist?(File.join(ui_dir, "panel.html")),
+        has_index_js:     File.exist?(File.join(ui_dir, "index.js")),
+      }
+    rescue StandardError => e
+      warn "[UiExtensionLoader] Failed to load UI extension for skill '#{skill_name}': #{e.message}"
+      nil
+    end
+  end
+end

--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -282,9 +282,12 @@ const Router = (() => {
 })();
 
 // ── Skill UI system boot ──────────────────────────────────────────────────
-// Initialize skill UI extensions; store the Promise so session_list handler
-// can await it before calling Router.restoreFromHash().
-const _skillUiReady = SkillUI.init();
+// skill_ui.js is loaded synchronously before app.js in index.html, so SkillUI
+// is always defined here. Store the Promise so session_list handler can await
+// it before calling Router.restoreFromHash().
+const _skillUiReady = typeof SkillUI !== "undefined"
+  ? SkillUI.init()
+  : Promise.resolve();
 
 // ── Modal utility ─────────────────────────────────────────────────────────
 const Modal = (() => {

--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -53,11 +53,15 @@ const Router = (() => {
   let _params      = {};    // current params (e.g. { id: "abc" } for session view)
   let _skipNextHashChange = false;  // prevent echo loop when we set hash ourselves
 
-  // Hide all panels.
+  // Hide all panels (including dynamically injected skill UI panels).
   function _hideAll() {
     PANELS.forEach(p => {
       const el = $(p);
       if (el) el.style.display = "none";
+    });
+    // Hide all skill UI panels
+    document.querySelectorAll(".ui-panel").forEach(el => {
+      el.style.display = "none";
     });
   }
 
@@ -77,23 +81,31 @@ const Router = (() => {
     if (h === "settings")             return { view: "settings", params: {} };
     const m = h.match(/^session\/(.+)$/);
     if (m)                            return { view: "session",  params: { id: m[1] } };
+    // Support both #ui/:id  and  #ui/:id/:sub
+    const pm = h.match(/^ui\/([^/]+)(?:\/(.+))?$/);
+    if (pm)                           return { view: "ui", params: { id: pm[1], sub: pm[2] || null } };
     return { view: "welcome", params: {} };
   }
 
   // Sidebar items managed by Router (keyed by view name → element id).
   // Router is the single authority for active highlight — modules must NOT
   // add/remove the "active" class on these elements themselves.
+  // Skill UI sidebar items are highlighted dynamically via getSidebarItem().
   const SIDEBAR_ITEMS = {
     tasks:    "tasks-sidebar-item",
     skills:   "skills-sidebar-item",
     channels: "channels-sidebar-item",
   };
 
-  // Remove active highlight from all Router-managed sidebar items.
+  // Remove active highlight from all Router-managed sidebar items (including skill UI entries).
   function _clearSidebarActive() {
     Object.values(SIDEBAR_ITEMS).forEach(id => {
       const el = $(id);
       if (el) el.classList.remove("active");
+    });
+    // Clear skill UI sidebar entries
+    document.querySelectorAll(".ui-sidebar-entry").forEach(el => {
+      el.classList.remove("active");
     });
   }
 
@@ -196,6 +208,33 @@ const Router = (() => {
         $("setup-panel").style.display = "flex";
         break;
 
+      case "ui": {
+        // Skill UI panel: show the injected panel for the given skill id
+        // Supports sub-routes: #ui/:id  and  #ui/:id/:sub
+        const skillUiId    = params.id;
+        const skillUiSub   = params.sub || null;  // e.g. a project id
+        const skillUiPanel = SkillUI.getPanel(skillUiId);
+        if (!skillUiPanel) {
+          _apply("welcome");
+          return;
+        }
+        // Write hash including sub-route when present
+        _setHash(skillUiSub ? `ui/${skillUiId}/${skillUiSub}` : `ui/${skillUiId}`);
+        skillUiPanel.style.display = "flex";
+        skillUiPanel.style.flex = "1";
+        skillUiPanel.style.flexDirection = "column";
+
+        // Highlight skill UI sidebar entry
+        const sidebarItem = SkillUI.getSidebarItem(skillUiId);
+        if (sidebarItem) sidebarItem.classList.add("active");
+
+        // Notify skill UI scripts that navigation has occurred (pass sub as part of params)
+        SkillUI.notifyNavListeners("ui", params);
+
+        Sessions.renderList();
+        break;
+      }
+
       case "onboard":
         // Kept for compatibility; setup-panel is now used for first-run setup.
         $("onboard-panel").style.display = "flex";
@@ -241,6 +280,11 @@ const Router = (() => {
     },
   };
 })();
+
+// ── Skill UI system boot ──────────────────────────────────────────────────
+// Initialize skill UI extensions; store the Promise so session_list handler
+// can await it before calling Router.restoreFromHash().
+const _skillUiReady = SkillUI.init();
 
 // ── Modal utility ─────────────────────────────────────────────────────────
 const Modal = (() => {
@@ -305,7 +349,9 @@ WS.onEvent(ev => {
       if (!_initialRestoreDone) {
         _initialRestoreDone = true;
         if (Router.current !== "session") {
-          Router.restoreFromHash();
+          // Wait for SkillUI panels to be injected before restoring hash,
+          // so #ui/:id routes can find their panel elements.
+          _skillUiReady.then(() => Router.restoreFromHash());
         }
       } else {
         // If active session was deleted, go to welcome

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -86,7 +86,10 @@
         </div>
         <!-- Load more buttons are rendered dynamically inside each section by Sessions.renderList() -->
       </div>
-      
+
+      <!-- Skill UI sidebar entries injected here dynamically by skill_ui.js -->
+      <div id="ui-section"></div>
+
       <!-- Config Group -->
       <div id="config-section">
         <div class="sidebar-divider"><span data-i18n="sidebar.config">Config</span></div>
@@ -598,5 +601,14 @@
 <script src="/brand.js"></script>
 <script src="/version.js"></script>
 <script src="/app.js"></script>
+<!-- skill_ui.js loaded dynamically after app.js to avoid touching the static script list -->
+<script>
+  (function () {
+    var s = document.createElement('script');
+    s.src = '/skill_ui.js';
+    s.async = false;
+    document.head.appendChild(s);
+  })();
+</script>
 </body>
 </html>

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -600,15 +600,7 @@
 <script src="/onboard.js"></script>
 <script src="/brand.js"></script>
 <script src="/version.js"></script>
+<script src="/skill_ui.js"></script>
 <script src="/app.js"></script>
-<!-- skill_ui.js loaded dynamically after app.js to avoid touching the static script list -->
-<script>
-  (function () {
-    var s = document.createElement('script');
-    s.src = '/skill_ui.js';
-    s.async = false;
-    document.head.appendChild(s);
-  })();
-</script>
 </body>
 </html>

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1087,5 +1087,197 @@ const Sessions = (() => {
       _pendingMessage = null;
       return msg;
     },
+
+    // ── ChatContext — embeddable chat surface ──────────────────────────────
+    //
+    // Sessions.createChatContext(container, sessionId) returns a ChatContext
+    // object that plugins (or any consumer) can use to embed a fully functional
+    // chat surface inside an arbitrary DOM container.
+    //
+    // The context:
+    //   - Subscribes to WS events for the given session_id
+    //   - Renders messages, tool calls, progress into `container`
+    //   - Loads history from the server on first mount
+    //   - Cleans up its WS listener on destroy()
+    //
+    // Usage:
+    //   const ctx = Sessions.createChatContext(myDiv, sessionId);
+    //   // ... user interacts ...
+    //   ctx.destroy();   // when done (call before navigating away)
+    //
+    // The caller is responsible for:
+    //   - WS.send({ type: "subscribe", session_id }) before/after creating context
+    //   - Sending user messages via WS.send({ type: "message", ... })
+    //   - Calling ctx.destroy() when the container is no longer needed
+
+    createChatContext(container, sessionId) {
+      // ── Per-context state (completely isolated from host chat) ──────────
+      let _ctxLiveToolGroup    = null;
+      let _ctxLiveLastToolItem = null;
+      let _ctxProgressEl       = null;
+      let _destroyed           = false;
+
+      // ── Helpers ──────────────────────────────────────────────────────────
+
+      function _scrollBottom() {
+        container.scrollTop = container.scrollHeight;
+      }
+
+      function _ctxCollapseToolGroup() {
+        if (_ctxLiveToolGroup) {
+          _collapseToolGroup(_ctxLiveToolGroup);
+          _ctxLiveToolGroup    = null;
+          _ctxLiveLastToolItem = null;
+        }
+      }
+
+      // ── Public methods ────────────────────────────────────────────────────
+
+      function appendMsg(type, html) {
+        _ctxCollapseToolGroup();
+        const el = document.createElement("div");
+        el.className = `msg msg-${type}`;
+        el.innerHTML = type === "assistant" ? _renderMarkdown(html) : html;
+        container.appendChild(el);
+        _scrollBottom();
+      }
+
+      function appendInfo(text) {
+        _ctxCollapseToolGroup();
+        const el = document.createElement("div");
+        el.className   = "msg msg-info";
+        el.textContent = text;
+        container.appendChild(el);
+        _scrollBottom();
+      }
+
+      function appendToolCall(name, args, summary) {
+        if (!_ctxLiveToolGroup) {
+          _ctxLiveToolGroup = _makeToolGroup();
+          container.appendChild(_ctxLiveToolGroup);
+        }
+        _ctxLiveLastToolItem = _addToolCallToGroup(_ctxLiveToolGroup, name, args, summary);
+        _scrollBottom();
+      }
+
+      function appendToolResult() {
+        if (_ctxLiveToolGroup && _ctxLiveLastToolItem) {
+          _completeLastToolItem(_ctxLiveToolGroup);
+          _ctxLiveLastToolItem = null;
+        }
+      }
+
+      function showProgress(text) {
+        clearProgress();
+        const el = document.createElement("div");
+        el.className   = "progress-msg";
+        el.textContent = "⟳ " + text;
+        container.appendChild(el);
+        _ctxProgressEl = el;
+        _scrollBottom();
+      }
+
+      function clearProgress() {
+        if (_ctxProgressEl) { _ctxProgressEl.remove(); _ctxProgressEl = null; }
+      }
+
+      function appendTokenUsage(ev) {
+        // Reuse the shared helper; pass our container so it renders there
+        Sessions.appendTokenUsage(ev, container);
+      }
+
+      // Load history from server into this container.
+      async function loadHistory() {
+        try {
+          const res = await fetch(`/api/sessions/${sessionId}/messages?limit=50`);
+          if (!res.ok) return;
+          const data   = await res.json();
+          const events = data.events || [];
+          const frag   = document.createDocumentFragment();
+          const ctx    = { group: null, lastItem: null };
+          events.forEach(ev => _renderHistoryEvent(ev, frag, ctx));
+          if (ctx.group) _collapseToolGroup(ctx.group);
+          container.innerHTML = "";
+          container.appendChild(frag);
+          _scrollBottom();
+        } catch (_) { /* history errors are non-fatal */ }
+      }
+
+      // ── WS event listener ─────────────────────────────────────────────────
+      // Route WS events for this session into the context's render methods.
+
+      const _wsHandler = ev => {
+        if (_destroyed) return;
+        // Only handle events belonging to this session
+        if (ev.session_id && ev.session_id !== sessionId) return;
+
+        switch (ev.type) {
+          case "assistant_message":
+            clearProgress();
+            appendMsg("assistant", ev.content);
+            break;
+          case "tool_call":
+            clearProgress();
+            appendToolCall(ev.name, ev.args, ev.summary);
+            break;
+          case "tool_result":
+            appendToolResult();
+            break;
+          case "tool_error":
+            appendMsg("error", `Tool error: ${escapeHtml(ev.error)}`);
+            break;
+          case "token_usage":
+            appendTokenUsage(ev);
+            break;
+          case "progress":
+            if (ev.status === "start") showProgress(ev.message || "Thinking…");
+            else clearProgress();
+            break;
+          case "complete":
+            clearProgress();
+            _ctxCollapseToolGroup();
+            appendInfo(`✓ Done (${ev.iterations} steps · $${(ev.cost || 0).toFixed(4)})`);
+            break;
+          case "interrupted":
+            clearProgress();
+            _ctxCollapseToolGroup();
+            appendInfo("⚠ Interrupted");
+            break;
+          case "info":
+            appendInfo(ev.message);
+            break;
+          case "error":
+            appendMsg("error", escapeHtml(ev.message));
+            break;
+        }
+      };
+
+      WS.onEvent(_wsHandler);
+
+      // ── Destroy ───────────────────────────────────────────────────────────
+
+      function destroy() {
+        _destroyed = true;
+        WS.offEvent(_wsHandler);
+        _ctxLiveToolGroup    = null;
+        _ctxLiveLastToolItem = null;
+        _ctxProgressEl       = null;
+      }
+
+      // Load history immediately on creation
+      loadHistory();
+
+      return {
+        appendMsg,
+        appendInfo,
+        appendToolCall,
+        appendToolResult,
+        showProgress,
+        clearProgress,
+        appendTokenUsage,
+        loadHistory,
+        destroy,
+      };
+    },
   };
 })();

--- a/lib/clacky/web/skill_ui.js
+++ b/lib/clacky/web/skill_ui.js
@@ -1,0 +1,361 @@
+// ── skill_ui.js — Skill UI Extension loader ───────────────────────────────
+//
+// Fetches installed skill UI extensions from GET /api/ui-extensions on boot, then:
+//   1. Dynamically injects sidebar entries into #ui-section
+//   2. Dynamically injects panel containers into #main
+//   3. Loads each extension's index.js via a <script> tag
+//
+// Panel IDs follow the convention: ui-panel-{id}
+// Sidebar item IDs: ui-sidebar-{id}
+//
+// Skill UI extensions communicate with the host app via the SkillBridge API
+// exposed on window.SkillBridge.
+// ─────────────────────────────────────────────────────────────────────────
+
+const SkillUI = (() => {
+  // Installed skill UI extension descriptors returned by /api/ui-extensions
+  let _extensions = [];
+
+  // ── i18n helper ───────────────────────────────────────────────────────
+  //
+  // Resolve a field that may be either:
+  //   - a plain string:  "Coding Agent"
+  //   - an i18n object:  { en: "Coding Agent", zh: "编程助手" }
+  //
+  // Falls back to "en", then to the raw value, then to the fallback arg.
+  //
+  // Usage: _t(ext.name)  or  _t(ext.sidebar_divider, "")
+  // ─────────────────────────────────────────────────────────────────────
+  function _t(field, fallback = "") {
+    if (!field) return fallback;
+    if (typeof field === "string") return field;
+    if (typeof field === "object") {
+      const lang = (typeof I18n !== "undefined") ? I18n.lang() : "en";
+      return field[lang] ?? field["en"] ?? fallback;
+    }
+    return fallback;
+  }
+
+  // ── SkillBridge ───────────────────────────────────────────────────────
+  //
+  // Public API exposed to skill UI scripts so they can interact with the host
+  // app without touching internals directly.
+  //
+  // Available inside skill_ui.js as: SkillBridge.navigate(...)
+  //                                  SkillBridge.onNavigate(...)
+  //                                  SkillBridge.getActiveSession()
+  // ─────────────────────────────────────────────────────────────────────
+  const SkillBridge = {
+    /**
+     * Navigate to a skill UI panel.
+     * @param {string} skillId - The skill id (e.g. "coding-agent")
+     */
+    navigate(skillId) {
+      if (typeof Router !== "undefined") {
+        Router.navigate("ui", { id: skillId });
+      }
+    },
+
+    /**
+     * Register a callback that fires whenever the active view changes.
+     * @param {Function} fn - Called with (view, params)
+     */
+    onNavigate(fn) {
+      _navListeners.push(fn);
+    },
+
+    /**
+     * Returns the currently active session object, or null.
+     */
+    getActiveSession() {
+      if (typeof Sessions !== "undefined") {
+        return Sessions.find(Sessions.activeId) || null;
+      }
+      return null;
+    },
+
+    /**
+     * Make an authenticated fetch to the local server API.
+     * @param {string} path - e.g. "/api/sessions"
+     * @param {object} opts - fetch options
+     */
+    async fetch(path, opts = {}) {
+      const res = await fetch(path, {
+        headers: { "Content-Type": "application/json", ...(opts.headers || {}) },
+        ...opts,
+      });
+      return res;
+    },
+
+    /**
+     * Show a simple info message in the current panel (uses Sessions.appendInfo if available).
+     * @param {string} message
+     */
+    info(message) {
+      if (typeof Sessions !== "undefined") {
+        Sessions.appendInfo(message);
+      }
+    },
+
+    /**
+     * Register a callback that fires once when the given skill UI's panel.html is fully
+     * injected into the DOM. If the panel is already ready, the callback fires on the
+     * next microtask.
+     *
+     * @param {string} skillId - e.g. "coding-agent"
+     * @param {Function} fn - called with no arguments when panel DOM is ready
+     */
+    onPanelReady(skillId, fn) {
+      const panelId = `ui-panel-${skillId}`;
+      const panel = document.getElementById(panelId);
+      // If panel element already has children, html has already been injected
+      if (panel && panel.children.length > 0) {
+        Promise.resolve().then(fn);
+        return;
+      }
+      if (!_panelReadyListeners[skillId]) {
+        _panelReadyListeners[skillId] = [];
+      }
+      _panelReadyListeners[skillId].push(fn);
+    },
+  };
+
+  // Navigation change listeners registered by skill UI extensions
+  const _navListeners = [];
+
+  // Panel-ready listeners: called once when a skill UI's panel.html is fully injected into DOM.
+  // Map of skillId → [callback, ...]
+  const _panelReadyListeners = {};
+
+  // Called by Router._apply() after each view change (wired up in app.js)
+  function _notifyNavListeners(view, params) {
+    _navListeners.forEach(fn => {
+      try { fn(view, params); } catch (e) { console.error("[SkillUI] onNavigate error:", e); }
+    });
+  }
+
+  // ── Sidebar injection ─────────────────────────────────────────────────
+
+  // Ensure the #ui-section container exists in the sidebar.
+  // It is created once and appended to #sidebar-list.
+  function _ensureSkillUiSection() {
+    if (document.getElementById("ui-section")) return;
+
+    const section = document.createElement("div");
+    section.id = "ui-section";
+
+    const list = document.getElementById("sidebar-list");
+    if (list) list.appendChild(section);
+  }
+
+  // Inject a sidebar entry for one skill UI extension.
+  function _injectSidebarEntry(ext) {
+    _ensureSkillUiSection();
+
+    const section = document.getElementById("ui-section");
+    if (!section) return;
+
+    // Check if already injected (idempotent)
+    if (document.getElementById(`ui-sidebar-${ext.id}`)) return;
+
+    // If the extension declares a sidebar_divider, inject it before the entry.
+    const dividerText = _t(ext.sidebar_divider);
+    if (dividerText) {
+      const divider = document.createElement("div");
+      divider.className = "sidebar-divider";
+      // Store skill id so we can re-translate on language change
+      divider.dataset.uiDivider = ext.id;
+      divider.innerHTML = `<span>${dividerText}</span>`;
+      section.appendChild(divider);
+    }
+
+    // If the extension has a custom sidebar.html, fetch and inject it.
+    // Otherwise render a default entry.
+    if (ext.has_sidebar_html) {
+      fetch(`/api/ui-extensions/${ext.id}/assets/sidebar.html`)
+        .then(r => r.text())
+        .then(html => {
+          const wrapper = document.createElement("div");
+          wrapper.id        = `ui-sidebar-${ext.id}`;
+          wrapper.className = "ui-sidebar-entry";
+          wrapper.innerHTML = html;
+
+          // Wire up click → navigate to skill UI panel
+          wrapper.addEventListener("click", () => {
+            if (typeof Router !== "undefined") {
+              Router.navigate("ui", { id: ext.id });
+            }
+          });
+
+          section.appendChild(wrapper);
+          // Notify skill UI scripts that sidebar is ready
+          document.dispatchEvent(new CustomEvent(`ui:sidebar-ready:${ext.id}`));
+        })
+        .catch(e => console.error(`[SkillUI] Failed to load sidebar.html for ${ext.id}:`, e));
+    } else {
+      // Default sidebar entry — use _t() to resolve i18n name
+      const wrapper = document.createElement("div");
+      wrapper.id        = `ui-sidebar-${ext.id}`;
+      wrapper.className = "task-item task-item-summary ui-sidebar-entry";
+      wrapper.innerHTML = `
+        <div class="task-row">
+          <span class="task-icon">${ext.icon || "🧩"}</span>
+          <div class="task-info">
+            <span class="task-name">${_t(ext.name, ext.id)}</span>
+          </div>
+        </div>
+      `;
+      wrapper.addEventListener("click", () => {
+        if (typeof Router !== "undefined") {
+          Router.navigate("ui", { id: ext.id });
+        }
+      });
+      section.appendChild(wrapper);
+    }
+  }
+
+  // ── Panel injection ───────────────────────────────────────────────────
+
+  // Inject a panel container for one skill UI extension into #main.
+  // Returns a Promise that resolves once the panel HTML (if any) is injected.
+  function _injectPanel(ext) {
+    const panelId = `ui-panel-${ext.id}`;
+    if (document.getElementById(panelId)) return Promise.resolve();
+
+    const main = document.getElementById("main");
+    if (!main) return Promise.resolve();
+
+    const panel = document.createElement("div");
+    panel.id            = panelId;
+    panel.className     = "ui-panel";
+    panel.style.display = "none";
+
+    main.appendChild(panel);
+
+    if (ext.has_panel_html) {
+      return fetch(`/api/ui-extensions/${ext.id}/assets/panel.html`)
+        .then(r => r.text())
+        .then(html => {
+          panel.innerHTML = html;
+          // Notify any listeners waiting for this skill UI's panel to be ready
+          const skillId = ext.id;
+          if (_panelReadyListeners[skillId]) {
+            _panelReadyListeners[skillId].forEach(fn => {
+              try { fn(); } catch (e) { console.error(`[SkillUI] onPanelReady error for ${skillId}:`, e); }
+            });
+            delete _panelReadyListeners[skillId];
+          }
+        })
+        .catch(e => console.error(`[SkillUI] Failed to load panel.html for ${ext.id}:`, e));
+    } else {
+      // Default empty panel placeholder — use _t() to resolve i18n fields
+      panel.innerHTML = `
+        <div class="ui-panel-placeholder">
+          <span>${ext.icon || "🧩"}</span>
+          <h2>${_t(ext.name, ext.id)}</h2>
+          <p>${_t(ext.description)}</p>
+        </div>
+      `;
+      return Promise.resolve();
+    }
+  }
+
+  // ── Skill UI JS loader ────────────────────────────────────────────────
+
+  // Dynamically load a skill UI extension's index.js.
+  // The script runs in the page context and can access window.SkillBridge.
+  function _loadSkillUiScript(ext) {
+    if (!ext.has_index_js) return;
+
+    const script = document.createElement("script");
+    script.src   = `/api/ui-extensions/${ext.id}/assets/index.js`;
+    script.async   = true;
+    script.onerror = () => console.error(`[SkillUI] Failed to load ${filename} for ${ext.id}`);
+    document.head.appendChild(script);
+  }
+
+  // ── Language change — re-translate sidebar dividers ───────────────────
+  //
+  // Sidebar divider text is rendered once on load. When the user switches
+  // language in Settings, we re-translate all dividers via data-ui-divider.
+
+  document.addEventListener("i18n:langchange", () => {
+    document.querySelectorAll("[data-ui-divider]").forEach(divider => {
+      const skillId = divider.dataset.uiDivider;
+      const ext     = _extensions.find(e => e.id === skillId);
+      if (!ext) return;
+      const text = _t(ext.sidebar_divider);
+      if (text) {
+        const span = divider.querySelector("span");
+        if (span) span.textContent = text;
+      }
+    });
+  });
+
+  // ── Boot ──────────────────────────────────────────────────────────────
+
+  // Fetch skill UI extension list from server and bootstrap all extensions.
+  // Returns a Promise that resolves once all panel HTML fetches are done,
+  // so callers (app.js) can wait before running Router.restoreFromHash().
+  async function init() {
+    try {
+      const res  = await fetch("/api/ui-extensions");
+      const data = await res.json();
+      _extensions = data.ui_extensions || [];
+
+      if (_extensions.length === 0) return;  // No skill UI extensions installed
+
+      // Expose SkillBridge globally so skill UI scripts can access it
+      window.SkillBridge = SkillBridge;
+
+      // Inject sidebars and panels; collect panel-html fetch promises so we
+      // can await them before the router restores from hash.
+      const panelFetches = [];
+      _extensions.forEach(ext => {
+        if (ext.sidebar !== false) {
+          _injectSidebarEntry(ext);
+        }
+        panelFetches.push(_injectPanel(ext));
+        _loadSkillUiScript(ext);
+      });
+
+      // Wait for all panel HTML to land in the DOM before resolving.
+      await Promise.all(panelFetches);
+    } catch (e) {
+      console.error("[SkillUI] Failed to initialize skill UI extensions:", e);
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────
+
+  return {
+    init,
+
+    /** All loaded skill UI extension descriptors. */
+    get all() { return _extensions; },
+
+    /** Find a skill UI extension by id. */
+    find: id => _extensions.find(e => e.id === id) || null,
+
+    /**
+     * Get the panel DOM element for a skill UI extension.
+     * @param {string} id - Skill id
+     */
+    getPanel: id => document.getElementById(`ui-panel-${id}`),
+
+    /**
+     * Get the sidebar DOM element for a skill UI extension.
+     * @param {string} id - Skill id
+     */
+    getSidebarItem: id => document.getElementById(`ui-sidebar-${id}`),
+
+    /**
+     * Called by Router after each view change to notify skill UI extensions.
+     * Wired up in app.js.
+     */
+    notifyNavListeners: _notifyNavListeners,
+
+    /** Expose SkillBridge for external use */
+    Bridge: SkillBridge,
+  };
+})();

--- a/lib/clacky/web/ws.js
+++ b/lib/clacky/web/ws.js
@@ -98,6 +98,9 @@ const WS = (() => {
     /** Register a handler for all server events. */
     onEvent(fn) { _handlers.push(fn); },
 
+    /** Unregister a previously registered handler. */
+    offEvent(fn) { _handlers = _handlers.filter(h => h !== fn); },
+
     /** Send a message. If not connected, queue it for later. */
     send(obj) {
       if (_ready && _socket) {


### PR DESCRIPTION
## Summary

A minimum-invasive Skill UI extension system that allows skills to register custom UI components in the Web UI, migrated from `feat/plugin` without modifying core files.

## Changes

### feat: Skill UI extension system (`lib/clacky/ui_extension_loader.rb`, `lib/clacky/server/skill_ui_routes.rb`, `lib/clacky/web/skill_ui.js`)

- Add `UiExtensionLoader` — scans `~/.clacky/skills/*/ui/` for skill UI extensions
- Add `SkillUiRouter` DSL + `SkillUiRoutes` mixin — isolated module, `HttpServer` only gains `include SkillUiRoutes` + `load_skill_ui_routes` call
- Add `skill_ui.js` frontend — `SkillBridge` / `SkillUI` object; skills register panels/buttons/event handlers via `SkillUI.register()`
- Add API routes: `GET /api/ui-extensions`, `GET /api/ui-extensions/:id/assets/:f`, dynamic skill routes
- Add `#ui-section` mount point + dynamic script loader in `index.html` (no static `<script>` tag)
- Add `Router` support for `#ui/:id` hash routes + `SkillUI.init()` boot in `app.js`

### fix: load `skill_ui.js` synchronously before `app.js`

- Prevents `SkillUI undefined` error when `app.js` calls `SkillUI.init()` on boot

### fix: add `profile:` keyword to `build_session_from_data` signature

- Missing keyword caused `ArgumentError` when restoring sessions that include a `profile` field

### fix: add `WS.offEvent()` to allow deregistering WebSocket event handlers

- Prevents memory leaks when skill UI components unmount and re-register handlers

### chore: ignore local `dev` launcher script in `.gitignore`