### PR TITLE
feat: add diagnostics to web search for provider debugging

### DIFF
--- a/lib/clacky/tools/web_search.rb
+++ b/lib/clacky/tools/web_search.rb
@@ -39,36 +39,51 @@ module Clacky
         end
 
         last_error = nil
+        diagnostics = []
 
         providers = active_providers
         providers.each do |provider|
           begin
-            results = send(:"search_#{provider}", query, max_results)
-            # Consider it a success only if we got real results
-            next if results.empty? || results.first[:url].include?("duckduckgo.com") && results.first[:title] == "Web search results"
+            results, provider_meta = send(:"search_#{provider}", query, max_results)
+            filtered_results = filter_placeholder_results(provider, results)
+
+            diagnostics << provider_diagnostic(
+              provider: provider,
+              status: filtered_results.empty? ? "no_results" : "ok",
+              result_count: filtered_results.length,
+              meta: provider_meta
+            )
 
             return {
               query: query,
-              results: results,
-              count: results.length,
+              results: filtered_results,
+              count: filtered_results.length,
               provider: provider.to_s,
+              diagnostics: diagnostics,
               error: nil
-            }
+            } unless filtered_results.empty?
           rescue StandardError => e
             # DuckDuckGo failed — suppress it for 10 minutes
             @ddg_unavailable_until = Time.now + 600 if provider == :duckduckgo
             last_error = e
+            diagnostics << provider_diagnostic(
+              provider: provider,
+              status: "error",
+              result_count: 0,
+              error: e.message
+            )
             next
           end
         end
 
-        # All providers failed
+        # All providers failed or returned no results
         {
           query: query,
           results: [],
           count: 0,
           provider: nil,
-          error: "All search providers failed. Last error: #{last_error&.message}"
+          diagnostics: diagnostics,
+          error: build_failure_message(diagnostics, last_error)
         }
       end
 
@@ -87,9 +102,10 @@ module Clacky
         encoded_query = CGI.escape(query)
         url = URI("https://html.duckduckgo.com/html/?q=#{encoded_query}")
         response = http_get(url)
-        return [] unless response.is_a?(Net::HTTPSuccess)
+        meta = { http_status: response&.code.to_i, body_size: response&.body&.bytesize.to_i }
+        return [[], meta] unless response.is_a?(Net::HTTPSuccess)
 
-        parse_duckduckgo_html(response.body, max_results)
+        [parse_duckduckgo_html(response.body, max_results), meta]
       end
 
       private def parse_duckduckgo_html(html, max_results)
@@ -126,9 +142,10 @@ module Clacky
         # follow_redirects ensures both environments work with the same code path.
         url = URI("https://cn.bing.com/search?q=#{encoded_query}&count=#{max_results}")
         response = http_get(url, accept_language: "zh-CN,zh;q=0.9,en;q=0.8", follow_redirects: 2)
-        return [] unless response.is_a?(Net::HTTPSuccess)
+        meta = { http_status: response&.code.to_i, body_size: response&.body&.bytesize.to_i }
+        return [[], meta] unless response.is_a?(Net::HTTPSuccess)
 
-        parse_bing_html(response.body, max_results)
+        [parse_bing_html(response.body, max_results), meta]
       end
 
       private def parse_bing_html(html, max_results)
@@ -185,6 +202,50 @@ module Clacky
         decoded.force_encoding("UTF-8").valid_encoding? ? decoded : url
       rescue StandardError
         url
+      end
+
+      private def filter_placeholder_results(provider, results)
+        return results unless provider == :duckduckgo
+        return [] if results.empty?
+
+        first = results.first
+        if first[:url].include?("duckduckgo.com") && first[:title] == "Web search results"
+          return []
+        end
+
+        results
+      end
+
+      private def provider_diagnostic(provider:, status:, result_count:, meta: {}, error: nil)
+        {
+          provider: provider.to_s,
+          status: status,
+          result_count: result_count,
+          http_status: meta[:http_status],
+          body_size: meta[:body_size],
+          error: error
+        }
+      end
+
+      private def build_failure_message(diagnostics, last_error)
+        summary = diagnostics.map do |item|
+          fragment = "#{item[:provider]}: #{item[:status]}"
+          fragment += "(http=#{item[:http_status]})" if item[:http_status]
+          fragment += " error=#{item[:error]}" if item[:error]
+          fragment
+        end.join(", ")
+
+        suffix = if summary.empty?
+          "no provider diagnostics"
+        else
+          summary
+        end
+
+        if diagnostics.any? { |item| item[:status] == "no_results" }
+          "No search results from providers. Details: #{suffix}"
+        else
+          "All search providers failed. Details: #{suffix}. Last error: #{last_error&.message}"
+        end
       end
 
       # ── Shared HTTP helper ─────────────────────────────────────────────────
