### PR TITLE
fix: file:// links not rendered during streaming & click not working (C-5552, C-5553)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1252,13 +1252,13 @@ module Clacky
     #   [Download report](file:///path/to/file.pdf)
     #   ![chart](file:///path/to/chart.png)
     #
-    # Returns { text: String, files: Array<{name:, path:, inline:}> }
-    # File links are stripped from the returned text.
+    # Returns { text: String (original content, unmodified),
+    #           files: Array<{name:, path:, inline:}> }
     private def parse_file_links(content)
       return { text: content, files: [] } if content.nil? || content.empty?
 
       files = []
-      text = content.gsub(/(!?)\[([^\]]*)\]\(file:\/\/([^)]+)\)/) do
+      content.scan(/(!?)\[([^\]]*)\]\(file:\/\/([^)]+)\)/) do
         inline = $1 == "!"
         # URL-decode percent-encoded characters (e.g. Chinese filenames encoded by AI)
         raw_path = CGI.unescape($3)
@@ -1266,9 +1266,8 @@ module Clacky
         path   = File.expand_path(raw_path)
         Clacky::Logger.info("[parse_file_links] raw=#{$3.inspect} expanded=#{path.inspect} exist=#{File.exist?(path)}")
         files << { name: name, path: path, inline: inline }
-        ""
       end
-      { text: text.strip, files: files }
+      { text: content, files: files }
     end
 
     # Emit assistant message to UI, parsing any embedded file:// links first.

--- a/lib/clacky/server/channel/channel_ui_controller.rb
+++ b/lib/clacky/server/channel/channel_ui_controller.rb
@@ -51,7 +51,11 @@ module Clacky
       def show_assistant_message(content, files:)
         flush_buffer
         Clacky::Logger.info("[ChannelUI] show_assistant_message files=#{files.size} content_len=#{content.to_s.length}")
-        send_text(content) unless content.nil? || content.to_s.strip.empty?
+        # Strip file:// markdown links from the text sent to IM channels —
+        # the actual files are delivered via send_file() below, so the
+        # raw markdown links would just be noise in the chat.
+        text = content.to_s.gsub(/!?\[[^\]]*\]\(file:\/\/[^)]+\)/, "").strip
+        send_text(text) unless text.empty?
         files.each do |f|
           Clacky::Logger.info("[ChannelUI] sending file path=#{f[:path].inspect} name=#{f[:name].inspect}")
           send_file(f[:path], f[:name])

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -382,6 +382,7 @@ module Clacky
         when ["GET",    "/api/channels"]          then api_list_channels(res)
         when ["POST",   "/api/tool/browser"]      then api_tool_browser(req, res)
         when ["POST",   "/api/upload"]            then api_upload_file(req, res)
+        when ["POST",   "/api/open-file"]         then api_open_file(req, res)
         when ["GET",    "/api/version"]           then api_get_version(res)
         when ["POST",   "/api/version/upgrade"]   then api_upgrade_version(req, res)
         when ["POST",   "/api/restart"]           then api_restart(req, res)
@@ -1147,6 +1148,50 @@ module Clacky
         )
 
         json_response(res, 200, { ok: true, name: saved[:name], path: saved[:path] })
+      rescue => e
+        json_response(res, 500, { ok: false, error: e.message })
+      end
+
+      # POST /api/open-file
+      # Opens a local file or directory using the OS default handler.
+      # Used by the Web UI to handle file:// links — browsers block direct
+      # file:// navigation from http:// pages for security reasons.
+      def api_open_file(req, res)
+        path = parse_json_body(req)["path"]
+        return json_response(res, 400, { error: "path is required" }) unless path && !path.empty?
+
+        os = Utils::EnvironmentDetector.os_type
+
+        # On WSL the file may be specified as a Windows path (e.g. "C:/Users/…").
+        # Convert it to the Linux-side path so File.exist? works.
+        linux_path = if os == :wsl && path.match?(/\A[A-Za-z]:[\/\\]/)
+                       drive = path[0].downcase
+                       rest  = path[2..].gsub("\\", "/")
+                       "/mnt/#{drive}#{rest}"
+                     else
+                       path
+                     end
+
+        return json_response(res, 404, { error: "file not found" }) unless File.exist?(linux_path)
+
+        cmd = case os
+              when :macos then "open"
+              when :linux then "xdg-open"
+              when :wsl   then "explorer.exe"
+              else nil
+              end
+        return json_response(res, 501, { error: "unsupported OS" }) unless cmd
+
+        # explorer.exe only understands Windows-style paths.
+        # Convert Linux paths to Windows paths via wslpath.
+        open_path = if os == :wsl
+                      Clacky::Utils::Encoding.cmd_to_utf8(`wslpath -w '#{linux_path.gsub("'", "'\''")}'`, source_encoding: "UTF-8").strip
+                    else
+                      linux_path
+                    end
+
+        system(cmd, open_path)
+        json_response(res, 200, { ok: true })
       rescue => e
         json_response(res, 500, { ok: false, error: e.message })
       end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1160,32 +1160,14 @@ module Clacky
         path = parse_json_body(req)["path"]
         return json_response(res, 400, { error: "path is required" }) unless path && !path.empty?
 
