### PR TITLE
fix(agent): inject vision warning into system prompt for minimax (C-5527)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -203,9 +203,21 @@ module Clacky
         end
       end
 
+      # Resolve provider once — used for both system prompt injection and image downgrade below.
+      provider_id = Clacky::Providers.find_by_base_url(@config.base_url)
+
       # Add system prompt as the first message if this is the first run
       if @history.empty?
         system_prompt = build_system_prompt
+        # Inform text-only models that they cannot process images so they don't
+        # attempt to read image files via tools (which would send base64 data and
+        # consume tokens abnormally).
+        unless Clacky::Providers.vision?(provider_id)
+          system_prompt += "\n\nIMPORTANT: You are a text-only model and do not support vision input. " \
+                           "If the user sends an image or you encounter an image file, do NOT attempt " \
+                           "to read or analyze it. Instead, inform the user that you cannot process " \
+                           "images and suggest they use a vision-capable model."
+        end
         @history.append({ role: "system", content: system_prompt })
       end
 
@@ -217,6 +229,15 @@ module Clacky
 
       # Split files into vision images and disk files; downgrade oversized images to disk
       image_files, disk_files = partition_files(Array(files))
+
+      # If the current provider does not support vision, downgrade all images to disk files
+      # to avoid sending base64 data to a model that cannot process it,
+      # which would cause abnormal token consumption.
+      unless Clacky::Providers.vision?(provider_id)
+        disk_files  = disk_files + image_files.map { |f| f.merge(type: "image") }
+        image_files = []
+      end
+
       vision_images, downgraded = resolve_vision_images(image_files)
       all_disk_files = disk_files + downgraded
 

--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -28,6 +28,7 @@ module Clacky
         "api" => "openai-completions",
         "default_model" => "MiniMax-M2.7",
         "models" => ["MiniMax-M2.5", "MiniMax-M2.7"],
+        "vision" => false,  # text-only model, does not support image input
         "website_url" => "https://www.minimaxi.com/user-center/basic-information/interface-key"
       }.freeze,
 
@@ -154,6 +155,18 @@ module Clacky
       def fallback_model(provider_id, model)
         preset = PRESETS[provider_id]
         preset&.dig("fallback_models", model)
+      end
+
+      # Check if a provider supports vision (image) input.
+      # Unknown providers (no preset) default to true to avoid breaking existing behaviour.
+      # Providers without a "vision" key also default to true.
+      # Only providers explicitly set with "vision" => false are blocked.
+      # @param provider_id [String, nil] The provider identifier
+      # @return [Boolean] True if the provider supports vision input
+      def vision?(provider_id)
+        preset = PRESETS[provider_id]
+        return true if preset.nil?       # unknown provider — allow by default
+        preset.fetch("vision", true)     # no "vision" key — allow by default
       end
 
       # Find provider ID by base URL.


### PR DESCRIPTION
## Problem

MiniMax do not support vision input. When images are present, they get base64-encoded and sent to the model, causing abnormal token consumption and context window overflow.

## Fix

- Added `vision?()` method to `Providers` and marked MiniMax as `vision: false`.
- In `Agent#run`, text-only providers downgrade image files to disk file references, preventing base64 encoding.
- At session start, inject a warning into the system prompt instructing text-only models not to attempt reading image files via tools.

## Test

Tested with MiniMax. Token consumption stays minimal when images are present. Model correctly declines image requests and suggests switching to a vision-capable model.