### PR TITLE
fix: feedback option click now auto-sends message

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -2484,14 +2484,14 @@ const Sessions = (() => {
 
       card.innerHTML = cardHtml;
 
-      // Click → disable card + submit immediately via sendMessage()
+      // Click → disable card + submit immediately via _sendMessage()
       card.querySelectorAll(".feedback-option-btn").forEach(btn => {
         btn.onclick = () => {
           card.querySelectorAll(".feedback-option-btn").forEach(b => b.disabled = true);
           card.classList.add("feedback-card--submitted");
           const input = $("user-input");
           if (input) input.value = btn.textContent.trim();
-          sendMessage();
+          _sendMessage();
         };
       });
 


### PR DESCRIPTION
sendMessage() was undefined in the IIFE scope — the internal function is named _sendMessage(). The ReferenceError silently prevented the message from being dispatched after setting the input value, causing the 'click option but no send' bug.