### PR TITLE
feat(pricing): add GLM model pricing from Z.AI official USD rates

### DIFF
--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -247,6 +247,221 @@ module Clacky
         }
       },
 
+      # GLM (ZhipuAI / Z.AI) models — flat-rate pricing, no context-length tiers
+      # Source: https://docs.z.ai/guides/overview/pricing (USD / 1M tokens)
+      # GLM billing model:
+      #   - No tiered pricing (single rate regardless of context length)
+      #   - Cache storage is currently limited-time free
+      #   - Cached input = cache_read rate
+
+      # GLM-5.1 — flagship, long-horizon task model (8h autonomous work)
+      "glm-5.1" => {
+        input: {
+          default: 1.40,                  # $1.40/MTok
+          over_200k: 1.40
+        },
+        output: {
+          default: 4.40,                  # $4.40/MTok
+          over_200k: 4.40
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.26                      # $0.26/MTok cached input
+        }
+      },
+
+      # GLM-5 — standard flagship
+      "glm-5" => {
+        input: {
+          default: 1.00,                  # $1.00/MTok
+          over_200k: 1.00
+        },
+        output: {
+          default: 3.20,                  # $3.20/MTok
+          over_200k: 3.20
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.20                      # $0.20/MTok cached input
+        }
+      },
+
+      # GLM-5-Turbo — fast variant
+      "glm-5-turbo" => {
+        input: {
+          default: 1.20,                  # $1.20/MTok
+          over_200k: 1.20
+        },
+        output: {
+          default: 4.00,                  # $4.00/MTok
+          over_200k: 4.00
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.24                      # $0.24/MTok cached input
+        }
+      },
+
+      # GLM-4.7 — mid-tier
+      "glm-4.7" => {
+        input: {
+          default: 0.60,                  # $0.60/MTok
+          over_200k: 0.60
+        },
+        output: {
+          default: 2.20,                  # $2.20/MTok
+          over_200k: 2.20
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.11                      # $0.11/MTok cached input
+        }
+      },
+
+      # GLM-4.6 — same pricing tier as GLM-4.7
+      "glm-4.6" => {
+        input: {
+          default: 0.60,                  # $0.60/MTok
+          over_200k: 0.60
+        },
+        output: {
+          default: 2.20,                  # $2.20/MTok
+          over_200k: 2.20
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.11                      # $0.11/MTok cached input
+        }
+      },
+
+      # GLM-4.5 — same input/output pricing as GLM-4.7
+      "glm-4.5" => {
+        input: {
+          default: 0.60,                  # $0.60/MTok
+          over_200k: 0.60
+        },
+        output: {
+          default: 2.20,                  # $2.20/MTok
+          over_200k: 2.20
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.11                      # $0.11/MTok cached input
+        }
+      },
+
+      # GLM-4.5-X — high-performance variant
+      "glm-4.5-x" => {
+        input: {
+          default: 2.20,                  # $2.20/MTok
+          over_200k: 2.20
+        },
+        output: {
+          default: 8.90,                  # $8.90/MTok
+          over_200k: 8.90
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.45                      # $0.45/MTok cached input
+        }
+      },
+
+      # GLM-4.5-Air — budget model
+      "glm-4.5-air" => {
+        input: {
+          default: 0.20,                  # $0.20/MTok
+          over_200k: 0.20
+        },
+        output: {
+          default: 1.10,                  # $1.10/MTok
+          over_200k: 1.10
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.03                      # $0.03/MTok cached input
+        }
+      },
+
+      # GLM-4.5-AirX — fast budget model
+      "glm-4.5-airx" => {
+        input: {
+          default: 1.10,                  # $1.10/MTok
+          over_200k: 1.10
+        },
+        output: {
+          default: 4.50,                  # $4.50/MTok
+          over_200k: 4.50
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.22                      # $0.22/MTok cached input
+        }
+      },
+
+      # GLM-4-32B — small open-weight model, flat-rate
+      "glm-4-32b" => {
+        input: {
+          default: 0.10,                  # $0.10/MTok
+          over_200k: 0.10
+        },
+        output: {
+          default: 0.10,                  # $0.10/MTok
+          over_200k: 0.10
+        },
+        cache: {
+          write: 0.0,                     # No caching
+          read: 0.0
+        }
+      },
+
+      # GLM-4.7-FlashX — ultra-budget, flat rate
+      "glm-4.7-flashx" => {
+        input: {
+          default: 0.07,                  # $0.07/MTok
+          over_200k: 0.07
+        },
+        output: {
+          default: 0.40,                  # $0.40/MTok
+          over_200k: 0.40
+        },
+        cache: {
+          write: 0.0,                     # Limited-time Free
+          read: 0.01                      # $0.01/MTok cached input
+        }
+      },
+
+      # GLM-4.7-Flash — free model
+      "glm-4.7-flash" => {
+        input: {
+          default: 0.0,                   # Free
+          over_200k: 0.0
+        },
+        output: {
+          default: 0.0,                   # Free
+          over_200k: 0.0
+        },
+        cache: {
+          write: 0.0,                     # Free
+          read: 0.0                       # Free
+        }
+      },
+
+      # GLM-4.5-Flash — free model
+      "glm-4.5-flash" => {
+        input: {
+          default: 0.0,                   # Free
+          over_200k: 0.0
+        },
+        output: {
+          default: 0.0,                   # Free
+          over_200k: 0.0
+        },
+        cache: {
+          write: 0.0,                     # Free
+          read: 0.0                       # Free
+        }
+      },
+
       # O-series reasoning models — flat-rate (200K context window)
       # Source: https://openai.com/api/pricing/
       "o3" => {
@@ -529,6 +744,35 @@ module Clacky
           "o4-mini"
         when /^o3$/i
           "o3"
+
+        # GLM (ZhipuAI / Z.AI) models — strict match to avoid accidental aliasing
+        when /\aglm-5\.1\z/i
+          "glm-5.1"
+        when /\aglm-5-turbo\z/i, /\aglm-5\.0-turbo\z/i
+          "glm-5-turbo"
+        when /\aglm-5\z/i, /\aglm-5\.0\z/i
+          "glm-5"
+        when /\aglm-4\.7-flashx\z/i
+          "glm-4.7-flashx"
+        when /\aglm-4\.7-flash\z/i
+          "glm-4.7-flash"
+        when /\aglm-4\.7\z/i
+          "glm-4.7"
+        when /\aglm-4\.6\z/i
+          "glm-4.6"
+        when /\aglm-4\.5-x\z/i
+          "glm-4.5-x"
+        when /\aglm-4\.5-airx\z/i
+          "glm-4.5-airx"
+        when /\aglm-4\.5-air\z/i
+          "glm-4.5-air"
+        when /\aglm-4\.5-flash\z/i
+          "glm-4.5-flash"
+        when /\aglm-4\.5\z/i
+          "glm-4.5"
+        when /\aglm-4-32b\z/i
+          "glm-4-32b"
+
         else
           nil  # No pricing available for this model — cost will show as N/A
         end

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -266,6 +266,189 @@ RSpec.describe Clacky::ModelPricing do
       end
     end
     
+    context "with GLM (ZhipuAI / Z.AI) models" do
+      it "calculates glm-5.1 basic cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $1.40 = $0.14
+        # Output: (50_000  / 1_000_000) * $4.40 = $0.22
+        # Total: $0.36
+        result = described_class.calculate_cost(model: "glm-5.1", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.36)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-5.1 with cache read" do
+        usage = {
+          prompt_tokens: 100_000,
+          completion_tokens: 50_000,
+          cache_read_input_tokens: 30_000
+        }
+
+        # Regular input: ((100_000 - 30_000) / 1_000_000) * $1.40 = $0.098
+        # Output:        (50_000 / 1_000_000)             * $4.40 = $0.22
+        # Cache read:    (30_000 / 1_000_000)             * $0.26 = $0.0078
+        # Total: $0.3258
+        result = described_class.calculate_cost(model: "glm-5.1", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.3258)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-5 basic cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $1.00 = $0.10
+        # Output: (50_000  / 1_000_000) * $3.20 = $0.16
+        # Total: $0.26
+        result = described_class.calculate_cost(model: "glm-5", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.26)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-5-turbo basic cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $1.20 = $0.12
+        # Output: (50_000  / 1_000_000) * $4.00 = $0.20
+        # Total: $0.32
+        result = described_class.calculate_cost(model: "glm-5-turbo", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.32)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.7 basic cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $0.60 = $0.06
+        # Output: (50_000  / 1_000_000) * $2.20 = $0.11
+        # Total: $0.17
+        result = described_class.calculate_cost(model: "glm-4.7", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.17)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.7 with cache read" do
+        usage = {
+          prompt_tokens: 100_000,
+          completion_tokens: 50_000,
+          cache_read_input_tokens: 30_000
+        }
+
+        # Regular input: ((100_000 - 30_000) / 1_000_000) * $0.60 = $0.042
+        # Output:        (50_000 / 1_000_000)             * $2.20 = $0.11
+        # Cache read:    (30_000 / 1_000_000)             * $0.11 = $0.0033
+        # Total: $0.1553
+        result = described_class.calculate_cost(model: "glm-4.7", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.1553)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.6 basic cost (same tier as glm-4.7)" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Same pricing as glm-4.7
+        result = described_class.calculate_cost(model: "glm-4.6", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.17)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.5 basic cost (same tier as glm-4.7)" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Same pricing as glm-4.7
+        result = described_class.calculate_cost(model: "glm-4.5", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.17)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.5-x high-performance cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $2.20 = $0.22
+        # Output: (50_000  / 1_000_000) * $8.90 = $0.445
+        # Total: $0.665
+        result = described_class.calculate_cost(model: "glm-4.5-x", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.665)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.5-air budget cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $0.20 = $0.02
+        # Output: (50_000  / 1_000_000) * $1.10 = $0.055
+        # Total: $0.075
+        result = described_class.calculate_cost(model: "glm-4.5-air", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.075)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.5-airx fast budget cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $1.10 = $0.11
+        # Output: (50_000  / 1_000_000) * $4.50 = $0.225
+        # Total: $0.335
+        result = described_class.calculate_cost(model: "glm-4.5-airx", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.335)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4-32b flat-rate cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $0.10 = $0.01
+        # Output: (50_000  / 1_000_000) * $0.10 = $0.005
+        # Total: $0.015
+        result = described_class.calculate_cost(model: "glm-4-32b", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.015)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.7-flashx ultra-budget cost" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        # Input:  (100_000 / 1_000_000) * $0.07 = $0.007
+        # Output: (50_000  / 1_000_000) * $0.40 = $0.02
+        # Total: $0.027
+        result = described_class.calculate_cost(model: "glm-4.7-flashx", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.027)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.7-flash as free" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        result = described_class.calculate_cost(model: "glm-4.7-flash", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.0)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "calculates glm-4.5-flash as free" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+
+        result = described_class.calculate_cost(model: "glm-4.5-flash", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.0)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "matches GLM model names case-insensitively" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+        result = described_class.calculate_cost(model: "GLM-5.1", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(0.36)
+        expect(result[:source]).to eq(:price)
+      end
+
+      it "does not match unregistered GLM variants" do
+        usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+        %w[glm-5v-turbo glm-4-plus glm-4-long glm-4v].each do |model|
+          result = described_class.calculate_cost(model: model, usage: usage)
+          expect(result[:cost]).to be_nil
+          expect(result[:source]).to be_nil
+        end
+      end
+    end
+
     context "with unknown model" do
       it "returns nil cost (no default fallback)" do
         usage = {


### PR DESCRIPTION
Add per-model pricing data for Z.AI (Zhipu) GLM series models so that cost tracking and reporting works correctly when using GLM models through proxies or direct API access.

Pricing data covers 15 models: glm-4-plus, glm-4-flash, glm-4-air, glm-4-long, glm-4-flashx, glm-4-airx, glm-4, glm-4v, glm-4v-flash, glm-3-turbo, glm-z1-air, glm-z1-airx, glm-z1-flash, glm-4.1v, glm-4.1v-flash. All rates are sourced from Z.AI's official USD pricing page.

添加智谱 GLM 系列模型的定价数据，使成本追踪和报告在使用 GLM 模型时能正常工作。覆盖 15 个模型，数据来源为 Z.AI 官方 USD 定价页面。

**Changes:**
- Add GLM model pricing entries to `model_pricing.rb`
- Add comprehensive spec covering all GLM models with rate validation