### PR TITLE
fix: resolve relative paths against working_dir in write/edit tools

### DIFF
--- a/lib/clacky/tools/base.rb
+++ b/lib/clacky/tools/base.rb
@@ -29,12 +29,14 @@ module Clacky
       end
 
       # Expand ~ to home directory only if path starts with ~
-      # Relative paths are kept as-is to avoid expanding to long absolute paths
+      # Relative paths are resolved against working_dir if provided
       # @param path [String, nil] The path to expand
+      # @param working_dir [String, nil] The working directory to resolve relative paths against
       # @return [String, nil] The expanded path, or original if no ~ present
-      private def expand_path(path)
+      private def expand_path(path, working_dir: nil)
         return path if path.nil? || path.strip.empty?
         return File.expand_path(path) if path.start_with?("~")
+        return File.expand_path(path, working_dir) if working_dir && !path.start_with?("/")
 
         path
       end

--- a/lib/clacky/tools/edit.rb
+++ b/lib/clacky/tools/edit.rb
@@ -32,8 +32,8 @@ module Clacky
       }
 
       def execute(path:, old_string:, new_string:, replace_all: false, working_dir: nil)
-        # Expand ~ to home directory
-        path = expand_path(path)
+        # Expand ~ to home directory, resolve relative paths against working_dir
+        path = expand_path(path, working_dir: working_dir)
 
         unless File.exist?(path)
           return { error: "File not found: #{path}" }

--- a/lib/clacky/tools/write.rb
+++ b/lib/clacky/tools/write.rb
@@ -28,8 +28,8 @@ module Clacky
         end
 
         begin
-          # Expand ~ to home directory
-          path = expand_path(path)
+          # Expand ~ to home directory, resolve relative paths against working_dir
+          path = expand_path(path, working_dir: working_dir)
 
           # Ensure parent directory exists
           dir = File.dirname(path)


### PR DESCRIPTION
## Problem

`write` and `edit` tools both accept a `working_dir` parameter (injected by `agent.rb`), but the parameter was silently ignored. Additionally, `base.rb#expand_path` had no handling for relative paths combined with a working directory.

This caused a critical issue with git worktrees: when the agent operated inside a worktree, file writes always resolved to the main repository directory instead of the correct worktree path.

## Root Cause

**Bug 1** — `write.rb` / `edit.rb` received `working_dir` but never passed it to `expand_path`:
```ruby
# Before
path = expand_path(path)  # working_dir ignored!
```

**Bug 2** — `base.rb#expand_path` returned relative paths as-is, never joining with `working_dir`:
```ruby
# Before
private def expand_path(path)
  return File.expand_path(path) if path.start_with?("~")
  path  # relative path returned unchanged
end
```

## Fix

```ruby
# base.rb — expand_path now accepts and uses working_dir
private def expand_path(path, working_dir: nil)
  return File.expand_path(path) if path.start_with?("~")
  return File.expand_path(path, working_dir) if working_dir && !path.start_with?("/")
  path
end

# write.rb / edit.rb — pass working_dir through
path = expand_path(path, working_dir: working_dir)
```

## Behavior After Fix

| Path type | working_dir | Result |
|-----------|-------------|--------|
| `~/foo` | any | Expands to home dir (unchanged) |
| `/abs/path` | any | Used as-is (unchanged) |
| `relative/path` | provided | Resolved against `working_dir` ✅ |
| `relative/path` | nil | Returned as-is (backward compat) |

## Tests

All 244 tool specs pass with no changes required.