### PR TITLE
fix(ui): brand skill names not following language switch (C-5554)

### DIFF
--- a/lib/clacky/web/skills.js
+++ b/lib/clacky/web/skills.js
@@ -165,7 +165,7 @@ const Skills = (() => {
       <div class="brand-skill-card-main">
         <div class="brand-skill-info">
           <div class="brand-skill-title">
-            <span class="brand-skill-name">${escapeHtml(skill.name_zh || name)}</span>
+            <span class="brand-skill-name">${escapeHtml((currentLang === "zh" && skill.name_zh) ? skill.name_zh : name)}</span>
             ${privateBadge}
           </div>
           <div class="brand-skill-desc">${escapeHtml(description)}</div>
@@ -319,7 +319,7 @@ const Skills = (() => {
         <div class="skill-card-info">
           <div class="skill-card-title">
             ${warnIconHtml}
-            <span class="skill-name">${escapeHtml(skill.name_zh || skill.name)}</span>
+            <span class="skill-name">${escapeHtml((currentLang === "zh" && skill.name_zh) ? skill.name_zh : skill.name)}</span>
             <span class="${badgeClass}">${badgeLabel}</span>
             ${skill.invalid ? `<span class="skill-badge skill-badge-invalid">${I18n.t("skills.badge.invalid")}</span>` : ""}
           </div>


### PR DESCRIPTION
## Problem

When WebUI language is set to English, skill names in both Brand Skills and My Skills tabs still display in Chinese. The name field always prefers `name_zh` regardless of the current language setting.

## Fix

Apply the same language-aware logic already used for skill descriptions to skill names: show `name_zh` when the current language is Chinese, otherwise show the English `name`.

Two lines changed in `skills.js`: `_renderBrandSkillCard` and `_renderSkillCard`.

## Test

1. Set WebUI language to English → skill names display in English
2. Switch language to Chinese → skill names display in Chinese