### PR TITLE
fix(web): preserve line breaks in multi-line chat messages

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -1522,6 +1522,7 @@ body {
   line-height: 1.6;
   word-break: break-word;
   position: relative;
+  white-space: pre-wrap;
 }
 
 .msg-time {


### PR DESCRIPTION
Multi-line messages in the chat UI had all line breaks collapsed into spaces, displaying as a single auto-wrapped paragraph. This significantly hurt readability for code snippets, logs, and structured text that rely on explicit line breaks.

The root cause is the missing `white-space: pre-wrap` on the `.msg-content` element — the default CSS white-space behavior (`normal`) merges consecutive whitespace and line breaks.

多行消息在聊天界面中所有换行符都被显示为空格，自动合并为一整段文本。对于代码片段、日志和结构化文本的可读性影响很大。

**Changes:**
- Add `white-space: pre-wrap` to `.msg-content` CSS rule to preserve line breaks while still wrapping long lines