### PR TITLE
feat(browser): Chrome headless auto-launch, WSL2 fallback, and disconnect recovery

### DIFF
--- a/lib/clacky/default_skills/browser-setup/SKILL.md
+++ b/lib/clacky/default_skills/browser-setup/SKILL.md
@@ -146,10 +146,35 @@ Then tell the user:
 
 **On WSL**:
 
+First, ask the user which browser they want to use:
+
+> WSL2 detected. Which browser do you want to use?
+>
+> 1. **Windows browser** (Chrome/Edge running on Windows side) — recommended, avoids Linux GUI dependencies
+> 2. **Linux browser** (Chrome running inside WSL2 via X11/Wayland) — only if you have a Linux GUI set up
+>
+> Enter 1 or 2:
+
+Wait for user response. Parse the answer:
+- **1 or "windows"** → set `WSL_MODE="windows"` and proceed with Windows browser steps
+- **2 or "linux"** → set `WSL_MODE="linux"` and proceed with Linux browser steps
+
+**If Windows browser (mode = "windows")**:
+
 > Please follow these steps:
-> 1. Open **Edge** on Windows
-> 2. Visit: `edge://inspect/#remote-debugging`
+> 1. Open **Chrome or Edge** on Windows
+> 2. Visit: `chrome://inspect/#remote-debugging` (or `edge://inspect/#remote-debugging`)
 > 3. Click **"Allow remote debugging for this browser instance"**
+>
+> Let me know when done ✅
+
+**If Linux browser (mode = "linux")**:
+
+> Please follow these steps:
+> 1. Make sure **Chrome is installed inside WSL2** and can open (requires X11/Wayland setup)
+> 2. Open Chrome inside WSL2
+> 3. Visit: `chrome://inspect/#remote-debugging`
+> 4. Click **"Allow remote debugging for this browser instance"**
 >
 > Let me know when done ✅
 
@@ -206,6 +231,16 @@ Parse the version number:
 ### Step 5 — Save configuration via API
 
 Call the API to save the configuration:
