### PR TITLE
fix: prevent session badge from being clipped by long session name 

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -793,12 +793,22 @@ body {
 .session-item .session-name {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   color: var(--color-text-secondary);
   font-weight: 500;
   transition: color .2s ease, font-weight .2s ease;
+}
+.session-item .session-name .session-name__text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-item .session-name .session-badge {
+  flex-shrink: 0;
 }
 /* Hover: subtle background overlay */
 .session-item:hover {
@@ -863,8 +873,6 @@ body {
 .session-name {
   font-size: 12px;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 /* While renaming, lift overflow so the input is fully visible */
 .session-name.renaming {

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -683,7 +683,7 @@ const Sessions = (() => {
     el.innerHTML = `
       <span class="session-dot dot-${s.status || "idle"}"></span>
       <div class="session-body">
-        <div class="session-name">${escapeHtml(displayName)}${badgeHtml}</div>
+        <div class="session-name"><span class="session-name__text">${escapeHtml(displayName)}</span>${badgeHtml}</div>
         <div class="session-meta">${metaText}</div>
       </div>
       <button class="session-delete-btn" title="${I18n.t("sessions.deleteTitle")}">×</button>`;


### PR DESCRIPTION
## Problem

When a session name is too long, the badge (e.g. "配置", "自动") gets clipped and disappears. This is because the badge `<span>` sits inside the same `.session-name` div as the title text, and `overflow: hidden` truncates both together.

## Root Cause

`.session-name` applied `overflow: hidden` to the entire container, so a long title would swallow the badge along with the overflow text.

## Fix

- Wrap the title text in a `<span class="session-name__text">` so it can be truncated independently
- Make `.session-name` a flex container; move `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap` onto `.session-name__text`
- Add `flex-shrink: 0` to `.session-badge` inside `.session-name` so the badge is never compressed

## Tested

Verified in Chrome and Safari. Sessions with long names now show the badge correctly, and title ellipsis behaviour remains intact.