### PR TITLE
Fix/feishu setup bugs

### DIFF
--- a/lib/clacky/default_skills/channel-setup/SKILL.md
+++ b/lib/clacky/default_skills/channel-setup/SKILL.md
@@ -114,7 +114,10 @@ ruby "SKILL_DIR/feishu_setup.rb"
     ```
   - Tell the user: "I've opened Feishu in your browser. Please log in, then reply 'done'."
   - Wait for "done".
-  - **Retry the script** (same command, same timeout). If it succeeds this time, stop. If it fails again with a different error, continue to Step 2.
+  - **Retry the script** (same command, same timeout). Repeat this login-wait-retry loop up to **3 times total**.
+    - If any attempt succeeds (exit code 0), stop — setup is complete.
+    - If an attempt fails with a **different** error (not a login error), break out of the loop and continue to Step 2.
+    - If all 3 attempts fail with login errors, tell the user: "Automated setup was unable to detect a Feishu login after 3 attempts. Switching to guided setup..." and continue to Step 2.
 - **Otherwise (non-login, non-browser error):**
   - Tell the user: "Automated setup encountered an issue: `<error message>`. Switching to guided setup..."
   - Continue to Step 2 (manual flow) below.

--- a/lib/clacky/default_skills/channel-setup/feishu_setup.rb
+++ b/lib/clacky/default_skills/channel-setup/feishu_setup.rb
@@ -130,6 +130,12 @@ class BrowserSession
     snapshot
   end
 
+  def open(url)
+    @client.call("open", url: url)
+    sleep 2
+    snapshot
+  end
+
   def snapshot(interactive: true, compact: true)
     result = @client.call("snapshot", interactive: interactive, compact: compact)
     result["output"].to_s
@@ -394,7 +400,7 @@ def run_setup(browser, api)
 
   # ── Phase 1: Verify login ────────────────────────────────────────────────
   step "Phase 1 — Verifying Feishu login..."
-  snap = browser.navigate("https://open.feishu.cn/app")
+  snap = browser.open("https://open.feishu.cn/app")
   unless snap.include?("创建企业自建") || snap.include?("Create Custom App") || snap.include?("Create Enterprise")
     fail! "Not logged in to Feishu Open Platform. Please log in to open.feishu.cn in Chrome first, then re-run."
   end
@@ -554,7 +560,7 @@ browser     = BrowserSession.new(tool_client)
 
 # Navigate to Feishu to establish page context
 step "Initializing browser session..."
-browser.navigate("https://open.feishu.cn/app")
+browser.open("https://open.feishu.cn/app")
 sleep 1
 
 # Quick sanity check — verify we have cookies

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -333,7 +333,13 @@ module Clacky
         # hosts with OPEN_TIMEOUT=8s per attempt × 2 attempts = up to ~16s on the
         # primary alone, before failing over to the fallback domain.  Give them a
         # generous 90s so retry + failover can complete without being cut short.
-        timeout_sec = path.start_with?("/api/brand") ? 90 : 10
+        timeout_sec = if path.start_with?("/api/brand")
+          90
+        elsif path == "/api/tool/browser"
+          30
+        else
+          10
+        end
         Timeout.timeout(timeout_sec) do
           _dispatch_rest(req, res)
         end


### PR DESCRIPTION
## Summary

Fixes three issues in the Feishu channel setup flow.

---

### C-5540 — Browser tool requests timing out with 503

`/api/tool/browser` was grouped under the default 10s timeout, but browser
operations can take up to 60s internally, causing the outer layer to cut the
request short and return 503.

**Fix:** Give `/api/tool/browser` its own 30s timeout in `http_server.rb`.

---

### C-5538 — Setup falls back to manual mode immediately when user is not logged in

When the setup script detected no Feishu login, it exited with code 1.
The AI was supposed to pause, prompt the user to log in, and retry — but
in practice it skipped the retry branch entirely and jumped straight to
manual guided mode.

**Fix:** Rewrite the login-error branch in `SKILL.md` to loop up to 3 times:
prompt the user to log in → wait for "done" → retry the script. Only falls
back to manual mode after 3 consecutive login failures.

---

### C-5541 — Setup crashes when all browser tabs are closed

The setup script used `browser.navigate()` at the entrypoint and in Phase 1,
which requires an existing active tab. If the user had closed all tabs,
this threw `Browser error: The browser tab was closed` and the script exited.

**Fix:** Add a `BrowserSession#open(url)` method that calls the `open` action
(creates a new tab) instead of navigating in the current one. Replace both
`navigate` calls with `open`.

---

## Files Changed

- `lib/clacky/server/http_server.rb` — C-5540
- `lib/clacky/default_skills/channel-setup/SKILL.md` — C-5538
- `lib/clacky/default_skills/channel-setup/feishu_setup.rb` — C-5541

---

## Testing

Tested on macOS and Windows:

- **C-5540** — Verified `/api/tool/browser` requests no longer return 503 during Feishu setup.
- **C-5538** — Verified that when the user is not logged in, the AI now prompts to log in and retries the script instead of falling back to manual mode immediately.
- **C-5541** — Verified that closing all browser tabs before running setup no longer crashes the script; a new tab is opened automatically.
