### PR TITLE
fix(session): persist pinned status in agent object (C-5556)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -43,6 +43,7 @@ module Clacky
     attr_reader :session_id, :name, :history, :iterations, :total_cost, :working_dir, :created_at, :total_tasks, :todos,
                 :cache_stats, :cost_source, :ui, :skill_loader, :agent_profile,
                 :status, :error, :updated_at, :source
+    attr_accessor :pinned
 
     def permission_mode
       @config&.permission_mode&.to_s || ""
@@ -57,6 +58,7 @@ module Clacky
       @hooks = HookManager.new
       @session_id = session_id
       @name = ""
+      @pinned = false
       @history = MessageHistory.new
       @todos = []  # Store todos in memory
       @iterations = 0

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -10,6 +10,7 @@ module Clacky
       def restore_session(session_data)
         @session_id = session_data[:session_id]
         @name = session_data[:name] || ""
+        @pinned = session_data[:pinned] || false
         @history = MessageHistory.new(session_data[:messages] || [])
         @todos = session_data[:todos] || []  # Restore todos from session
         @iterations = session_data.dig(:stats, :total_iterations) || 0
@@ -77,6 +78,7 @@ module Clacky
         {
           session_id: @session_id,
           name: @name,
+          pinned: @pinned,
           created_at: @created_at,
           updated_at: Time.now.iso8601,
           working_dir: @working_dir,

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1831,15 +1831,13 @@ module Clacky
           agent.rename(new_name)
         end
         
-        # Save session data
-        session_data = agent.to_session_data
-        
-        # Update pinned field if provided (not stored in agent, only in session file)
+        # Update pinned status if provided
         if !pinned.nil?
-          session_data[:pinned] = pinned
+          agent.pinned = pinned
         end
         
-        @session_manager.save(session_data)
+        # Save session data
+        @session_manager.save(agent.to_session_data)
         
         # Broadcast update event
         update_data = { type: "session_updated", session_id: session_id }

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -265,10 +265,6 @@ module Clacky
 
         model_info = agent.current_model_info
         
-        # Load pinned status from disk session file
-        disk_session = @session_manager.load(session_id)
-        pinned = disk_session ? (disk_session[:pinned] || false) : false
-        
         {
           id:              session[:id],
           name:            agent.name,
@@ -283,7 +279,7 @@ module Clacky
           permission_mode: agent.permission_mode,
           source:          agent.source.to_s,
           agent_profile:   agent.agent_profile.name,
-          pinned:          pinned,
+          pinned:          agent.pinned || false,
         }
       end
     end


### PR DESCRIPTION
## Problem

After pinning a session, sending a message and refreshing the browser causes the pinned status to be lost. The `pinned` field was only stored in the session file on disk but not in the agent object. When `to_session_data()` was called during save, it did not include `pinned`, and the full-file overwrite erased it.

## Fix

Store `pinned` in the agent object (same pattern as `name`), so every `to_session_data()` call automatically includes it. Also removed the redundant disk read in `session_summary` — now reads `pinned` directly from the agent.

## Test

1. Pin a session
2. Send a message in that session
3. Refresh browser → pinned status preserved ✅
4. Restart server → pinned status preserved ✅