### PR TITLE
feat: pre-install platform-recommended skills during onboard

### DIFF
--- a/lib/clacky/default_skills/onboard/SKILL.md
+++ b/lib/clacky/default_skills/onboard/SKILL.md
@@ -210,7 +210,16 @@ zh template:
 [1–2 句话，根据用户目标和背景量身定制。]
 ```
 
-### A.9. Import external skills (optional)
+### A.9. Pre-install platform-recommended skills
+
+Silently run `ruby "SKILL_DIR/scripts/install_platform_skills.rb" --recommended`,
+then parse the last stdout line as JSON and read `installed` as N.
+
+- If N > 0, show one line:
+  - zh: `✅ 已为你内置 N 个推荐技能，输入 /skills 随时查看。`
+  - en: `✅ Installed N recommended skills. Type /skills anytime to view them.`
+
+### A.10. Import external skills (optional)
 
 Run `test -d ~/.openclaw && echo yes || echo no`. If `no`, skip silently.
 If `yes`:
@@ -221,7 +230,7 @@ If `yes`:
    - en: `{ "question": "OpenClaw detected. Found N skills. Import them into Clacky?", "options": ["Import", "Skip"] }`
 4. If confirmed: `ruby "SKILL_DIR/scripts/import_external_skills.rb" --source openclaw --yes`
 
-### A.10. Celebrate soul setup & offer browser
+### A.11. Celebrate soul setup & offer browser
 
 zh:
 > ✅ 你的专属 AI 灵魂已设定完成！[ai.name] 已经准备好了。
@@ -240,14 +249,14 @@ en: `{ "question": "Want to set up browser automation now? (You can always run /
 
 If chosen → invoke `browser-setup` skill with subcommand `setup`.
 
-### A.11. Offer personal website
+### A.12. Offer personal website
 
 zh: `{ "question": "还有一件有意思的事：要帮你生成一个个人主页吗？我会根据你刚才分享的信息做一个，生成后你会得到一个公开链接。", "options": ["生成主页", "跳过，完成设置"] }`
 en: `{ "question": "One more thing: want me to generate a personal website from the info you just shared? You'll get a public link you can share.", "options": ["Generate my site", "Skip, I'm done"] }`
 
 If chosen → invoke `personal-website` skill.
 
-### A.12. Confirm and close
+### A.13. Confirm and close
 
 Speak as [ai.name]. This is the AI's first moment of truly being alive — it has a soul,
 it knows its person, it has hands and eyes, and it just did its first real thing in the world.
@@ -315,7 +324,7 @@ en:
 
 Do NOT open a new session — the UI handles navigation after the skill finishes.
 
-### A.13. First-run notes
+### A.14. First-run notes
 
 - Keep both files under 300 words each.
 - Do not ask follow-up questions beyond the cards above.

--- a/lib/clacky/default_skills/onboard/scripts/install_platform_skills.rb
+++ b/lib/clacky/default_skills/onboard/scripts/install_platform_skills.rb
@@ -1,0 +1,195 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Install platform skills into ~/.clacky/skills/.
+#
+# Fetches the skill list from GET /api/v1/skills on the openclacky platform
+# (public, no auth), then downloads and installs each skill's zip package
+# in parallel (5 workers, 30s total timeout).
+#
+# Called by onboard skill: `ruby install_platform_skills.rb --recommended`
+#
+# Output:
+#   - Diagnostics → STDERR
+#   - Last line of STDOUT → JSON: {"installed":N,"attempted":N,"skipped_existing":N}
+#   - Exit code: always 0
+
+require 'uri'
+require 'net/http'
+require 'json'
+require 'optparse'
+require 'timeout'
+
+# Reuse the downloader/extractor/installer from the skill-add skill.
+# Physical relocation to lib/clacky/ is deferred until a third caller appears.
+require_relative '../../skill-add/scripts/install_from_zip'
+
+class PlatformSkillsInstaller
+  PRIMARY_HOST     = ENV.fetch('CLACKY_LICENSE_SERVER', 'https://www.openclacky.com')
+  FALLBACK_HOST    = 'https://openclacky.up.railway.app'
+  API_HOSTS        = ENV['CLACKY_LICENSE_SERVER'] ? [PRIMARY_HOST] : [PRIMARY_HOST, FALLBACK_HOST]
+  API_OPEN_TIMEOUT = 5
+  API_READ_TIMEOUT = 10
+  CONCURRENCY      = 5
+
+  def initialize(options)
+    @query_params      = build_query_params(options)
+    @target_dir        = File.join(Dir.home, '.clacky', 'skills')
+    @per_skill_timeout = 10
+    @total_timeout     = 30
+
+    @installed         = 0
+    @skipped_existing  = 0
+    @attempted         = 0
+    @errors            = []
+    @mutex             = Mutex.new
+  end
+
+  def run
+    skills = fetch_skill_list
+    if skills.nil? || skills.empty?
+      emit_summary
+      return
+    end
+
+    install_concurrently(skills)
+  ensure
+    emit_summary
+  end
+
+  # --- Internals -------------------------------------------------------------
+
+  # Build the query-parameter hash that mirrors the platform API spec.
+  private def build_query_params(options)
+    params = {}
+    params['recommended'] = 'true' if options[:recommended]
+    params['category'] = options[:category] if options[:category]
+    params
+  end
+
+  # /api/v1/skills[?...]. Empty query when no filters.
+  private def api_path
+    qs = URI.encode_www_form(@query_params)
+    qs.empty? ? '/api/v1/skills' : "/api/v1/skills?#{qs}"
+  end
+
+  # Returns an array of skill hashes, or nil on total failure.
+  private def fetch_skill_list
+    API_HOSTS.each do |host|
+      begin
+        uri = URI.parse(host + api_path)
+        Net::HTTP.start(uri.host, uri.port,
+                        use_ssl:      uri.scheme == 'https',
+                        open_timeout: API_OPEN_TIMEOUT,
+                        read_timeout: API_READ_TIMEOUT) do |http|
+          response = http.request(Net::HTTP::Get.new(uri.request_uri))
+          if response.code.to_i == 200
+            payload = JSON.parse(response.body)
+            return Array(payload['skills'])
+          else
+            @errors << "API #{host}: HTTP #{response.code}"
+          end
+        end
+      rescue StandardError => e
+        @errors << "API #{host}: #{e.class}: #{e.message}"
+      end
+    end
+    nil
+  end
+
+  # Install skills in parallel, bounded by CONCURRENCY and @total_timeout.
+  # Workers pull from a shared queue and self-check the deadline, so the
+  # global timeout is enforced without killing threads mid-download (which
+  # would leak temp dirs). Whatever finishes before the deadline stays
+  # installed; the rest is recovered on the next onboard run via skip_if_exists.
+  private def install_concurrently(skills)
+    queue = Queue.new
+    skills.each { |s| queue << s }
+
+    deadline    = Time.now + @total_timeout
+    worker_pool = [CONCURRENCY, skills.size].min
+
+    workers = Array.new(worker_pool) do
+      Thread.new do
+        loop do
+          break if Time.now >= deadline
+          skill = queue.pop(true) rescue nil    # non-blocking pop
+          break if skill.nil?
+          install_one(skill)
+        end
+      end
+    end
+
+    workers.each(&:join)
+
+    # If the deadline cut us off with items still in the queue, record it.
+    remaining = queue.size
+    if remaining.positive?
+      @mutex.synchronize do
+        @errors << "overall timeout after #{@total_timeout}s " \
+                   "(installed=#{@installed}, attempted=#{@attempted}, remaining=#{remaining})"
+      end
+    end
+  end
+
+  # Install one skill entry (hash from the API payload).
+  # Bounded by @per_skill_timeout; any failure is swallowed into @errors.
+  # Thread-safe: all shared state writes go through @mutex.
+  private def install_one(skill)
+    name         = skill['name'].to_s
+    download_url = skill['download_url'].to_s
+
+    @mutex.synchronize { @attempted += 1 }
+
+    if name.empty? || download_url.empty?
+      @mutex.synchronize do
+        @errors << "skill payload missing name or download_url: #{skill.inspect}"
+      end
+      return
+    end
+
+    Timeout.timeout(@per_skill_timeout) do
+      installer = ZipSkillInstaller.new(
+        download_url,
+        skill_name:     name,
+        target_dir:     @target_dir,
+        skip_if_exists: true
+      )
+      result = installer.perform
+      @mutex.synchronize do
+        @installed        += result[:installed].size
+        @skipped_existing += result[:skipped].size
+        @errors.concat(result[:errors]) if result[:errors].any?
+      end
+    end
+  rescue Timeout::Error
+    @mutex.synchronize { @errors << "#{name}: install timeout after #{@per_skill_timeout}s" }
+  rescue StandardError => e
+    @mutex.synchronize { @errors << "#{name}: #{e.class}: #{e.message}" }
+  end
+
+  # Diagnostics to stderr; single-line JSON summary to stdout.
+  # The caller (onboard) should parse the LAST stdout line.
+  private def emit_summary
+    unless @errors.empty?
+      warn '[install_platform_skills] non-fatal errors:'
+      @errors.each { |e| warn "  - #{e}" }
+    end
+    puts JSON.generate(
+      installed:        @installed,
+      attempted:        @attempted,
+      skipped_existing: @skipped_existing
+    )
+  end
+end
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+if __FILE__ == $0
+  options = {}
+  OptionParser.new do |o|
+    o.on('--recommended', 'Only install recommended skills') { options[:recommended] = true }
+    o.on('--category SLUG', 'Filter by category slug') { |v| options[:category] = v }
+  end.parse!
+
+  PlatformSkillsInstaller.new(options).run
+end

--- a/lib/clacky/default_skills/skill-add/scripts/install_from_zip.rb
+++ b/lib/clacky/default_skills/skill-add/scripts/install_from_zip.rb
@@ -19,7 +19,7 @@ require 'find'
 class ZipSkillInstaller
   ZIP_URL_PATTERN = %r{^https?://.+\.zip(\?.*)?$}i
 
-  def initialize(zip_source, skill_name: nil, target_dir: nil)
+  def initialize(zip_source, skill_name: nil, target_dir: nil, skip_if_exists: false)
     @zip_source = zip_source
     @local_path = local_zip_path?(zip_source)
     # skill_name can be provided explicitly (e.g. slug from the store API).
@@ -27,45 +27,72 @@ class ZipSkillInstaller
     # "ui-ux-pro-max-1.0.0.zip" → "ui-ux-pro-max".
     @skill_name = skill_name || infer_skill_name(zip_source)
     @target_dir = target_dir || File.join(Dir.home, '.clacky', 'skills')
+    # When true, existing skill directories are preserved and the install for
+    # that specific skill is skipped (recorded in @skipped_skills).
+    # Default false keeps the legacy "overwrite" behaviour for `install`.
+    @skip_if_exists   = skip_if_exists
+    # Suppresses user-facing puts for programmatic callers (set by `perform`).
+    @silent           = false
     @installed_skills = []
-    @errors = []
+    @skipped_skills   = []
+    @errors           = []
   end
 
-  # Main installation entry point.
+  # Programmatic entry point for library-style callers (e.g. onboard pre-install).
+  #
+  # Unlike `install`, this method:
+  #   - does NOT print user-facing output
+  #   - does NOT call `exit` on failure (raises instead)
+  #   - returns a result hash: { installed: [...], skipped: [...], errors: [...] }
+  #
+  # The caller is responsible for rendering feedback and deciding whether any
+  # error is fatal.
+  def perform
+    @silent = true
+    do_install
+    { installed: @installed_skills, skipped: @skipped_skills, errors: @errors }
+  end
+
+  # Main installation entry point (CLI). Prints progress, prints a final
+  # report, and calls `exit` on failure. Use `perform` for programmatic use.
   def install
+    do_install
+    report_results
+  rescue ArgumentError => e
+    puts "Error: #{e.message}"
+    exit 1
+  rescue StandardError => e
+    puts "Error: Installation failed: #{e.message}"
+    exit 1
+  end
+
+  # Shared core used by both `install` (CLI) and `perform` (library).
+  # Raises on invalid input; the caller decides how to surface errors.
+  private def do_install
     if @local_path
       # Install directly from a local zip file — no download needed.
-      # Expand tilde in path (e.g. ~/Downloads/skill.zip)
+      # Expand tilde in path (e.g. ~/Downloads/skill.zip).
       expanded = File.expand_path(@zip_source)
-      raise ArgumentError, "File not found: #{@zip_source}" unless File.exist?(expanded)
-      raise ArgumentError, "Not a zip file: #{@zip_source}" unless expanded.end_with?('.zip')
+      raise ArgumentError, "File not found: #{@zip_source}"  unless File.exist?(expanded)
+      raise ArgumentError, "Not a zip file: #{@zip_source}"  unless expanded.end_with?('.zip')
 
       Dir.mktmpdir('clacky-zip-') do |tmpdir|
         extract_zip(expanded, tmpdir)
-        extracted_dir = File.join(tmpdir, 'extracted')
-        discover_and_install_skills(extracted_dir)
+        discover_and_install_skills(File.join(tmpdir, 'extracted'))
       end
     else
       # Install from a remote URL.
       unless valid_zip_url?
-        raise ArgumentError, "Invalid zip source: #{@zip_source}\nProvide an http(s) URL ending with .zip, or an absolute path to a local zip file."
+        raise ArgumentError, "Invalid zip source: #{@zip_source}\n" \
+                             "Provide an http(s) URL ending with .zip, or an absolute path to a local zip file."
       end
 
       Dir.mktmpdir('clacky-zip-') do |tmpdir|
         zip_path = download_zip(tmpdir)
         extract_zip(zip_path, tmpdir)
-        extracted_dir = File.join(tmpdir, 'extracted')
-        discover_and_install_skills(extracted_dir)
+        discover_and_install_skills(File.join(tmpdir, 'extracted'))
       end
     end
-
-    report_results
-  rescue ArgumentError => e
-    puts "❌ #{e.message}"
-    exit 1
-  rescue StandardError => e
-    puts "❌ Installation failed: #{e.message}"
-    exit 1
   end
 
   # Return true if the source looks like a local file path (absolute or relative ending in .zip).
@@ -93,8 +120,10 @@ class ZipSkillInstaller
 
   # Download the zip file to tmpdir and return its local path.
   private def download_zip(tmpdir)
-    puts "⬇️  Downloading skill package..."
-    puts "   #{@zip_source}"
+    unless @silent
+      puts "Downloading skill package..."
+      puts "   #{@zip_source}"
+    end
 
     zip_path = File.join(tmpdir, 'skill.zip')
     uri = URI.parse(@zip_source)
@@ -129,7 +158,7 @@ class ZipSkillInstaller
 
   # Extract the zip archive into <tmpdir>/extracted/.
   private def extract_zip(zip_path, tmpdir)
-    puts "📂 Extracting package..."
+    puts "Extracting package..." unless @silent
     extracted_dir = File.join(tmpdir, 'extracted')
     FileUtils.mkdir_p(extracted_dir)
 
@@ -184,7 +213,11 @@ class ZipSkillInstaller
     target_path = File.join(@target_dir, name)
 
     if File.exist?(target_path)
-      puts "♻️  Skill '#{name}' already exists — overwriting..."
+      if @skip_if_exists
+        @skipped_skills << { name: name, path: target_path, reason: 'already exists' }
+        return
+      end
+      puts "Skill '#{name}' already exists — overwriting..." unless @silent
       FileUtils.rm_rf(target_path)
     end
 
@@ -218,7 +251,7 @@ class ZipSkillInstaller
     puts "\n" + "=" * 60
 
     if @installed_skills.empty?
-      puts "❌ No skills were installed."
+      puts "No skills were installed."
       if @errors.any?
         puts "\nErrors:"
         @errors.each { |e| puts "   • #{e}" }
@@ -226,7 +259,7 @@ class ZipSkillInstaller
       exit 1
     end
 
-    puts "✅ Installation complete!"
+    puts "Installation complete!"
     puts "\nInstalled #{@installed_skills.size} skill(s):\n\n"
     @installed_skills.each do |skill|
       puts "   ✓ #{skill[:name]}"
@@ -236,7 +269,7 @@ class ZipSkillInstaller
     end
 
     if @errors.any?
-      puts "⚠️  Warnings:"
+      puts "Warnings:"
       @errors.each { |e| puts "   • #{e}" }
       puts
     end

--- a/lib/clacky/web/onboard.js
+++ b/lib/clacky/web/onboard.js
@@ -388,6 +388,7 @@ const Onboard = (() => {
   // Boot the normal UI (WS + sessions sidebar + tasks + skills).
   function _bootUI() {
     document.body.classList.remove("setup-mode");
+    SkillAC.init();
     WS.connect();
     Tasks.load();
     Skills.load();

--- a/lib/clacky/web/skills.js
+++ b/lib/clacky/web/skills.js
@@ -782,6 +782,7 @@ const Skills = (() => {
 //             I18n, global $ helper.
 // ─────────────────────────────────────────────────────────────────────────
 const SkillAC = (() => {
+  let _initialized    = false;
   let _visible        = false;
   let _activeIndex    = -1;
   let _items          = [];  // filtered [{ name, description, encrypted, source }]
@@ -1175,6 +1176,9 @@ const SkillAC = (() => {
 
     /** Initialize event listeners (call once on page load). */
     init() {
+      if (_initialized) return;
+      _initialized = true;
+
       const chk = $("chk-ac-show-system-skills");
 
       if (chk) {


### PR DESCRIPTION
- Add install_platform_skills.rb script with concurrent downloading, dual-host fallback, and deadline-based timeout
- Extend install_from_zip.rb with programmatic  method and option for idempotent installs
- Add onboard SKILL.md step A.9 to invoke platform skill pre-install
- Add SkillAC.init() idempotent guard to prevent duplicate listeners
- Call SkillAC.init() in onboard.js _bootUI() path