+
+**On WSL** (include wsl_browser_mode):
+
+```bash
+curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/browser/configure \
+  -H "Content-Type: application/json" \
+  -d "{\"chrome_version\":\"${VERSION}\",\"wsl_browser_mode\":\"${WSL_MODE}\"}"
+```
+
+**On macOS / Linux**:
 
 ```bash
 curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/browser/configure \

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -3,6 +3,10 @@
 require "yaml"
 require "shellwords"
 require "open3"
+require "tmpdir"
+require "fileutils"
+require "net/http"
+require "json"
 
 module Clacky
   # BrowserManager owns the chrome-devtools-mcp daemon lifecycle.
@@ -126,13 +130,19 @@ module Clacky
     # Write browser.yml with the given config and reload the daemon.
     # Called by HttpServer POST /api/browser/configure.
     # @param chrome_version [String] detected Chrome major version
-    def configure(chrome_version:)
+    # @param wsl_browser_mode [String, nil] "windows" or "linux" (WSL only)
+    # @param chrome_port [Integer, nil] specific port for Chrome remote debugging
+    # @param auto_launch [Boolean, nil] whether to auto-launch headless Chrome
+    def configure(chrome_version:, wsl_browser_mode: nil, chrome_port: nil, auto_launch: nil)
       cfg = {
         "enabled"        => true,
         "browser"        => "chrome",
         "chrome_version" => chrome_version.to_s,
         "configured_at"  => Date.today.to_s
       }
+      cfg["wsl_browser_mode"] = wsl_browser_mode if wsl_browser_mode && !wsl_browser_mode.empty?
+      cfg["chrome_port"] = chrome_port.to_i if chrome_port && chrome_port.to_i > 0
+      cfg["auto_launch"] = auto_launch if [true, false].include?(auto_launch)
       FileUtils.mkdir_p(File.dirname(BROWSER_CONFIG_PATH))
       File.write(BROWSER_CONFIG_PATH, cfg.to_yaml)
       reload
@@ -151,6 +161,21 @@ module Clacky
       @config = cfg
       reload
       new_enabled
+    end
+
+    # Returns the configured WSL browser mode from browser.yml.
+    # @return [String] "windows" (default) or "linux"
+    def wsl_browser_mode
+      cfg = load_config
+      mode = cfg["wsl_browser_mode"].to_s.strip
+      mode.empty? ? "windows" : mode
+    end
+
+    # Public config reader for BrowserDetector (avoids circular deps).
+    # Returns the raw config hash from browser.yml.
+    # @return [Hash]
+    def load_config_for_detector
+      load_config
     end
 
     # ---------------------------------------------------------------------------
@@ -198,6 +223,20 @@ module Clacky
 
         result
       end
+    rescue RuntimeError => e
+      # If Chrome disconnected but MCP daemon is still alive, kill the daemon
+      # and auto-launch Chrome so the NEXT browser call can recover seamlessly.
+      if chrome_connection_error?(e.message)
+        Clacky::Logger.info("[BrowserManager] Chrome connection lost, cleaning up...")
+        @mutex.synchronize do
+          kill_process!
+          if auto_launch_enabled?
+            Clacky::Logger.info("[BrowserManager] Auto-launching Chrome for recovery...")
+            auto_launch_chrome
+          end
+        end
+      end
+      raise
     rescue Clacky::BrowserNotReachableError => e
       # Return friendly error for AI to guide user
       raise Clacky::AgentError, e.message
@@ -221,6 +260,18 @@ module Clacky
 
       # ⭐️ Critical: Verify Chrome is reachable BEFORE starting MCP daemon
       detected = Clacky::Utils::BrowserDetector.detect
+
+      if detected[:status] == :not_found
+        # Try auto-launching Chrome before giving up
+        if auto_launch_enabled?
+          Clacky::Logger.info("[BrowserManager] Chrome not found, attempting auto-launch...")
+          launched = auto_launch_chrome
+          if launched.is_a?(Hash)
+            Clacky::Logger.info("[BrowserManager] Auto-launch succeeded, using endpoint directly")
+            detected = launched.merge(status: :ok)
+          end
+        end
+      end
 
       if detected[:status] == :not_found
         raise Clacky::BrowserNotReachableError, <<~MSG.strip
@@ -294,7 +345,271 @@ module Clacky
       Clacky::Logger.info("[BrowserManager] MCP daemon started successfully (pid=#{wait_thr.pid})")
     end
 
-    # Build chrome-devtools-mcp command with explicit connection parameters.
+    # ---------------------------------------------------------------------------
+    # Auto-launch Chrome (headless)
+    # ---------------------------------------------------------------------------
+
+    # Check if auto-launch is enabled in browser.yml.
+    # Defaults to true on Linux/WSL-linux mode (where headless Chrome is available).
+    # @return [Boolean]
+    def auto_launch_enabled?
+      cfg = load_config
+      return cfg["auto_launch"] == true if cfg.key?("auto_launch")
+
+      # Default: enable auto-launch on Linux-based environments
+      os = Clacky::Utils::EnvironmentDetector.os_type
+      os == :linux || os == :wsl
+    end
+
+    # Attempt to auto-launch headless Chrome for remote debugging.
+    # Checks for existing Chrome instances first to avoid duplicates.
+    # Finds Chrome binary, picks a free port, launches, and waits for readiness.
+    # @return [Hash, false] detector-compatible hash on success, false on failure
+    def auto_launch_chrome
+      # First: check if Chrome is already running with remote debugging
+      existing = find_existing_chrome
+      if existing
+        Clacky::Logger.info("[BrowserManager] Found existing Chrome on port #{existing[:port]}, reusing")
+        return { mode: :ws_endpoint, value: existing[:ws] }
+      end
+
+      chrome_bin = find_chrome_binary
+      unless chrome_bin
+        Clacky::Logger.warn("[BrowserManager] Cannot auto-launch: no Chrome binary found")
+        return false
+      end
+
+      port = resolve_chrome_port
+      Clacky::Logger.info("[BrowserManager] Auto-launching Chrome: #{chrome_bin} on port #{port}")
+
+      # Kill any previously spawned Chrome before launching new one
+      kill_spawned_chrome!
+
+      pid = spawn_chrome(chrome_bin, port)
+      unless pid
+        Clacky::Logger.warn("[BrowserManager] Failed to spawn Chrome")
+        return false
+      end
+
+      @chrome_pid = pid
+      Clacky::Logger.info("[BrowserManager] Chrome spawned (pid=#{pid}), waiting for readiness...")
+      ready = wait_for_chrome(port, timeout: 10)
+      unless ready
+        Clacky::Logger.warn("[BrowserManager] Chrome did not become ready within timeout")
+        kill_spawned_chrome!
+        return false
+      end
+
+      Clacky::Logger.info("[BrowserManager] Chrome is ready on port #{port}")
+
+      # Fetch WebSocket endpoint directly from the known port
+      ws = Clacky::Utils::BrowserDetector.fetch_ws_endpoint(port)
+      unless ws
+        Clacky::Logger.warn("[BrowserManager] Chrome is running but could not fetch WebSocket URL")
+        kill_spawned_chrome!
+        return false
+      end
+
+      Clacky::Logger.info("[BrowserManager] Auto-launch complete: #{ws}")
+
+      # Persist the auto-launched port so BrowserDetector can find it on subsequent calls.
+      persist_auto_launch_port(port)
+
+      { mode: :ws_endpoint, value: ws }
+    rescue StandardError => e
+      Clacky::Logger.warn("[BrowserManager] Auto-launch failed: #{e.message}")
+      false
+    end
+
+    # Scan configured ports for an existing Chrome instance with remote debugging.
+    # @return [Hash, nil] { port: Integer, ws: String } or nil
+    def find_existing_chrome
+      require "net/http"
+      require "json"
+
+      ports = Clacky::Utils::BrowserDetector.load_scan_ports
+      ports.each do |port|
+        begin
+          uri  = URI("http://127.0.0.1:#{port}/json/version")
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.open_timeout = 0.5
+          http.read_timeout = 0.5
+          resp = http.get(uri.request_uri)
+          next unless resp.code.to_i == 200
+
+          data = JSON.parse(resp.body)
+          ws = data["webSocketDebuggerUrl"]
+          next unless ws && !ws.empty?
+
+          Clacky::Logger.debug("[BrowserManager] Existing Chrome found on port #{port}: #{ws}")
+          return { port: port, ws: ws }
+        rescue StandardError
+          next
+        end
+      end
+      nil
+    end
+
+    # Persist the auto-launched Chrome port to browser.yml so BrowserDetector
+    # can find it on subsequent ensure_process! calls, preventing duplicate spawns.
+    def persist_auto_launch_port(port)
+      cfg = load_config
+      cfg["chrome_port"] = port.to_i
+      FileUtils.mkdir_p(File.dirname(BROWSER_CONFIG_PATH))
+      File.write(BROWSER_CONFIG_PATH, cfg.to_yaml)
+      Clacky::Logger.debug("[BrowserManager] Persisted auto-launch port #{port} to browser.yml")
+    rescue StandardError => e
+      Clacky::Logger.warn("[BrowserManager] Failed to persist auto-launch port: #{e.message}")
+    end
+
+    # Kill the Chrome process that we spawned (if any).
+    def kill_spawned_chrome!
+      if @chrome_pid
+        Clacky::Logger.info("[BrowserManager] Killing spawned Chrome (pid=#{@chrome_pid})")
+        Process.kill("TERM", @chrome_pid) rescue nil
+        Process.wait(@chrome_pid, Process::WNOHANG) rescue nil
+        @chrome_pid = nil
+      end
+      # Also clean up temp user-data-dir
+      if @chrome_user_data_dir && Dir.exist?(@chrome_user_data_dir)
+        FileUtils.rm_rf(@chrome_user_data_dir) rescue nil
+        @chrome_user_data_dir = nil
+      end
+    end
+
+    # Find the Chrome/Chromium binary on the system.
+    # @return [String, nil] path to binary
+    def find_chrome_binary
+      candidates = %w[
+        google-chrome-stable
+        google-chrome
+        chromium-browser
+        chromium
+        /opt/google/chrome/chrome
+        /usr/bin/google-chrome-stable
+        /usr/bin/google-chrome
+      ]
+
+      candidates.each do |bin|
+        path = which_cmd?(bin)
+        return path if path
+      end
+
+      nil
+    end
+
+    # Resolve which port Chrome should use.
+    # Uses chrome_port from browser.yml if configured, otherwise finds a free port.
+    # @return [Integer]
+    def resolve_chrome_port
+      cfg = load_config
+      configured = cfg["chrome_port"]
+      if configured && configured.to_i > 0
+        port = configured.to_i
+        unless port_free?(port)
+          Clacky::Logger.warn("[BrowserManager] Configured port #{port} is in use, falling back to auto-select")
+          return find_free_port
+        end
+        return port
+      end
+      find_free_port
+    end
+
+    # Find a free TCP port for Chrome remote debugging.
+    # @return [Integer]
+    def find_free_port
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+      server.close
+      port
+    rescue StandardError
+      9223  # fallback
+    end
+
+    # Check if a port is free on localhost.
+    # @param port [Integer]
+    # @return [Boolean]
+    def port_free?(port)
+      TCPServer.new("127.0.0.1", port).close
+      true
+    rescue Errno::EADDRINUSE
+      false
+    end
+
+    # Spawn headless Chrome with remote debugging enabled.
+    # @param chrome_bin [String]
+    # @param port [Integer]
+    # @return [Integer, nil] pid
+    def spawn_chrome(chrome_bin, port)
+      user_data_dir = Dir.mktmpdir("clacky-chrome-")
+      args = [
+        chrome_bin,
+        "--headless=new",
+        "--remote-debugging-port=#{port}",
+        "--no-sandbox",
+        "--disable-gpu",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-extensions",
+        "--disable-background-networking",
+        "--disable-sync",
+        "--user-data-dir=#{user_data_dir}",
+      ]
+
+      Clacky::Logger.debug("[BrowserManager] Spawning: #{args.join(' ')}")
+      pid = Process.spawn(*args, pgroup: true, [:out, :err] => "/dev/null")
+      # Store user_data_dir so it can be cleaned up later
+      @chrome_user_data_dir = user_data_dir
+      pid
+    rescue StandardError => e
+      Clacky::Logger.warn("[BrowserManager] spawn_chrome error: #{e.message}")
+      nil
+    end
+
+    # Wait for Chrome's devtools HTTP endpoint to become available.
+    # @param port [Integer]
+    # @param timeout [Integer] seconds
+    # @return [Boolean]
+    def wait_for_chrome(port, timeout: 10)
+      require "net/http"
+      require "json"
+
+      uri = URI("http://127.0.0.1:#{port}/json/version")
+      deadline = Time.now + timeout
+
+      while Time.now < deadline
+        begin
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.open_timeout = 1
+          http.read_timeout = 1
+          response = http.get(uri.request_uri)
+          return true if response.code.to_i == 200
+        rescue StandardError
+          # Chrome not ready yet
+        end
+        sleep 0.5
+      end
+
+      false
+    end
+
+    # Check if a command is available on PATH.
+    # @param cmd [String]
+    # @return [String, nil] full path or nil
+    def which_cmd?(cmd)
+      # If it's already an absolute path and executable
+      return cmd if cmd.start_with?("/") && File.executable?(cmd)
+
+      ENV["PATH"].split(File::PATH_SEPARATOR).each do |dir|
+        full = File.join(dir, cmd)
+        return full if File.executable?(full)
+      end
+      nil
+    end
+
+    # ---------------------------------------------------------------------------
+    # Build MCP command
+    # ---------------------------------------------------------------------------
     # Always uses the detected browser endpoint (no --autoConnect fallback).
     # @param detected [Hash] { mode: :ws_endpoint, value: String } from BrowserDetector
     # @return [Array<String>] command array
@@ -360,6 +675,9 @@ module Clacky
         nil
       end
 
+      # Kill the Chrome process we spawned (if any) to prevent orphans
+      kill_spawned_chrome!
+
       Clacky::Logger.info("[BrowserManager] MCP daemon killed (pid=#{ps[:pid]})")
     end
 
@@ -392,6 +710,19 @@ module Clacky
         .select { |b| b.is_a?(Hash) && b["type"] == "text" }
         .map { |b| b["text"].to_s }
         .join("\n")
+    end
+
+    # Detect Chrome connectivity errors from MCP error messages.
+    # Returns true when the error indicates Chrome is unreachable
+    # (e.g. Chrome process died, port closed, connection refused).
+    def chrome_connection_error?(msg)
+      return false if msg.nil? || msg.empty?
+
+      msg.include?("Could not connect to Chrome") ||
+        msg.include?("ECONNREFUSED") ||
+        msg.include?("connect ECONNREFUSED") ||
+        msg.include?("Chrome is not reachable") ||
+        msg.include?("not running")
     end
   end
 end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -598,13 +598,26 @@ module Clacky
 
       # POST /api/browser/configure
       # Called by browser-setup skill to write browser.yml and hot-reload the daemon.
-      # Body: { chrome_version: "146" }
+      # Body: { chrome_version: "146", wsl_browser_mode: "windows", chrome_port: 9223, auto_launch: true }
       def api_browser_configure(req, res)
         body          = JSON.parse(req.body.to_s) rescue {}
         chrome_version = body["chrome_version"].to_s.strip
         return json_response(res, 422, { ok: false, error: "chrome_version is required" }) if chrome_version.empty?
 
-        @browser_manager.configure(chrome_version: chrome_version)
+        wsl_browser_mode = body["wsl_browser_mode"].to_s.strip
+        wsl_browser_mode = nil if wsl_browser_mode.empty?
+
+        chrome_port = body["chrome_port"]&.to_i
+        chrome_port = nil if chrome_port && chrome_port <= 0
+
+        auto_launch = body.key?("auto_launch") ? body["auto_launch"] : nil
+
+        @browser_manager.configure(
+          chrome_version: chrome_version,
+          wsl_browser_mode: wsl_browser_mode,
+          chrome_port: chrome_port,
+          auto_launch: auto_launch
+        )
         json_response(res, 200, { ok: true })
       rescue StandardError => e
         json_response(res, 500, { ok: false, error: e.message })

--- a/lib/clacky/utils/browser_detector.rb
+++ b/lib/clacky/utils/browser_detector.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "socket"
+require "timeout"
 
 module Clacky
   module Utils
@@ -29,6 +30,12 @@ module Clacky
         
         detected = detect_via_active_port_file
         
+        # Fallback: scan common remote-debugging ports (headless Chrome may not write ActivePort file)
+        unless detected
+          Clacky::Logger.debug("[BrowserDetector] ActivePort scan failed, trying port scan fallback...")
+          detected = detect_via_port_scan
+        end
+        
         unless detected
           Clacky::Logger.warn("[BrowserDetector] ✗ No reachable browser found")
           return { status: :not_found }
@@ -36,6 +43,74 @@ module Clacky
         
         Clacky::Logger.info("[BrowserDetector] ✓ Browser detected and reachable: #{detected[:mode]} → #{detected[:value]}")
         detected.merge(status: :ok)
+      end
+
+      # -----------------------------------------------------------------------
+      # Port scan fallback (for headless Chrome that doesn't write ActivePort)
+      # -----------------------------------------------------------------------
+
+      # Scan common remote-debugging ports by hitting /json/version.
+      # Headless Chrome with --remote-debugging-port may not create DevToolsActivePort.
+      # @return [Hash, nil] { mode: :ws_endpoint, value: String }
+      private_class_method def self.detect_via_port_scan
+        ports = load_scan_ports
+        Clacky::Logger.debug("[BrowserDetector] Scanning ports: #{ports.join(', ')}")
+
+        ports.each do |port|
+          next unless tcp_open?("127.0.0.1", port)
+
+          ws = fetch_ws_endpoint(port)
+          next unless ws
+
+          Clacky::Logger.debug("[BrowserDetector] Port scan found browser on port #{port}: #{ws}")
+          return { mode: :ws_endpoint, value: ws }
+        end
+
+        nil
+      end
+
+      # Get list of ports to scan. Reads from browser.yml chrome_port if configured,
+      # otherwise scans default range.
+      # @return [Array<Integer>]
+      def self.load_scan_ports
+        configured = configured_chrome_port
+        return [configured] if configured && configured > 0
+
+        # Default: scan 9222-9230 (covers common custom ports)
+        (9222..9230).to_a
+      end
+
+      # Read chrome_port from browser.yml config.
+      # @return [Integer, nil]
+      private_class_method def self.configured_chrome_port
+        cfg = Clacky::BrowserManager.instance.load_config_for_detector
+        port = cfg["chrome_port"]
+        port.to_i if port && port.to_i > 0
+      rescue StandardError
+        nil
+      end
+
+      # Fetch WebSocket debugger URL from a Chrome devtools HTTP endpoint.
+      # @param port [Integer]
+      # @return [String, nil] ws:// URL string
+      def self.fetch_ws_endpoint(port)
+        require "net/http"
+        require "json"
+
+        uri = URI("http://127.0.0.1:#{port}/json/version")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.open_timeout = 1
+        http.read_timeout = 1
+
+        response = http.get(uri.request_uri)
+        return nil unless response.code.to_i == 200
+
+        data = JSON.parse(response.body)
+        ws = data["webSocketDebuggerUrl"]
+        ws if ws.is_a?(String) && !ws.empty?
+      rescue StandardError => e
+        Clacky::Logger.debug("[BrowserDetector] Port #{port} fetch failed: #{e.message}")
+        nil
       end
 
       # -----------------------------------------------------------------------
@@ -117,26 +192,70 @@ module Clacky
         end
       end
 
-      # WSL: Chrome/Edge run on Windows side — resolve via LOCALAPPDATA.
+      # WSL: Chrome/Edge may run on Windows side OR inside WSL2 (Linux Chrome).
+      # Respects wsl_browser_mode config from browser.yml:
+      #   "windows" (default) → only scan Windows-side Chrome/Edge paths
+      #   "linux"             → only scan Linux-native Chrome paths
       private_class_method def self.wsl_user_data_dirs
-        appdata = Utils::Encoding.cmd_to_utf8(
-          `powershell.exe -NoProfile -Command '$env:LOCALAPPDATA' 2>/dev/null`
-        ).strip.tr("\r\n", "")
-        return [] if appdata.empty?
+        mode = wsl_browser_mode
+        Clacky::Logger.debug("[BrowserDetector] WSL browser mode: #{mode}")
 
-        win_paths = [
-          "#{appdata}\\Microsoft\\Edge\\User Data",
-          "#{appdata}\\Google\\Chrome\\User Data",
-          "#{appdata}\\Google\\Chrome Beta\\User Data",
-          "#{appdata}\\Google\\Chrome SxS\\User Data",
-        ]
-
-        win_paths.filter_map do |win_path|
-          linux_path = Utils::Encoding.cmd_to_utf8(
-            `wslpath '#{win_path}' 2>/dev/null`, source_encoding: "UTF-8"
-          ).strip
-          linux_path.empty? ? nil : linux_path
+        case mode
+        when "linux"  then linux_user_data_dirs
+        when "windows" then wsl_windows_user_data_dirs
+        else
+          # Fallback: try both (backward compatible)
+          wsl_windows_user_data_dirs + linux_user_data_dirs
         end
+      end
+
+      # Read wsl_browser_mode from browser.yml via BrowserManager.
+      # Defaults to "windows" if not configured or on non-WSL.
+      # @return [String] "windows" or "linux"
+      private_class_method def self.wsl_browser_mode
+        Clacky::BrowserManager.instance.wsl_browser_mode
+      rescue StandardError
+        "windows"
+      end
+
+      # Scan Windows-side Chrome/Edge (via LOCALAPPDATA → wslpath).
+      # @return [Array<String>]
+      private_class_method def self.wsl_windows_user_data_dirs
+        dirs = []
+
+        begin
+          appdata = Timeout.timeout(3) do
+            Utils::Encoding.cmd_to_utf8(
+              `powershell.exe -NoProfile -Command '$env:LOCALAPPDATA' 2>/dev/null`
+            ).strip.tr("\r\n", "")
+          end
+        rescue Timeout::Error, StandardError
+          appdata = ""
+        end
+
+        unless appdata.empty?
+          win_paths = [
+            "#{appdata}\\Microsoft\\Edge\\User Data",
+            "#{appdata}\\Google\\Chrome\\User Data",
+            "#{appdata}\\Google\\Chrome Beta\\User Data",
+            "#{appdata}\\Google\\Chrome SxS\\User Data",
+          ]
+
+          win_paths.each do |win_path|
+            begin
+              linux_path = Timeout.timeout(3) do
+                Utils::Encoding.cmd_to_utf8(
+                  `wslpath '#{win_path}' 2>/dev/null`, source_encoding: "UTF-8"
+                ).strip
+              end
+              dirs << linux_path unless linux_path.empty?
+            rescue Timeout::Error, StandardError
+              nil
+            end
+          end
+        end
+
+        dirs
       end
 
       # Linux: standard XDG config paths for Chrome and Edge.

--- a/spec/clacky/server/browser_manager_spec.rb
+++ b/spec/clacky/server/browser_manager_spec.rb
@@ -299,6 +299,7 @@ RSpec.describe Clacky::BrowserManager do
 
     it "raises BrowserNotReachableError when browser is not found" do
       allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({ status: :not_found })
+      allow(manager).to receive(:auto_launch_enabled?).and_return(false)
 
       expect { manager.send(:ensure_process!) }.to raise_error(
         Clacky::BrowserNotReachableError,
@@ -419,6 +420,53 @@ RSpec.describe Clacky::BrowserManager do
       inject_process([err_resp])
 
       expect { manager.mcp_call("navigate_page", { url: "bad" }) }.to raise_error(/navigation failed/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #wsl_browser_mode
+  # ---------------------------------------------------------------------------
+  describe "#wsl_browser_mode" do
+    it "returns 'windows' when browser.yml is missing" do
+      expect(manager.wsl_browser_mode).to eq("windows")
+    end
+
+    it "returns 'windows' when wsl_browser_mode is not set" do
+      write_config("enabled" => true, "chrome_version" => "148")
+      expect(manager.wsl_browser_mode).to eq("windows")
+    end
+
+    it "returns 'linux' when wsl_browser_mode is set to linux" do
+      write_config("enabled" => true, "chrome_version" => "148", "wsl_browser_mode" => "linux")
+      expect(manager.wsl_browser_mode).to eq("linux")
+    end
+
+    it "returns 'windows' when wsl_browser_mode is set to an empty string" do
+      write_config("enabled" => true, "chrome_version" => "148", "wsl_browser_mode" => "")
+      expect(manager.wsl_browser_mode).to eq("windows")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #configure
+  # ---------------------------------------------------------------------------
+  describe "#configure" do
+    it "saves wsl_browser_mode in browser.yml" do
+      manager.configure(chrome_version: "148", wsl_browser_mode: "linux")
+      cfg = YAML.load_file(config_path)
+      expect(cfg["wsl_browser_mode"]).to eq("linux")
+    end
+
+    it "does not save wsl_browser_mode when nil" do
+      manager.configure(chrome_version: "148", wsl_browser_mode: nil)
+      cfg = YAML.load_file(config_path)
+      expect(cfg).not_to have_key("wsl_browser_mode")
+    end
+
+    it "does not save wsl_browser_mode when empty string" do
+      manager.configure(chrome_version: "148", wsl_browser_mode: "")
+      cfg = YAML.load_file(config_path)
+      expect(cfg).not_to have_key("wsl_browser_mode")
     end
   end
 


### PR DESCRIPTION
Several reliability improvements to the browser automation subsystem for better support across different environments (native Linux, WSL2, headless servers).

针对不同运行环境（原生 Linux、WSL2、无头服务器）的浏览器自动化可靠性改进。

**WSL2 support:**
- Add Linux Chrome fallback path when Windows Chrome is not found in WSL2 environments
- Add timeout protection to prevent hangs during browser detection on slow/misconfigured systems

**Headless Chrome auto-launch:**
- Auto-detect and launch headless Chrome when no existing browser instance is found
- PID-based deduplication to prevent spawning duplicate browser instances
- Graceful disconnect recovery: detect crashed/disconnected browsers and automatically respawn

**Other:**
- Port scan fallback when Chrome's `ActivePort` file is not written (common with headless mode)
- Updated browser-setup SKILL.md documentation

**Changes:**
- `lib/clacky/utils/browser_detector.rb` — port scan fallback, WSL2 Linux Chrome path, timeout protection
- `lib/clacky/server/browser_manager.rb` — auto-launch, PID dedup, disconnect recovery
- `lib/clacky/server/http_server.rb` — wire auto-launch into browser lifecycle
- `lib/clacky/default_skills/browser-setup/SKILL.md` — updated docs
- `spec/clacky/server/browser_manager_spec.rb` — auto-launch specs