-        os = Utils::EnvironmentDetector.os_type
-
         # On WSL the file may be specified as a Windows path (e.g. "C:/Users/…").
         # Convert it to the Linux-side path so File.exist? works.
-        linux_path = if os == :wsl && path.match?(/\A[A-Za-z]:[\/\\]/)
-                       drive = path[0].downcase
-                       rest  = path[2..].gsub("\\", "/")
-                       "/mnt/#{drive}#{rest}"
-                     else
-                       path
-                     end
+        linux_path = Utils::EnvironmentDetector.win_to_linux_path(path)
 
         return json_response(res, 404, { error: "file not found" }) unless File.exist?(linux_path)
 
-        cmd = Utils::EnvironmentDetector.open_command
-        return json_response(res, 501, { error: "unsupported OS" }) unless cmd
-
-        # explorer.exe only understands Windows-style paths.
-        # Convert Linux paths to Windows paths via wslpath.
-        open_path = if os == :wsl
-                      Clacky::Utils::Encoding.cmd_to_utf8(`wslpath -w '#{linux_path.gsub("'", "'\''")}'`, source_encoding: "UTF-8").strip
-                    else
-                      linux_path
-                    end
-
-        system(cmd, open_path)
+        result = Utils::EnvironmentDetector.open_file(linux_path)
+        return json_response(res, 501, { error: "unsupported OS" }) if result.nil?
         json_response(res, 200, { ok: true })
       rescue => e
         json_response(res, 500, { ok: false, error: e.message })

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1174,12 +1174,7 @@ module Clacky
 
         return json_response(res, 404, { error: "file not found" }) unless File.exist?(linux_path)
 
-        cmd = case os
-              when :macos then "open"
-              when :linux then "xdg-open"
-              when :wsl   then "explorer.exe"
-              else nil
-              end
+        cmd = Utils::EnvironmentDetector.open_command
         return json_response(res, 501, { error: "unsupported OS" }) unless cmd
 
         # explorer.exe only understands Windows-style paths.

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -87,22 +87,7 @@ module Clacky
       def show_assistant_message(content, files:)
         return if (content.nil? || content.to_s.strip.empty?) && files.empty?
 
-        # Re-append file:// links as markdown so the browser can render them.
-        # agent.rb strips them from content into `files` for IM channels that
-        # call send_file(); the web frontend only uses `content`, so we put
-        # them back here.
-        full_content = content.to_s.dup
-        unless files.empty?
-          links = files.map do |f|
-            prefix = f[:inline] ? "!" : ""
-            "#{prefix}[#{f[:name]}](file://#{f[:path]})"
-          end
-          full_content = full_content.strip
-          full_content += "\n\n" + links.join("\n") unless full_content.empty?
-          full_content = links.join("\n") if full_content.empty?
-        end
-
-        emit("assistant_message", content: full_content, files: files)
+        emit("assistant_message", content: content.to_s, files: files)
         forward_to_subscribers { |sub| sub.show_assistant_message(content, files: files) }
       end
 

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -87,7 +87,22 @@ module Clacky
       def show_assistant_message(content, files:)
         return if (content.nil? || content.to_s.strip.empty?) && files.empty?
 
