### PR TITLE
fix(css): align sidebar-footer and input-area with consistent height

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -78,6 +78,9 @@
   --shadow-md: 0 4px 12px rgba(15, 18, 28, 0.08), 0 2px 4px rgba(15, 18, 28, 0.04);
   --shadow-lg: 0 12px 28px rgba(15, 18, 28, 0.12), 0 4px 8px rgba(15, 18, 28, 0.06);
 
+  /* Layout — shared dimensions */
+  --footer-height: 56px;
+
   /* Transitions — unified timing */
   --transition-fast: 120ms ease;
   --transition-base: 160ms ease;
@@ -2079,7 +2082,6 @@ body {
   padding: 4px 14px;
   background: var(--color-bg-primary);
   border-top: 1px solid var(--color-border-secondary);
-  border-bottom: 1px solid var(--color-border-secondary);
   font-size: 11px;
   color: var(--color-text-secondary);
   font-family: var(--font-mono, monospace);
@@ -2437,6 +2439,9 @@ body {
   border-top: 1px solid var(--color-border-primary);
   background: var(--color-bg-secondary);
   flex-shrink: 0;
+  min-height: var(--footer-height);
+  display: flex;
+  flex-direction: column;
 }
 
 /* Hide top border when skill autocomplete is visible */
@@ -2762,9 +2767,11 @@ body {
 
 /* ── Input bar ───────────────────────────────────────────────────────────── */
 #input-bar {
-  padding: 13.5px 16px;
+  margin-top: auto;
+  margin-bottom: auto;
+  padding: 0 16px;
   display: flex;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
   background: var(--color-bg-secondary);
 }
@@ -2775,7 +2782,9 @@ body {
   background: transparent;
   color: var(--color-text-secondary);
   cursor: pointer;
-  padding: 6px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   line-height: 1;
   flex-shrink: 0;
   display: flex;
@@ -2789,16 +2798,20 @@ body {
   background: transparent;
   color: var(--color-text-secondary);
   cursor: pointer;
-  padding: 4px 7px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   line-height: 1;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 6px;
-  font-size: 15px;
   font-weight: 600;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}
+#btn-slash span {
+  font-size: 18px;
 }
 #btn-slash:hover { color: var(--color-accent-primary); background: var(--color-border-secondary); }
 #btn-slash.active { color: var(--color-accent-primary); }
@@ -2839,7 +2852,10 @@ body {
 /* ── Sidebar footer ──────────────────────────────────────────────────────── */
 #sidebar-footer {
   border-top: 1px solid var(--color-border-primary);
-  padding: 14px 8px;
+  min-height: var(--footer-height);
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
   flex-shrink: 0;
 }
 .sidebar-nav-btn {
@@ -5748,6 +5764,7 @@ body.setup-mode[data-theme="dark"] {
   border-radius: 6px;
   overflow: hidden;
   transition: background .15s;
+  width: 100%;
 }
 .sidebar-nav-row:hover {
   background: var(--color-bg-hover);

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2835,18 +2835,23 @@ body {
 #btn-send, #btn-interrupt {
   border: none;
   border-radius: 6px;
-  padding: 8px 16px;
+  padding: 0 16px;
+  height: 32px;
   font-size: 13px;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 #btn-send           { background: var(--color-button-primary); color: #fff; }
 #btn-send:hover     { background: var(--color-button-primary-hover); }
 [data-theme="dark"] #btn-send       { background: #2563eb; }
 [data-theme="dark"] #btn-send:hover { background: #1d4ed8; }
 #btn-send:disabled  { background: var(--color-border-primary); color: var(--color-text-secondary); cursor: not-allowed; }
-#btn-interrupt      { background: var(--color-error); color: #fff; font-size: 16px; line-height: 1; padding: 8px 16px; }
+#btn-interrupt      { background: var(--color-error); color: #fff; }
+#btn-interrupt::after { content: ''; display: block; width: 10px; height: 10px; background: #fff; border-radius: 2px; }
 #btn-interrupt:hover{ background: var(--color-error); opacity: 0.85; }
 
 /* ── Sidebar footer ──────────────────────────────────────────────────────── */

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -360,7 +360,7 @@
             data-i18n-placeholder="chat.input.placeholder"
             placeholder="Message… (Enter to send, Shift+Enter for newline)"></textarea>
           <button id="btn-send" data-i18n="chat.btn.send">Send</button>
-          <button id="btn-interrupt" style="display:none" title="Stop">■</button>
+          <button id="btn-interrupt" style="display:none" title="Stop"></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Add --footer-height CSS variable (56px) for shared dimensions
- Make #input-area a flex column container with min-height
- Vertically center #input-bar using margin auto
- Fix #sidebar-footer to use flex + min-height instead of padding
- Make .sidebar-nav-row fill full width
- Normalize icon button sizes (28x28) for attachment and slash buttons
- Remove redundant border-bottom from status bar