### PR TITLE
fix(pricing): add Kimi K2.5 / K2.6 to ModelPricing table (C-5574)

### DIFF
--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -141,6 +141,42 @@ module Clacky
         }
       },
 
+      # Kimi K2.5 / K2.6 multimodal models
+      # Source: https://platform.moonshot.cn (USD / 1M tokens)
+      # Kimi billing model (same shape as DeepSeek):
+      #   - "cache miss input" = regular prompt_tokens rate
+      #   - "cache hit input"  = cache_read rate (no separate cache-write charge)
+      #   - No tiered pricing (single rate regardless of context length)
+      "kimi-k2.5" => {
+        input: {
+          default: 0.60,                  # $0.60/MTok cache miss
+          over_200k: 0.60                 # no tiered pricing
+        },
+        output: {
+          default: 3.00,                  # $3.00/MTok
+          over_200k: 3.00
+        },
+        cache: {
+          write: 0.60,                    # Kimi doesn't charge extra for writes; bill at miss rate
+          read: 0.10                      # $0.10/MTok cache hit
+        }
+      },
+
+      "kimi-k2.6" => {
+        input: {
+          default: 0.95,                  # $0.95/MTok cache miss
+          over_200k: 0.95
+        },
+        output: {
+          default: 4.00,                  # $4.00/MTok
+          over_200k: 4.00
+        },
+        cache: {
+          write: 0.95,                    # no separate write charge; bill at miss rate
+          read: 0.16                      # $0.16/MTok cache hit
+        }
+      },
+
     }.freeze
 
     # Threshold for tiered pricing (200K tokens)
@@ -270,6 +306,14 @@ module Clacky
         # non-thinking / thinking modes respectively. Bill at flash rates.
         when /^deepseek-chat$/i, /^deepseek-reasoner$/i
           "deepseek-v4-flash"
+        # Kimi K2.5 / K2.6 — strict match only. K2 text-only models
+        # (kimi-k2-0905-preview, kimi-k2-thinking, etc.) are not yet
+        # registered in providers.rb and will be added in a follow-up
+        # issue together with their model_capabilities overrides.
+        when /^kimi-k2\.?5$/i
+          "kimi-k2.5"
+        when /^kimi-k2\.?6$/i
+          "kimi-k2.6"
         else
           nil  # No pricing available for this model — cost will show as N/A
         end

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -191,6 +191,57 @@ RSpec.describe Clacky::ModelPricing do
       end
     end
 
+    context "with Kimi K2 multimodal models" do
+      it "calculates kimi-k2.5 basic cost" do
+        usage = {
+          prompt_tokens: 100_000,          # 100K tokens
+          completion_tokens: 50_000         # 50K tokens
+        }
+
+        # Input:  (100_000 / 1_000_000) * $0.60 = $0.060
+        # Output: (50_000  / 1_000_000) * $3.00 = $0.150
+        # Total:  $0.210
+        result = described_class.calculate_cost(model: "kimi-k2.5", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.210)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates kimi-k2.6 with cache read (cache hit billing)" do
+        usage = {
+          prompt_tokens: 100_000,          # includes cache reads per OpenAI-style counting
+          completion_tokens: 50_000,
+          cache_read_input_tokens: 30_000  # cache hit portion
+        }
+
+        # Regular input (non-cached): ((100_000 - 30_000) / 1_000_000) * $0.95 = $0.0665
+        # Output:                     (50_000 / 1_000_000)             * $4.00 = $0.200
+        # Cache read:                 (30_000 / 1_000_000)             * $0.16 = $0.0048
+        # Total: $0.2713
+        result = described_class.calculate_cost(model: "kimi-k2.6", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.2713)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "matches kimi-k2.5 case-insensitively" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+        result = described_class.calculate_cost(model: "Kimi-K2.5", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.210)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "does not match unregistered k2 text-only variants" do
+        # K2 text-only models (kimi-k2-0905-preview, kimi-k2-thinking, etc.)
+        # are not in the pricing table yet — they must return N/A, not
+        # accidentally bill at k2.5/k2.6 rates via a loose regex.
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+        %w[kimi-k2-0905-preview kimi-k2-thinking kimi-k2-turbo-preview].each do |model|
+          result = described_class.calculate_cost(model: model, usage: usage)
+          expect(result[:cost]).to be_nil
+          expect(result[:source]).to be_nil
+        end
+      end
+    end
+
     context "with Claude 3.5 models" do
       it "supports claude-3-5-sonnet-20241022" do
         usage = {


### PR DESCRIPTION
## Problem

Conversations using `kimi-k2.5` / `kimi-k2.6` showed **Cost: N/A** because the built-in `ModelPricing` table had no entries for Kimi — `normalize_model_name` fell through to `else nil`, so `calculate_cost` returned `{cost: nil, source: nil}`.

## Fix

- `PRICING_TABLE`: added `kimi-k2.5` and `kimi-k2.6` following the DeepSeek shape (no tiered pricing, cache-write billed at miss rate). Prices from Moonshot official pricing page (USD/MTok).
- `normalize_model_name`: added **strict anchored** regex branches (`^kimi-k2.5$` / `^kimi-k2.6$`) to avoid accidentally matching unregistered K2 text-only variants (`kimi-k2-thinking`, `kimi-k2-0905-preview`, etc.)
- Scope limited to `model_pricing.rb` + spec.

## Test

- ✅ `kimi-k2.5` / `kimi-k2.6` basic input + output cost calculation
- ✅ `kimi-k2.6` cache-hit billing (verifies cache_read path)
- ✅ `Kimi-K2.5` case-insensitive matching
- ✅ Unregistered K2 variants (`kimi-k2-0905-preview`, `kimi-k2-thinking`, `kimi-k2-turbo-preview`) still return N/A — regex does not over-match
- ✅ Full suite: 1601 examples, 0 failures