### PR TITLE
fix(ui): prevent session list scroll jump on load-more (C-5568)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1618,7 +1618,7 @@ const Sessions = (() => {
       // session when renderList() forces scroll-to-active.
       const sidebarList = document.getElementById("sidebar-list");
       const savedScrollTop = sidebarList ? sidebarList.scrollTop : 0;
-      Sessions.renderList();
+      Sessions.renderList({ skipScrollToActive: true });
 
       try {
         // Cursor: oldest created_at in the current list, EXCLUDING pinned
@@ -1651,7 +1651,7 @@ const Sessions = (() => {
         console.error("loadMore error:", e);
       } finally {
         _loadingMore = false;
-        Sessions.renderList();
+        Sessions.renderList({ skipScrollToActive: true });
         // Restore scroll position so the user stays where they were
         if (sidebarList) sidebarList.scrollTop = savedScrollTop;
       }
@@ -1826,7 +1826,7 @@ const Sessions = (() => {
 
     // ── Rendering ─────────────────────────────────────────────────────────
 
-    renderList() {
+    renderList({ skipScrollToActive = false } = {}) {
       // Sort helper: pinned first, then newest-first by created_at
       const byPinnedAndTime = (a, b) => {
         // Pinned sessions always come first
@@ -1877,15 +1877,17 @@ const Sessions = (() => {
       if (_hasMore) list.appendChild(_makeLoadMoreBtn());
 
       // Scroll active session into view so the sidebar always shows the current session.
-      const activeEl = list.querySelector(".session-item.active");
-      if (activeEl) {
-        // If the active session is the very first item, scroll to top of the sidebar
-        // container so sticky headers / expanded panels don't obscure it.
-        if (activeEl === list.firstElementChild) {
-          const sidebarList = document.getElementById("sidebar-list");
-          if (sidebarList) sidebarList.scrollTop = 0;
-        } else {
-          activeEl.scrollIntoView({ block: "nearest" });
+      if (!skipScrollToActive) {
+        const activeEl = list.querySelector(".session-item.active");
+        if (activeEl) {
+          // If the active session is the very first item, scroll to top of the sidebar
+          // container so sticky headers / expanded panels don't obscure it.
+          if (activeEl === list.firstElementChild) {
+            const sidebarList = document.getElementById("sidebar-list");
+            if (sidebarList) sidebarList.scrollTop = 0;
+          } else {
+            activeEl.scrollIntoView({ block: "nearest" });
+          }
         }
       }
     },


### PR DESCRIPTION
## Problem
Clicking "Load More" in the session sidebar causes a visible scroll jump — `renderList()` unconditionally calls `scrollIntoView` on the active session, momentarily shifting the scroll position before `finally` restores it via `savedScrollTop`.

## Fix
Add a `skipScrollToActive` option to `renderList()` (defaults to `false`, no impact on other call sites). The two `renderList()` calls inside `loadMore()` pass `{ skipScrollToActive: true }`, letting the existing `savedScrollTop` restoration handle scroll position exclusively.

## Test
1. Create enough sessions so the "Load More" button appears
2. Open a session near the top of the list
3. Scroll the sidebar to the bottom and click "Load More"
4. Verify no scroll jump — new sessions append smoothly without the list flashing to the active session