-        emit("assistant_message", content: content, files: files)
+        # Re-append file:// links as markdown so the browser can render them.
+        # agent.rb strips them from content into `files` for IM channels that
+        # call send_file(); the web frontend only uses `content`, so we put
+        # them back here.
+        full_content = content.to_s.dup
+        unless files.empty?
+          links = files.map do |f|
+            prefix = f[:inline] ? "!" : ""
+            "#{prefix}[#{f[:name]}](file://#{f[:path]})"
+          end
+          full_content = full_content.strip
+          full_content += "\n\n" + links.join("\n") unless full_content.empty?
+          full_content = links.join("\n") if full_content.empty?
+        end
+
+        emit("assistant_message", content: full_content, files: files)
         forward_to_subscribers { |sub| sub.show_assistant_message(content, files: files) }
       end
 

--- a/lib/clacky/utils/environment_detector.rb
+++ b/lib/clacky/utils/environment_detector.rb
@@ -20,14 +20,47 @@ module Clacky
         end
       end
 
-      # Return the OS-specific command for opening files/URLs.
-      # @return [String, nil] "open" (macOS), "xdg-open" (Linux), "explorer.exe" (WSL), or nil
-      def self.open_command
+      # Open a file with the OS-default application.
+      # On WSL, uses "cmd.exe /c start" instead of explorer.exe so the opened
+      # window receives foreground focus even when called from a background
+      # thread (e.g. WEBrick request handler).
+      # @param path [String] Linux-side file path
+      # @return [Boolean, nil] true/false from system(), or nil on unsupported OS
+      def self.open_file(path)
         case os_type
-        when :macos then "open"
-        when :linux then "xdg-open"
-        when :wsl   then "explorer.exe"
+        when :macos then system("open", path)
+        when :linux then system("xdg-open", path)
+        when :wsl
+          win_path = linux_to_win_path(path)
+          system("cmd.exe", "/c", "start", "", win_path)
         end
+      end
+
+      # Convert a Windows-style path to a WSL/Linux-side path.
+      # e.g. "C:/Users/foo/file.txt" → "/mnt/c/Users/foo/file.txt"
+      # Returns the original path unchanged on non-WSL or if already a Linux path.
+      # @param path [String]
+      # @return [String]
+      def self.win_to_linux_path(path)
+        return path unless os_type == :wsl && path.match?(/\A[A-Za-z]:[\/\\]/)
+
+        drive = path[0].downcase
+        rest  = path[2..].gsub("\\", "/")
+        "/mnt/#{drive}#{rest}"
+      end
+
+      # Convert a Linux-side path to a Windows-style path via wslpath.
+      # e.g. "/mnt/c/Users/foo/file.txt" → "C:\Users\foo\file.txt"
+      # Returns the original path unchanged on non-WSL.
+      # @param path [String]
+      # @return [String]
+      def self.linux_to_win_path(path)
+        return path unless os_type == :wsl
+
+        Clacky::Utils::Encoding.cmd_to_utf8(
+          `wslpath -w '#{path.gsub("'", "'\''")}'`,
+          source_encoding: "UTF-8"
+        ).strip
       end
 
       # Human-readable OS label for injection into session context.

--- a/lib/clacky/utils/environment_detector.rb
+++ b/lib/clacky/utils/environment_detector.rb
@@ -20,6 +20,16 @@ module Clacky
         end
       end
 
