### PR TITLE
fix: run install_browser.sh automatically when Node.js is missing

### DIFF
--- a/lib/clacky/default_skills/browser-setup/SKILL.md
+++ b/lib/clacky/default_skills/browser-setup/SKILL.md
@@ -43,6 +43,15 @@ node --version 2>/dev/null
 
 Parse the version. If Node.js is missing or version < 20:
 
+Run the bundled installer to automatically install Node.js:
+```bash
+bash ~/.clacky/scripts/install_browser.sh
+```
+
+If the script exits 0 → Node.js is now installed. Proceed to Step 2.
+
+If the script exits non-zero or doesn't exist:
+
 > ❌ Node.js 20+ is required for browser automation.
 >
 > Please install Node.js from: https://nodejs.org


### PR DESCRIPTION
## Problem
When Node.js is missing or version < 20, browser-setup would prompt the user 
to manually install Node.js from nodejs.org and wait for confirmation. 
This interrupts the setup flow unnecessarily.
﻿
## Solution
Before falling back to the manual install prompt, automatically run the bundled 
`install_browser.sh` script which handles Node.js installation silently.
﻿
- Script succeeds → proceed to Step 2 as normal
- Script fails or doesn't exist → fall back to the original manual install prompt
﻿
## Changes
- `lib/clacky/default_skills/browser-setup/SKILL.md`: updated Step 1 failure branch only
- No changes to `install_browser.sh`
﻿
## Test
- Verified behavior when Node.js is missing
- Confirmed install_browser.sh runs automatically