@@ -246,3 +307,4 @@ module Clacky
     end
   end
 end
+

--- a/spec/clacky/tools/web_search_spec.rb
+++ b/spec/clacky/tools/web_search_spec.rb
@@ -16,24 +16,51 @@ RSpec.describe Clacky::Tools::WebSearch do
       expect(result[:error]).to include("cannot be empty")
     end
 
-    # Note: Actual web search tests would require network access or mocking
-    # For now, we test the basic structure and error handling
-    it "handles network errors gracefully" do
-      allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(StandardError.new("Network error"))
+    it "returns diagnostics when all providers raise errors" do
+      allow(tool).to receive(:active_providers).and_return(%i[duckduckgo bing])
+      allow(tool).to receive(:search_duckduckgo).and_raise(StandardError.new("ddg down"))
+      allow(tool).to receive(:search_bing).and_raise(StandardError.new("bing down"))
 
       result = tool.execute(query: "test query")
 
-      # All providers failed — should return an error message
+      expect(result[:results]).to eq([])
+      expect(result[:provider]).to be_nil
       expect(result[:error]).to include("All search providers failed")
-      expect(result[:results]).to be_empty
+      expect(result[:error]).to include("duckduckgo: error")
+      expect(result[:error]).to include("bing: error")
+      expect(result[:diagnostics].size).to eq(2)
+      expect(result[:diagnostics].all? { |d| d[:status] == "error" }).to be(true)
     end
 
-    it "respects max_results parameter" do
-      result = tool.execute(query: "ruby programming", max_results: 5)
+    it "returns no_results message when providers succeed but return empty" do
+      allow(tool).to receive(:active_providers).and_return(%i[duckduckgo bing])
+      allow(tool).to receive(:search_duckduckgo).and_return([[], { http_status: 200, body_size: 100 }])
+      allow(tool).to receive(:search_bing).and_return([[], { http_status: 200, body_size: 120 }])
 
-      expect(result[:query]).to eq("ruby programming")
-      # Count should not exceed max_results
-      expect(result[:count]).to be <= 5
+      result = tool.execute(query: "no result query")
+
+      expect(result[:results]).to eq([])
+      expect(result[:provider]).to be_nil
+      expect(result[:error]).to include("No search results from providers")
+      expect(result[:diagnostics].size).to eq(2)
+      expect(result[:diagnostics].all? { |d| d[:status] == "no_results" }).to be(true)
+    end
+
+    it "returns first successful provider with diagnostics" do
+      allow(tool).to receive(:active_providers).and_return(%i[duckduckgo bing])
+      allow(tool).to receive(:search_duckduckgo).and_return([
+        [{ title: "Hello", url: "https://example.com", snippet: "world" }],
+        { http_status: 200, body_size: 256 }
+      ])
+
+      result = tool.execute(query: "ok query", max_results: 5)
+
+      expect(result[:error]).to be_nil
+      expect(result[:provider]).to eq("duckduckgo")
+      expect(result[:count]).to eq(1)
+      expect(result[:diagnostics].size).to eq(1)
+      expect(result[:diagnostics].first[:status]).to eq("ok")
+      expect(result[:diagnostics].first[:http_status]).to eq(200)
     end
   end
 


### PR DESCRIPTION
When web search returns no results, it was previously impossible to tell which provider was tried, whether it returned an error, or why results were empty. Errors and provider-level metadata were silently discarded.

This PR adds a `diagnostics` array to search results that tracks each provider's outcome throughout the fallback chain:

Web 搜索返回空结果时，之前无法判断哪个 provider 被尝试过、是否返回了错误、以及为什么结果为空。

**Changes:**
- Track per-provider diagnostics after each attempt: status (`ok`/`no_results`/`error`), result count, and error messages
- Add `provider_diagnostic` helper to build structured diagnostic entries
- Filter placeholder DuckDuckGo results that look like results but contain no real data
- Return `diagnostics` array in search results for visibility and debugging
- Add spec coverage for multi-provider fallback and error tracking scenarios