+      # Return the OS-specific command for opening files/URLs.
+      # @return [String, nil] "open" (macOS), "xdg-open" (Linux), "explorer.exe" (WSL), or nil
+      def self.open_command
+        case os_type
+        when :macos then "open"
+        when :linux then "xdg-open"
+        when :wsl   then "explorer.exe"
+        end
+      end
+
       # Human-readable OS label for injection into session context.
       def self.os_label
         case os_type

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -95,14 +95,6 @@ const Sessions = (() => {
       const renderer = new marked.Renderer();
       renderer.link = function({ href, title, text }) {
         const titleAttr = title ? ` title="${title}"` : "";
-        // file:// links cannot be opened by the browser directly (security policy).
-        // Delegate to the backend API which calls the OS default handler.
-        if (href && href.startsWith("file://")) {
-          let filePath = decodeURIComponent(href.replace(/^file:\/\//, ""));
-          // file:///C:/foo → /C:/foo after replace; strip the leading slash for Windows drive letters
-          if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.substring(1);
-          return `<a href="javascript:void(0)" class="file-link" data-file-path="${filePath.replace(/"/g, "&quot;")}"${titleAttr}>${text}</a>`;
-        }
         return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
       };
       // Use marked with a few sensible defaults:
@@ -752,12 +744,14 @@ const Sessions = (() => {
       // Re-render session list (badges/labels) when the user switches language
       document.addEventListener("langchange", () => Sessions.renderList());
       // Browsers block file:// navigation from http:// pages. Intercept clicks on
-      // .file-link elements and delegate to the backend API (OS default handler).
+      // file:// links and delegate to the backend API (OS default handler).
       document.addEventListener("click", (e) => {
-        const link = e.target.closest("a.file-link");
+        const link = e.target.closest("a[href^='file://']");
         if (!link) return;
         e.preventDefault();
-        const filePath = link.getAttribute("data-file-path");
+        let filePath = decodeURIComponent(link.getAttribute("href").replace(/^file:\/\//, ""));
+        // file:///C:/foo → /C:/foo after replace; strip the leading slash for Windows drive letters
+        if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.substring(1);
         if (!filePath) return;
         fetch("/api/open-file", {
           method: "POST",

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -95,6 +95,14 @@ const Sessions = (() => {
       const renderer = new marked.Renderer();
       renderer.link = function({ href, title, text }) {
         const titleAttr = title ? ` title="${title}"` : "";
+        // file:// links cannot be opened by the browser directly (security policy).
+        // Delegate to the backend API which calls the OS default handler.
+        if (href && href.startsWith("file://")) {
+          let filePath = decodeURIComponent(href.replace(/^file:\/\//, ""));
+          // file:///C:/foo → /C:/foo after replace; strip the leading slash for Windows drive letters
+          if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.substring(1);
+          return `<a href="javascript:void(0)" class="file-link" data-file-path="${filePath.replace(/"/g, "&quot;")}"${titleAttr}>${text}</a>`;
+        }
         return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
       };
       // Use marked with a few sensible defaults:
@@ -743,6 +751,20 @@ const Sessions = (() => {
       _initNewMessageBanner();
       // Re-render session list (badges/labels) when the user switches language
       document.addEventListener("langchange", () => Sessions.renderList());
+      // Browsers block file:// navigation from http:// pages. Intercept clicks on
+      // .file-link elements and delegate to the backend API (OS default handler).
+      document.addEventListener("click", (e) => {
+        const link = e.target.closest("a.file-link");
+        if (!link) return;
+        e.preventDefault();
+        const filePath = link.getAttribute("data-file-path");
+        if (!filePath) return;
+        fetch("/api/open-file", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ path: filePath })
+        });
+      });
     },
 
     // ── List management ───────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Two issues with `file://` links in Web UI:

1. **C-5552**: `file://` links are not rendered during streaming output — they appear only after the full message is loaded.
2. **C-5553**: Clicking `file://` links does nothing — Chrome blocks `file://` navigation from `http://` pages for security reasons. On WSL, additional path conversion is needed (Windows paths ↔ Linux paths).

## Fix

### Bug 1 — Streaming render (C-5552)
- `web_ui_controller.rb`: Re-assemble the `files` array back into markdown link format in `show_assistant_message` so they are visible during streaming.

### Bug 2 — Click handling (C-5553)
- `sessions.js`: Override `marked` renderer for `file://` links — render as `<a class="file-link" data-file-path="...">` instead of a real link. Add event delegation in `init()` to intercept clicks and call the backend API.
- `http_server.rb`: New `POST /api/open-file` endpoint that opens files via OS default handler (`open` on macOS, `xdg-open` on Linux, `explorer.exe` on WSL). On WSL, converts Windows drive paths (`C:/...`) to Linux paths (`/mnt/c/...`) for `File.exist?`, then uses `wslpath -w` to convert back for `explorer.exe`.

## Test

- **macOS**: `file://` links render during streaming ✅, click opens file in Finder ✅
- **Windows (WSL)**: Three path types all work ✅
  - WSL Linux path (`/root/...`) → `\\wsl$\...`
  - WSL mount path (`/mnt/c/...`) → `C:\Users\...`
  - Windows path (`C:/Users/...`) → `C:\Users\...`