### PR TITLE
Fix/switch language bugs

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -732,6 +732,8 @@ const Sessions = (() => {
     // ── Init ──────────────────────────────────────────────────────────────
     init() {
       _initNewMessageBanner();
+      // Re-render session list (badges/labels) when the user switches language
+      document.addEventListener("langchange", () => Sessions.renderList());
     },
 
     // ── List management ───────────────────────────────────────────────────

--- a/lib/clacky/web/skills.js
+++ b/lib/clacky/web/skills.js
@@ -435,6 +435,12 @@ const Skills = (() => {
           });
         }
 
+        // Re-render skill cards when the user switches language
+        document.addEventListener("langchange", () => {
+          _renderMySkills();
+          _renderBrandSkills();
+        });
+
         _domWired = true;
       }
 


### PR DESCRIPTION
## Summary

Fixes two issues where UI elements did not update after switching language,
both sub-issues of C-5515.

---

### C-5515-1 — Skill cards not re-rendered after language switch

The Skill Management page (both "My Skills" and "Brand Skills" tabs) rendered
skill descriptions once on load and never updated them. After switching
language, descriptions stayed in the original language until the page was
manually refreshed.

**Fix:** Add a `langchange` event listener in `skills.js` that calls both
`_renderMySkills()` and `_renderBrandSkills()` whenever the language changes.

---

### C-5515-2 — Session list badges not re-rendered after language switch

The session list in the sidebar uses `I18n.t()` to render source badges
(e.g. "Auto", "Channel"). After switching language, these badges stayed
in the original language until the page was manually refreshed.

**Fix:** Add a `langchange` event listener in `Sessions.init()` that calls
`Sessions.renderList()` whenever the language changes.

---

## Files Changed

- `lib/clacky/web/skills.js` — C-5515-1
- `lib/clacky/web/sessions.js` — C-5515-2

---

## Testing

Tested on macOS and Windows:

- **C-5515-1** — Verified that switching language immediately updates skill
  descriptions in both tabs without requiring a page refresh.
- **C-5515-2** — Verified that switching language immediately updates session
  badges in the sidebar without requiring a page refresh.