### PR TITLE
fix(wecom): fix queue empty error on Ruby < 3.2 (C-5535)

### DIFF
--- a/lib/clacky/server/channel/adapters/wecom/ws_client.rb
+++ b/lib/clacky/server/channel/adapters/wecom/ws_client.rb
@@ -361,7 +361,9 @@ module Clacky
 
             send_frame(cmd: cmd, req_id: req_id, body: body)
 
-            result = queue.pop(timeout: 30)
+            timeout_thread = Thread.new { sleep 30; queue.push(nil) }
+            result = queue.pop
+            timeout_thread.kill
             raise "Timeout waiting for ack (req_id=#{req_id}, cmd=#{cmd})" if result.nil?
 
             errcode = result["errcode"] || result.dig("body", "errcode")


### PR DESCRIPTION
## Problem
`Queue#pop(timeout:)` was introduced in Ruby 3.2. On older versions (2.6, 3.0), the `timeout:` hash is treated as a truthy `non_block` argument, causing an immediate `ThreadError: queue empty` when the ACK hasn't arrived yet.

## Fix
Replace `queue.pop(timeout: 30)` with a `timeout_thread` pattern that is compatible with all Ruby versions.

## Test
Verified on Ruby 2.6.10 (macOS) and Ruby 3.0 (WSL) — both fixed.