### PR TITLE
feat: add Telegram channel adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Telegram channel adapter.** New IM channel adapter that connects openclacky to Telegram via the Bot API. Setup is just a bot token from @BotFather — no browser automation, no QR. Mirrors the existing Feishu / WeCom / Weixin contract: HTTPS long-poll inbound, `sendMessage` / `sendPhoto` / `sendDocument` outbound, photo + document download routed through the standard FileProcessor + vision pipeline, group `@-mention` filtering and `allowed_users` whitelist. `base_url` is configurable to support self-hosted Bot API servers (https://github.com/tdlib/telegram-bot-api) for networks where `api.telegram.org` is unreachable. Frontend Channels panel, `channel-setup` skill, English/Chinese i18n, and `app.css` logo class added. 32 new specs in `spec/clacky/server/channel/adapters/telegram/`.
+
 ## [1.0.4] - 2026-05-11
 
 ### Added

--- a/lib/clacky/default_skills/channel-setup/SKILL.md
+++ b/lib/clacky/default_skills/channel-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: channel-setup
 description: |
-  Configure IM platform channels (Feishu, WeCom, Weixin) for openclacky.
+  Configure IM platform channels (Feishu, WeCom, Weixin, Telegram) for openclacky.
   Uses browser automation for navigation; guides the user to paste credentials and perform UI steps.
-  Trigger on: "channel setup", "setup feishu", "setup wecom", "setup weixin", "setup wechat", "channel config",
-  "channel status", "channel enable", "channel disable", "channel reconfigure", "channel doctor",
-  "send message to weixin", "send message to feishu", "send message to wecom".
+  Trigger on: "channel setup", "setup feishu", "setup wecom", "setup weixin", "setup wechat", "setup telegram",
+  "channel config", "channel status", "channel enable", "channel disable", "channel reconfigure", "channel doctor",
+  "send message to weixin", "send message to feishu", "send message to wecom", "send message to telegram".
   Subcommands: setup, status, enable <platform>, disable <platform>, reconfigure, doctor, send.
 argument-hint: "setup | status | enable <platform> | disable <platform> | reconfigure | doctor | send <platform> <message>"
 allowed-tools:
@@ -28,13 +28,13 @@ Configure IM platform channels for openclacky.
 
 | User says | Subcommand |
 |---|---|
-| `channel setup`, `setup feishu`, `setup wecom`, `setup weixin`, `setup wechat` | setup |
+| `channel setup`, `setup feishu`, `setup wecom`, `setup weixin`, `setup wechat`, `setup telegram` | setup |
 | `channel status` | status |
-| `channel enable feishu/wecom/weixin` | enable |
-| `channel disable feishu/wecom/weixin` | disable |
+| `channel enable feishu/wecom/weixin/telegram` | enable |
+| `channel disable feishu/wecom/weixin/telegram` | disable |
 | `channel reconfigure` | reconfigure |
 | `channel doctor` | doctor |
-| `send <message> to weixin/feishu/wecom` | send |
+| `send <message> to weixin/feishu/wecom/telegram` | send |
 
 ---
 
@@ -51,7 +51,8 @@ Response shape (example):
 {"channels":[
   {"platform":"feishu","enabled":true,"running":true,"has_config":true,"app_id":"cli_xxx","domain":"https://open.feishu.cn","allowed_users":[]},
   {"platform":"wecom","enabled":false,"running":false,"has_config":false,"bot_id":""},
-  {"platform":"weixin","enabled":true,"running":true,"has_config":true,"has_token":true,"base_url":"https://ilinkai.weixin.qq.com","allowed_users":[]}
+  {"platform":"weixin","enabled":true,"running":true,"has_config":true,"has_token":true,"base_url":"https://ilinkai.weixin.qq.com","allowed_users":[]},
+  {"platform":"telegram","enabled":true,"running":true,"has_config":true,"has_token":true,"base_url":"https://api.telegram.org","parse_mode":"Markdown","allowed_users":[]}
 ]}
 ```
 
@@ -64,12 +65,14 @@ Platform   Enabled   Running   Details
 feishu     ✅ yes    ✅ yes    app_id: cli_xxx...
 wecom      ❌ no     ❌ no     (not configured)
 weixin     ✅ yes    ✅ yes    has_token: true
+telegram   ✅ yes    ✅ yes    has_token: true
 ─────────────────────────────────────────────────────
 ```
 
 - Feishu: show `app_id` (truncated to 12 chars)
 - WeCom: show `bot_id` if present
 - Weixin: show `has_token: true/false` (token value is never displayed)
+- Telegram: show `has_token: true/false` (bot token is never displayed)
 
 If the API is unreachable or returns an empty list: "No channels configured yet. Run `/channel-setup setup` to get started."
 
@@ -83,6 +86,7 @@ Ask:
 > 1. Feishu
 > 2. WeCom (Enterprise WeChat)
 > 3. Weixin (Personal WeChat via iLink QR login)
+> 4. Telegram (Bot API)
 
 ---
 
@@ -344,6 +348,45 @@ Tell the user while waiting:
 
 ---
 
+### Telegram setup (Bot API)
+
+Telegram setup is by far the simplest — no browser automation, no QR. The user creates a bot via @BotFather and pastes the token here.
+
+#### Step 1 — Create a bot via @BotFather
+
+Tell the user:
+
+> Open Telegram and start a chat with **@BotFather** (https://t.me/BotFather). Send `/newbot`, choose a display name and a username ending in `bot`. BotFather will reply with an HTTP API token that looks like `123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ`. Paste the token here.
+>
+> Optional: if your network blocks `api.telegram.org`, also tell me the base URL of your self-hosted Bot API server (e.g. `https://my-tg-proxy.example.com`). Otherwise leave it blank.
+
+Wait for the user's reply. Parse the token (matches `^\d+:[\w-]{30,}$`).
+
+#### Step 2 — Save credentials and validate
+
+Call the server API. It calls `getMe` against the Bot API to validate the token before persisting:
+
+```bash
+curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/channels/telegram \
+  -H "Content-Type: application/json" \
+  -d '{"bot_token":"<TOKEN>","base_url":"<BASE_URL_OR_OMIT>"}'
+```
+
+- `200 { "ok": true }` — token validated and saved. The adapter starts long-polling immediately.
+- `422 { "ok": false, "error": "..." }` — show the error (commonly "Unauthorized" → wrong token) and offer to retry.
+
+On success:
+
+> ✅ Telegram channel configured. Open your bot in Telegram and send any message to start chatting. In group chats, the bot only replies when you @-mention it.
+
+#### Notes
+
+- **Group chats**: Telegram bots respond only when @-mentioned or directly replied to (matches Feishu behaviour). For unrestricted reading in groups, the bot owner must disable "Group Privacy" in @BotFather (`/mybots → Bot Settings → Group Privacy → Turn off`), but `@-mention only` is recommended to avoid spam.
+- **Self-hosted Bot API**: set `base_url` when `api.telegram.org` is unreachable. See https://github.com/tdlib/telegram-bot-api for the official self-hosted server.
+- **`allowed_users`**: restrict which Telegram user IDs the bot will respond to. Find a user's numeric ID by messaging @userinfobot.
+
+---
+
 ## `enable`
 
 Call the server API to re-enable the platform (this reads from disk, sets enabled, saves, and hot-reloads):
@@ -391,9 +434,16 @@ Check each item, report ✅ / ❌ with remediation:
    - Feishu: `app_id`, `app_secret` present and non-empty
    - WeCom: `bot_id`, `secret` present and non-empty
    - Weixin: `token` present and non-empty in `channels.yml`
+   - Telegram: `bot_token` present and non-empty
 3. **Feishu credentials** (if enabled) — run the token API call, check `code=0`.
 4. **Weixin token** (if enabled) — call `GET /api/channels` and check `has_token: true` for the weixin entry.
-5. **WeCom credentials** (if enabled) — search today's log:
+5. **Telegram credentials** (if enabled) — call `getMe` against the Bot API:
+   ```bash
+   BOT_TOKEN=$(ruby -ryaml -e 'puts (YAML.load_file(File.expand_path("~/.clacky/channels.yml"))["channels"]["telegram"]["bot_token"] rescue "")')
+   BASE_URL=$(ruby -ryaml -e 'puts (YAML.load_file(File.expand_path("~/.clacky/channels.yml"))["channels"]["telegram"]["base_url"] || "https://api.telegram.org" rescue "https://api.telegram.org")')
+   curl -s "$BASE_URL/bot$BOT_TOKEN/getMe" | grep -q '"ok":true' && echo "✅ Telegram OK" || echo "❌ Telegram credentials rejected by getMe"
+   ```
+6. **WeCom credentials** (if enabled) — search today's log:
    ```bash
    grep -iE "wecom adapter loop started|WeCom authentication failed|WeCom WS error response|WecomAdapter" \
      ~/.clacky/logger/clacky-$(date +%Y-%m-%d).log
@@ -410,7 +460,7 @@ Proactively send a message to a user via an IM channel adapter.
 ### Parse the request
 
 Extract two things from the user's instruction:
-- **platform** — one of `weixin`, `feishu`, `wecom`
+- **platform** — one of `weixin`, `feishu`, `wecom`, `telegram`
 - **message** — the text content to send
 
 If the platform cannot be inferred, ask the user to clarify.
@@ -450,7 +500,7 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/channels/
 ### Constraints & notes
 
 - **Weixin (iLink protocol)**: Every outbound message requires a `context_token` that is obtained from the most recent inbound message from that user. The token is cached in memory and reset on server restart. If the server was restarted since the user last wrote, the token is gone and the send will fail — the user must message the bot again.
-- **Feishu / WeCom**: No token required. As long as the adapter is running and the `user_id` / `chat_id` is valid, the message will be delivered.
+- **Feishu / WeCom / Telegram**: No per-message token required. As long as the adapter is running and the `user_id` / `chat_id` is valid, the message will be delivered. For Telegram specifically, the `user_id` must be a Telegram chat_id that the bot can write to — the user must have sent at least one message to the bot first.
 - This feature is intended for **proactive notifications** (e.g. task completion, reminders). It is not a replacement for the normal reply flow triggered by inbound messages.
 
 ---

--- a/lib/clacky/server/channel.rb
+++ b/lib/clacky/server/channel.rb
@@ -24,6 +24,7 @@ require_relative "channel/adapters/base"
 require_relative "channel/adapters/feishu/adapter"
 require_relative "channel/adapters/wecom/adapter"
 require_relative "channel/adapters/weixin/adapter"
+require_relative "channel/adapters/telegram/adapter"
 
 require_relative "channel/channel_config"
 require_relative "channel/channel_ui_controller"

--- a/lib/clacky/server/channel/adapters/telegram/adapter.rb
+++ b/lib/clacky/server/channel/adapters/telegram/adapter.rb
@@ -1,0 +1,375 @@
+# frozen_string_literal: true
+
+require "base64"
+require_relative "../../adapters/base"
+require_relative "api_client"
+
+module Clacky
+  module Channel
+    module Adapters
+      module Telegram
+        # Telegram Bot API adapter.
+        #
+        # Transport: HTTPS long-poll via getUpdates (no public domain required).
+        # Auth:      single bot token obtained from @BotFather.
+        # Group rule: bots only react when @-mentioned or replied to (matches Feishu).
+        #
+        # Config keys (channels.yml `telegram`):
+        #   bot_token       String  required — from @BotFather
+        #   base_url        String  default "https://api.telegram.org"
+        #                            (override for self-hosted Bot API / proxy)
+        #   parse_mode      String  default "Markdown" — set "" / nil to disable
+        #   allowed_users   Array   optional whitelist of from.id (numeric, as String)
+        class Adapter < Base
+          # Telegram messages cap at 4096 UTF-16 code units; we leave a small margin.
+          MAX_MESSAGE_CHARS = 4000
+
+          MAX_IMAGE_BYTES = Clacky::Utils::FileProcessor::MAX_IMAGE_BYTES
+
+          def self.platform_id
+            :telegram
+          end
+
+          def self.env_keys
+            %w[IM_TELEGRAM_BOT_TOKEN IM_TELEGRAM_BASE_URL IM_TELEGRAM_PARSE_MODE IM_TELEGRAM_ALLOWED_USERS]
+          end
+
+          def self.platform_config(data)
+            {
+              bot_token:     data["IM_TELEGRAM_BOT_TOKEN"] || data["bot_token"],
+              base_url:      data["IM_TELEGRAM_BASE_URL"]  || data["base_url"]   || ApiClient::DEFAULT_BASE_URL,
+              parse_mode:    data.key?("parse_mode") ? data["parse_mode"] : (data["IM_TELEGRAM_PARSE_MODE"] || "Markdown"),
+              allowed_users: (data["IM_TELEGRAM_ALLOWED_USERS"] || data["allowed_users"] || "")
+                               .then { |v| v.is_a?(Array) ? v : v.to_s.split(",").map(&:strip).reject(&:empty?) }
+            }.compact
+          end
+
+          def self.set_env_data(data, config)
+            data["IM_TELEGRAM_BOT_TOKEN"]      = config[:bot_token]
+            data["IM_TELEGRAM_BASE_URL"]       = config[:base_url]    if config[:base_url]
+            data["IM_TELEGRAM_PARSE_MODE"]     = config[:parse_mode]  if config[:parse_mode]
+            data["IM_TELEGRAM_ALLOWED_USERS"]  = Array(config[:allowed_users]).join(",")
+          end
+
+          # Verify credentials by calling getMe.
+          # @param fields [Hash] symbol-keyed credential fields
+          # @return [Hash] { ok: Boolean, message:/error: String }
+          def self.test_connection(fields)
+            token = fields[:bot_token].to_s.strip
+            return { ok: false, error: "bot_token is required" } if token.empty?
+
+            base_url = fields[:base_url].to_s.strip
+            base_url = ApiClient::DEFAULT_BASE_URL if base_url.empty?
+
+            client = ApiClient.new(token: token, base_url: base_url)
+            me     = client.post("getMe", {})
+            { ok: true, message: "Connected — bot @#{me["username"]} (id #{me["id"]})" }
+          rescue StandardError => e
+            { ok: false, error: e.message }
+          end
+
+          def initialize(config)
+            @config        = config
+            @token         = config[:bot_token].to_s
+            @base_url      = config[:base_url] || ApiClient::DEFAULT_BASE_URL
+            @parse_mode    = config.key?(:parse_mode) ? config[:parse_mode] : "Markdown"
+            @parse_mode    = nil if @parse_mode.to_s.empty?
+            @allowed_users = Array(config[:allowed_users]).map(&:to_s)
+
+            @api          = ApiClient.new(token: @token, base_url: @base_url)
+            @running      = false
+            @on_message   = nil
+            @last_offset  = nil
+
+            # Cached bot identity (used for @-mention check in groups).
+            @bot_username = nil
+            @bot_id       = nil
+          end
+
+          # ── Lifecycle ──────────────────────────────────────────────────────
+
+          def start(&on_message)
+            @running    = true
+            @on_message = on_message
+
+            ensure_bot_identity
+
+            Clacky::Logger.info("[TelegramAdapter] starting long-poll (base_url=#{@base_url})")
+
+            consecutive_errors = 0
+            while @running
+              begin
+                updates = @api.get_updates(offset: @last_offset)
+                consecutive_errors = 0
+
+                updates.each do |update|
+                  @last_offset = update["update_id"] + 1
+                  process_update(update)
+                rescue => e
+                  Clacky::Logger.warn("[TelegramAdapter] process_update error: #{e.message}\n#{e.backtrace.first(3).join("\n")}")
+                end
+              rescue ApiClient::TimeoutError
+                # Long-poll cycle ended with no updates — just loop.
+              rescue ApiClient::ApiError => e
+                consecutive_errors += 1
+                Clacky::Logger.warn("[TelegramAdapter] API #{e.code}: #{e.description}")
+                sleep(consecutive_errors > 3 ? 30 : 5)
+              rescue => e
+                consecutive_errors += 1
+                Clacky::Logger.error("[TelegramAdapter] poll error: #{e.message}")
+                break unless @running
+                sleep(consecutive_errors > 3 ? 30 : 5)
+              end
+            end
+          end
+
+          def stop
+            @running = false
+          end
+
+          # ── Outbound (called by ChannelUIController) ────────────────────────
+
+          # Send a text message. Splits content longer than Telegram's 4096-char
+          # cap into multiple consecutive messages. Returns { message_id: } of
+          # the LAST chunk (matches the contract used by the other adapters).
+          def send_text(chat_id, text, reply_to: nil)
+            chunks = split_message(text.to_s)
+            return { message_id: nil } if chunks.empty?
+
+            last_message_id = nil
+            chunks.each_with_index do |chunk, i|
+              params = {
+                chat_id:                  chat_id.to_s,
+                text:                     chunk,
+                disable_web_page_preview: true
+              }
+              params[:parse_mode]          = @parse_mode if @parse_mode
+              params[:reply_to_message_id] = reply_to.to_i if reply_to && i == 0
+              msg = @api.post("sendMessage", params)
+              last_message_id = msg["message_id"]
+            end
+            { message_id: last_message_id }
+          rescue ApiClient::ApiError => e
+            # Markdown parse failures fall back to plain text — most common cause
+            # is unescaped Markdown reserved chars in the agent's output.
+            if @parse_mode && e.description.to_s =~ /can't parse entities|markdown/i
+              Clacky::Logger.warn("[TelegramAdapter] parse_mode failed, retrying as plain text: #{e.description}")
+              fallback = {
+                chat_id:                  chat_id.to_s,
+                text:                     text.to_s,
+                disable_web_page_preview: true
+              }
+              fallback[:reply_to_message_id] = reply_to.to_i if reply_to
+              msg = @api.post("sendMessage", fallback)
+              return { message_id: msg["message_id"] }
+            end
+            Clacky::Logger.error("[TelegramAdapter] send_text failed: #{e.message}")
+            { message_id: nil }
+          rescue => e
+            Clacky::Logger.error("[TelegramAdapter] send_text failed: #{e.message}")
+            { message_id: nil }
+          end
+
+          def send_file(chat_id, path, name: nil, reply_to: nil)
+            return { message_id: nil } unless File.exist?(path)
+
+            is_image = path.to_s.downcase.match?(/\.(png|jpe?g|gif|webp)\z/)
+            msg = if is_image
+                    @api.send_photo(
+                      chat_id:             chat_id.to_s,
+                      photo_path:          path,
+                      reply_to_message_id: reply_to&.to_i
+                    )
+                  else
+                    @api.send_document(
+                      chat_id:             chat_id.to_s,
+                      document_path:       path,
+                      filename:            name,
+                      reply_to_message_id: reply_to&.to_i
+                    )
+                  end
+            { message_id: msg["message_id"] }
+          rescue => e
+            Clacky::Logger.error("[TelegramAdapter] send_file failed for #{path}: #{e.message}")
+            { message_id: nil }
+          end
+
+          def update_message(chat_id, message_id, text)
+            @api.edit_message_text(
+              chat_id:    chat_id.to_s,
+              message_id: message_id.to_i,
+              text:       text,
+              parse_mode: @parse_mode
+            )
+            true
+          rescue => e
+            Clacky::Logger.warn("[TelegramAdapter] update_message failed: #{e.message}")
+            false
+          end
+
+          def supports_message_updates?
+            true
+          end
+
+          def validate_config(config)
+            errors = []
+            errors << "bot_token is required" if config[:bot_token].nil? || config[:bot_token].to_s.strip.empty?
+            errors
+          end
+
+          # ── Inbound ─────────────────────────────────────────────────────────
+
+          def ensure_bot_identity
+            me = @api.post("getMe", {})
+            @bot_id       = me["id"]
+            @bot_username = me["username"]
+            Clacky::Logger.info("[TelegramAdapter] bot identity: @#{@bot_username} (id=#{@bot_id})")
+          rescue => e
+            Clacky::Logger.warn("[TelegramAdapter] getMe failed: #{e.message} — group @-mentions will be dropped")
+          end
+
+          def process_update(update)
+            msg = update["message"]
+            return unless msg
+
+            chat = msg["chat"] || {}
+            from = msg["from"] || {}
+            chat_id = chat["id"]
+            user_id = from["id"]
+            return unless chat_id && user_id
+
+            chat_type = chat["type"].to_s
+            is_group  = %w[group supergroup].include?(chat_type)
+            text      = msg["text"].to_s
+
+            if is_group
+              return unless group_mention?(msg, text)
+              text = strip_bot_mention(text)
+            end
+
+            if @allowed_users.any? && !@allowed_users.include?(user_id.to_s)
+              Clacky::Logger.debug("[TelegramAdapter] ignoring message from #{user_id} (not in allowed_users)")
+              return
+            end
+
+            files = collect_files(msg)
+            caption = msg["caption"].to_s
+            text = caption if text.empty? && !caption.empty?
+            return if text.strip.empty? && files.empty?
+
+            event = {
+              type:       :message,
+              platform:   :telegram,
+              chat_id:    chat_id.to_s,
+              user_id:    user_id.to_s,
+              text:       text.strip,
+              files:      files,
+              message_id: msg["message_id"].to_s,
+              timestamp:  msg["date"] ? Time.at(msg["date"]) : Time.now,
+              chat_type:  is_group ? :group : :direct,
+              raw:        msg
+            }
+
+            Clacky::Logger.info("[TelegramAdapter] msg from #{user_id} in #{chat_id} (#{chat_type}): #{text.slice(0, 80)}")
+            @on_message&.call(event)
+          end
+
+          # The bot reacts to a group message only if:
+          #   1. text contains @<bot_username> as a mention entity, or
+          #   2. the message is a reply to a message authored by the bot
+          # Fail closed when bot identity is unknown — drop the message rather
+          # than respond to every line and spam the group.
+          def group_mention?(msg, text)
+            return false unless @bot_id
+
+            reply = msg["reply_to_message"]
+            return true if reply && reply.dig("from", "id") == @bot_id
+
+            entities = msg["entities"] || []
+            entities.any? do |e|
+              e["type"] == "mention" &&
+                text[e["offset"], e["length"]].to_s.casecmp?("@#{@bot_username}")
+            end
+          end
+
+          def strip_bot_mention(text)
+            return text unless @bot_username
+            text.gsub(/@#{Regexp.escape(@bot_username)}\b/i, "").strip
+          end
+
+          # Build file-attachment hashes for the agent's vision / file pipeline.
+          def collect_files(msg)
+            files = []
+
+            if msg["photo"].is_a?(Array) && !msg["photo"].empty?
+              # `photo` is an array of size variants — pick the largest.
+              largest = msg["photo"].max_by { |p| p["file_size"].to_i }
+              begin
+                raw = @api.download_file(largest["file_id"])
+                if raw.bytesize > MAX_IMAGE_BYTES
+                  Clacky::Logger.warn("[TelegramAdapter] image too large (#{raw.bytesize}B), dropping")
+                else
+                  mime = detect_image_mime(raw)
+                  files << {
+                    type:      :image,
+                    name:      "image.jpg",
+                    mime_type: mime,
+                    data_url:  "data:#{mime};base64,#{Base64.strict_encode64(raw)}"
+                  }
+                end
+              rescue => e
+                Clacky::Logger.warn("[TelegramAdapter] image download failed: #{e.message}")
+              end
+            end
+
+            if (doc = msg["document"])
+              begin
+                raw      = @api.download_file(doc["file_id"])
+                filename = doc["file_name"].to_s
+                filename = "attachment" if filename.empty?
+                saved    = Clacky::Utils::FileProcessor.save(body: raw, filename: filename)
+                files << { type: :file, name: saved[:name], path: saved[:path] }
+              rescue => e
+                Clacky::Logger.warn("[TelegramAdapter] document download failed: #{e.message}")
+              end
+            end
+
+            files
+          end
+
+          def detect_image_mime(bytes)
+            return "image/jpeg" unless bytes && bytes.bytesize >= 4
+            head = bytes.byteslice(0, 8).bytes
+            return "image/png"  if head[0] == 0x89 && head[1] == 0x50 && head[2] == 0x4E && head[3] == 0x47
+            return "image/gif"  if head[0] == 0x47 && head[1] == 0x49 && head[2] == 0x46
+            return "image/webp" if head[0] == 0x52 && head[1] == 0x49 && head[2] == 0x46 && head[3] == 0x46
+            "image/jpeg"
+          end
+
+          # ── Helpers ─────────────────────────────────────────────────────────
+
+          # Split text at Telegram's 4096-char cap (we use 4000 as a margin).
+          # Prefers paragraph / line / space boundaries; hard-cuts as a last resort.
+          def split_message(text)
+            return [] if text.nil? || text.empty?
+            return [text] if text.length <= MAX_MESSAGE_CHARS
+
+            chunks    = []
+            remaining = text.dup
+            while remaining.length > MAX_MESSAGE_CHARS
+              window = remaining[0, MAX_MESSAGE_CHARS]
+              cut = window.rindex("\n\n") || window.rindex("\n") || window.rindex(" ") || MAX_MESSAGE_CHARS
+              cut = MAX_MESSAGE_CHARS if cut.zero?
+              chunks << remaining[0, cut].rstrip
+              remaining = remaining[cut..].lstrip
+            end
+            chunks << remaining unless remaining.empty?
+            chunks
+          end
+        end
+
+        Adapters.register(:telegram, Adapter)
+      end
+    end
+  end
+end

--- a/lib/clacky/server/channel/adapters/telegram/api_client.rb
+++ b/lib/clacky/server/channel/adapters/telegram/api_client.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "net/https"
+require "openssl"
+require "securerandom"
+require "uri"
+
+module Clacky
+  module Channel
+    module Adapters
+      module Telegram
+        # Telegram Bot API HTTP client.
+        # Spec: https://core.telegram.org/bots/api
+        #
+        # All requests POST JSON to https://<base>/bot<TOKEN>/<method>.
+        # File downloads use https://<base>/file/bot<TOKEN>/<file_path>.
+        #
+        # `base_url` is configurable to allow self-hosted Bot API servers
+        # (https://github.com/tdlib/telegram-bot-api), which is the practical
+        # escape hatch for users on networks where api.telegram.org is blocked.
+        class ApiClient
+          DEFAULT_BASE_URL  = "https://api.telegram.org"
+          LONG_POLL_TIMEOUT = 25  # seconds; server holds the request open up to this long
+          OPEN_TIMEOUT      = 10
+          # Read timeout must comfortably exceed the long-poll window so we
+          # don't tear down healthy connections mid-poll.
+          POLL_READ_TIMEOUT = LONG_POLL_TIMEOUT + 10
+
+          class ApiError < StandardError
+            attr_reader :code, :description
+            def initialize(code, description)
+              @code = code
+              @description = description
+              super("Telegram API error #{code}: #{description}")
+            end
+          end
+
+          class TimeoutError < StandardError; end
+
+          def initialize(token:, base_url: DEFAULT_BASE_URL)
+            @token    = token.to_s
+            @base_url = (base_url.to_s.empty? ? DEFAULT_BASE_URL : base_url).chomp("/")
+          end
+
+          # Long-poll for updates. Returns the raw `result` array (possibly empty).
+          # `offset` is the highest update_id + 1 from the previous batch.
+          def get_updates(offset: nil, allowed_updates: %w[message])
+            params = { timeout: LONG_POLL_TIMEOUT, allowed_updates: allowed_updates }
+            params[:offset] = offset if offset
+            post("getUpdates", params, read_timeout: POLL_READ_TIMEOUT)
+          end
+
+          # Send a plain or Markdown-formatted message. Returns the Message hash.
+          def send_message(chat_id:, text:, parse_mode: nil, reply_to_message_id: nil, message_thread_id: nil, disable_web_page_preview: true)
+            params = {
+              chat_id:                  chat_id,
+              text:                     text,
+              disable_web_page_preview: disable_web_page_preview
+            }
+            params[:parse_mode]              = parse_mode          if parse_mode
+            params[:reply_to_message_id]     = reply_to_message_id if reply_to_message_id
+            params[:message_thread_id]       = message_thread_id   if message_thread_id
+            post("sendMessage", params)
+          end
+
+          # Edit the text of a previously sent message. Returns the edited Message hash.
+          def edit_message_text(chat_id:, message_id:, text:, parse_mode: nil, disable_web_page_preview: true)
+            params = {
+              chat_id:                  chat_id,
+              message_id:               message_id,
+              text:                     text,
+              disable_web_page_preview: disable_web_page_preview
+            }
+            params[:parse_mode] = parse_mode if parse_mode
+            post("editMessageText", params)
+          end
+
+          # Send a chat action (e.g. "typing") — auto-expires after 5s client-side.
+          def send_chat_action(chat_id:, action: "typing", message_thread_id: nil)
+            params = { chat_id: chat_id, action: action }
+            params[:message_thread_id] = message_thread_id if message_thread_id
+            post("sendChatAction", params)
+          end
+
+          # Send a photo by local file path. Returns the Message hash.
+          def send_photo(chat_id:, photo_path:, caption: nil, reply_to_message_id: nil)
+            params = { chat_id: chat_id }
+            params[:caption]             = caption             if caption
+            params[:reply_to_message_id] = reply_to_message_id if reply_to_message_id
+            post_multipart("sendPhoto", params, file_field: "photo", file_path: photo_path)
+          end
+
+          # Send a document (arbitrary file). Returns the Message hash.
+          def send_document(chat_id:, document_path:, filename: nil, caption: nil, reply_to_message_id: nil)
+            params = { chat_id: chat_id }
+            params[:caption]             = caption             if caption
+            params[:reply_to_message_id] = reply_to_message_id if reply_to_message_id
+            post_multipart("sendDocument", params, file_field: "document", file_path: document_path, filename: filename)
+          end
+
+          # Resolve a file_id to a file_path via getFile, then download the bytes.
+          # Returns the raw byte string.
+          def download_file(file_id)
+            file = post("getFile", { file_id: file_id })
+            path = file["file_path"]
+            raise ApiError.new(0, "getFile returned no file_path") if path.to_s.empty?
+
+            uri = URI("#{@base_url}/file/bot#{@token}/#{path}")
+            http_get_raw(uri)
+          end
+
+
+          def post(method_name, params, read_timeout: 30)
+            uri = URI("#{@base_url}/bot#{@token}/#{method_name}")
+            http = build_http(uri, read_timeout: read_timeout)
+
+            req = Net::HTTP::Post.new(uri.request_uri, "Content-Type" => "application/json")
+            req.body = JSON.generate(params)
+
+            res  = http.request(req)
+            body = parse_body(res)
+            unwrap(body, method_name)
+          rescue Net::ReadTimeout, Net::OpenTimeout
+            raise TimeoutError, "#{method_name} timed out"
+          end
+
+          def post_multipart(method_name, params, file_field:, file_path:, filename: nil)
+            uri      = URI("#{@base_url}/bot#{@token}/#{method_name}")
+            boundary = "----clacky-tg-#{SecureRandom.hex(8)}"
+            body     = String.new(encoding: "BINARY")
+
+            params.each do |k, v|
+              body << "--#{boundary}\r\n"
+              body << %(Content-Disposition: form-data; name="#{k}"\r\n\r\n)
+              body << v.to_s.dup.force_encoding("BINARY")
+              body << "\r\n"
+            end
+
+            file_bytes = File.binread(file_path)
+            body << "--#{boundary}\r\n"
+            body << %(Content-Disposition: form-data; name="#{file_field}"; filename="#{filename || File.basename(file_path)}"\r\n)
+            body << "Content-Type: #{mime_for(file_path)}\r\n\r\n"
+            body << file_bytes
+            body << "\r\n--#{boundary}--\r\n"
+
+            http = build_http(uri, read_timeout: 60)
+            req  = Net::HTTP::Post.new(uri.request_uri,
+                                       "Content-Type" => "multipart/form-data; boundary=#{boundary}")
+            req.body = body
+
+            unwrap(parse_body(http.request(req)), method_name)
+          end
+
+          def http_get_raw(uri)
+            http = build_http(uri, read_timeout: 60)
+            res  = http.request(Net::HTTP::Get.new(uri.request_uri))
+            unless res.is_a?(Net::HTTPSuccess)
+              raise ApiError.new(res.code.to_i, "GET #{uri.path} → HTTP #{res.code}: #{res.body.to_s.slice(0, 200)}")
+            end
+            res.body
+          rescue Net::ReadTimeout, Net::OpenTimeout
+            raise TimeoutError, "file download timed out"
+          end
+
+          def build_http(uri, read_timeout:)
+            http              = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl      = uri.scheme == "https"
+            http.verify_mode  = OpenSSL::SSL::VERIFY_PEER if http.use_ssl?
+            http.open_timeout = OPEN_TIMEOUT
+            http.read_timeout = read_timeout
+            http
+          end
+
+          def parse_body(res)
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            raise ApiError.new(res.code.to_i, "non-JSON response from Telegram: #{res.body.to_s.slice(0, 200)}")
+          end
+
+          def unwrap(body, method_name)
+            if body["ok"]
+              body["result"]
+            else
+              raise ApiError.new(body["error_code"].to_i, "#{method_name}: #{body["description"]}")
+            end
+          end
+
+          def mime_for(path)
+            case File.extname(path).downcase
+            when ".png"           then "image/png"
+            when ".gif"           then "image/gif"
+            when ".webp"          then "image/webp"
+            when ".jpg", ".jpeg"  then "image/jpeg"
+            when ".pdf"           then "application/pdf"
+            when ".txt", ".md"    then "text/plain"
+            else                       "application/octet-stream"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/server/channel/channel_config.rb
+++ b/lib/clacky/server/channel/channel_config.rb
@@ -109,6 +109,13 @@ module Clacky
           base_url:      raw["base_url"],
           allowed_users: raw["allowed_users"]
         }.compact
+      when :telegram
+        {
+          bot_token:     raw["bot_token"],
+          base_url:      raw["base_url"],
+          parse_mode:    raw.key?("parse_mode") ? raw["parse_mode"] : "Markdown",
+          allowed_users: raw["allowed_users"]
+        }.compact
       else
         # Unknown platform — pass all non-meta keys as symbol-keyed hash
         raw.reject { |k, _| k == "enabled" }

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1689,6 +1689,13 @@ module Clacky
             has_token:         !raw["token"].to_s.strip.empty?,
             token_updated_at:  raw["token_updated_at"]  # Unix timestamp, nil if never set
           }
+        when :telegram
+          {
+            base_url:      raw["base_url"] || Clacky::Channel::Adapters::Telegram::ApiClient::DEFAULT_BASE_URL,
+            parse_mode:    raw.key?("parse_mode") ? raw["parse_mode"] : "Markdown",
+            allowed_users: raw["allowed_users"] || [],
+            has_token:     !raw["bot_token"].to_s.strip.empty?
+          }
         else
           {}
         end

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -5764,6 +5764,11 @@ body.setup-mode[data-theme="dark"] {
   color: #fff;
 }
 
+.channel-logo-telegram {
+  background: linear-gradient(135deg, #2aabee, #229ed9);
+  color: #fff;
+}
+
 .channel-card-name {
   font-size: 15px;
   font-weight: 600;

--- a/lib/clacky/web/channels.js
+++ b/lib/clacky/web/channels.js
@@ -35,6 +35,14 @@ const Channels = (() => {
         setupCmd:  "/channel-setup setup weixin",
         testCmd:   "/channel-setup doctor",
       },
+      telegram: {
+        logo:      "T",
+        logoClass: "channel-logo-telegram",
+        name:      "Telegram",
+        desc:      I18n.t("channels.telegram.desc"),
+        setupCmd:  "/channel-setup setup telegram",
+        testCmd:   "/channel-setup doctor",
+      },
     };
   }
 

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -347,7 +347,7 @@ const I18n = (() => {
 
       // ── Channels panel ──
       "channels.title":           "Channels",
-      "channels.subtitle":        "Connect IM platforms so your users can chat with the assistant via Feishu, WeCom or Weixin",
+      "channels.subtitle":        "Connect IM platforms so your users can chat with the assistant via Feishu, WeCom, Weixin or Telegram",
       "channels.loading":         "Loading…",
       "channels.badge.running":         "Running",
       "channels.badge.enabled":         "Enabled",
@@ -368,6 +368,7 @@ const I18n = (() => {
       "channels.feishu.desc":     "Connect via Feishu open platform WebSocket long connection",
       "channels.wecom.desc":      "Connect via WeCom intelligent robot WebSocket",
       "channels.weixin.desc":     "Connect via WeChat iLink bot (QR login, HTTP long-poll)",
+      "channels.telegram.desc":   "Connect via Telegram Bot API (HTTPS long-poll, token from @BotFather)",
 
       // ── Settings panel ──
       "settings.title":           "Settings",
@@ -844,7 +845,7 @@ const I18n = (() => {
 
       // ── Channels panel ──
       "channels.title":           "频道",
-      "channels.subtitle":        "连接即时通讯平台，让用户通过飞书、企业微信或微信与助手对话",
+      "channels.subtitle":        "连接即时通讯平台，让用户通过飞书、企业微信、微信或 Telegram 与助手对话",
       "channels.loading":         "加载中…",
       "channels.loadError":       "加载频道失败：{{msg}}",
       "channels.badge.running":         "运行中",
@@ -865,6 +866,7 @@ const I18n = (() => {
       "channels.feishu.desc":     "通过飞书开放平台 WebSocket 长连接接入",
       "channels.wecom.desc":      "通过企业微信智能机器人 WebSocket 接入",
       "channels.weixin.desc":     "通过微信 iLink 机器人接入（扫码登录，HTTP 长轮询）",
+      "channels.telegram.desc":   "通过 Telegram Bot API 接入（HTTPS 长轮询，token 来自 @BotFather）",
 
       // ── Settings panel ──
       "settings.title":           "设置",

--- a/spec/clacky/server/channel/adapters/telegram/adapter_spec.rb
+++ b/spec/clacky/server/channel/adapters/telegram/adapter_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/channel/adapters/telegram/adapter"
+require "clacky/server/channel/adapters/telegram/api_client"
+
+RSpec.describe Clacky::Channel::Adapters::Telegram::Adapter do
+  let(:config) do
+    {
+      bot_token:     "123456:abc",
+      base_url:      "https://api.telegram.org",
+      parse_mode:    "Markdown",
+      allowed_users: []
+    }
+  end
+
+  let(:adapter) { described_class.new(config) }
+
+  # Pre-populate the cached bot identity so group-mention logic is exercisable
+  # without a live network call to getMe.
+  before do
+    adapter.instance_variable_set(:@bot_id, 9999)
+    adapter.instance_variable_set(:@bot_username, "clacky_bot")
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  describe ".platform_id" do
+    it { expect(described_class.platform_id).to eq(:telegram) }
+  end
+
+  describe ".platform_config" do
+    it "reads env-style keys" do
+      cfg = described_class.platform_config(
+        "IM_TELEGRAM_BOT_TOKEN"     => "tok",
+        "IM_TELEGRAM_BASE_URL"      => "https://proxy.example.com",
+        "IM_TELEGRAM_PARSE_MODE"    => "HTML",
+        "IM_TELEGRAM_ALLOWED_USERS" => "111, 222"
+      )
+      expect(cfg).to include(
+        bot_token:     "tok",
+        base_url:      "https://proxy.example.com",
+        parse_mode:    "HTML",
+        allowed_users: %w[111 222]
+      )
+    end
+
+    it "reads raw channels.yml keys (bot_token, base_url, parse_mode)" do
+      cfg = described_class.platform_config(
+        "bot_token"     => "tok",
+        "parse_mode"    => "",
+        "allowed_users" => %w[111]
+      )
+      expect(cfg[:bot_token]).to eq("tok")
+      expect(cfg[:parse_mode]).to eq("")        # explicit empty disables parse_mode
+      expect(cfg[:allowed_users]).to eq(%w[111])
+    end
+  end
+
+  describe "#validate_config" do
+    it "flags missing bot_token" do
+      errors = adapter.validate_config(bot_token: "")
+      expect(errors).to include("bot_token is required")
+    end
+
+    it "accepts a populated config" do
+      expect(adapter.validate_config(bot_token: "tok")).to eq([])
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  describe "#group_mention? (private)" do
+    it "returns true when text contains @bot_username as a mention entity" do
+      text = "hey @clacky_bot do this"
+      offset = text.index("@clacky_bot")
+      msg = { "entities" => [{ "type" => "mention", "offset" => offset, "length" => "@clacky_bot".length }] }
+      expect(adapter.send(:group_mention?, msg, text)).to eq(true)
+    end
+
+    it "returns true when the message replies to the bot" do
+      msg = { "reply_to_message" => { "from" => { "id" => 9999 } } }
+      expect(adapter.send(:group_mention?, msg, "what about this?")).to eq(true)
+    end
+
+    it "returns false when entities contain a non-bot mention" do
+      text = "@someone_else hello"
+      msg  = { "entities" => [{ "type" => "mention", "offset" => 0, "length" => 13 }] }
+      expect(adapter.send(:group_mention?, msg, text)).to eq(false)
+    end
+
+    it "fails closed (returns false) when bot identity is unknown" do
+      adapter.instance_variable_set(:@bot_id, nil)
+      msg = { "entities" => [{ "type" => "mention", "offset" => 0, "length" => 11 }] }
+      expect(adapter.send(:group_mention?, msg, "@clacky_bot")).to eq(false)
+    end
+  end
+
+  describe "#strip_bot_mention (private)" do
+    it "removes the @bot_username token" do
+      out = adapter.send(:strip_bot_mention, "@clacky_bot please summarize")
+      expect(out).to eq("please summarize")
+    end
+
+    it "leaves text untouched when bot username is unset" do
+      adapter.instance_variable_set(:@bot_username, nil)
+      expect(adapter.send(:strip_bot_mention, "@x hi")).to eq("@x hi")
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  describe "#process_update" do
+    let(:events) { [] }
+    before { adapter.instance_variable_set(:@on_message, ->(e) { events << e }) }
+
+    it "yields a standardized event for a private text message" do
+      update = {
+        "update_id" => 100,
+        "message"   => {
+          "message_id" => 7,
+          "date"       => 1_700_000_000,
+          "chat"       => { "id" => 42, "type" => "private" },
+          "from"       => { "id" => 1001, "username" => "alice" },
+          "text"       => "deploy now"
+        }
+      }
+      adapter.process_update(update)
+      expect(events.size).to eq(1)
+      expect(events[0]).to include(
+        platform:   :telegram,
+        chat_id:    "42",
+        user_id:    "1001",
+        text:       "deploy now",
+        chat_type:  :direct,
+        message_id: "7"
+      )
+    end
+
+    it "drops group messages without an @bot mention" do
+      update = {
+        "update_id" => 101,
+        "message"   => {
+          "message_id" => 8,
+          "date"       => 1_700_000_001,
+          "chat"       => { "id" => -100, "type" => "supergroup" },
+          "from"       => { "id" => 1001 },
+          "text"       => "just chatting"
+        }
+      }
+      adapter.process_update(update)
+      expect(events).to be_empty
+    end
+
+    it "accepts group messages when @bot_username is mentioned, and strips the mention" do
+      text   = "@clacky_bot summarize this"
+      offset = text.index("@clacky_bot")
+      update = {
+        "update_id" => 102,
+        "message"   => {
+          "message_id" => 9,
+          "date"       => 1_700_000_002,
+          "chat"       => { "id" => -200, "type" => "group" },
+          "from"       => { "id" => 1002 },
+          "text"       => text,
+          "entities"   => [{ "type" => "mention", "offset" => offset, "length" => "@clacky_bot".length }]
+        }
+      }
+      adapter.process_update(update)
+      expect(events.size).to eq(1)
+      expect(events[0][:chat_type]).to eq(:group)
+      expect(events[0][:text]).to eq("summarize this")
+    end
+
+    it "drops messages from users not on the allowed_users list" do
+      adapter.instance_variable_set(:@allowed_users, %w[42])
+      update = {
+        "update_id" => 103,
+        "message"   => {
+          "message_id" => 10,
+          "date"       => 1_700_000_003,
+          "chat"       => { "id" => 99, "type" => "private" },
+          "from"       => { "id" => 1003 },
+          "text"       => "hi"
+        }
+      }
+      adapter.process_update(update)
+      expect(events).to be_empty
+    end
+
+    it "drops update payloads without a message key (e.g. edited_message)" do
+      expect { adapter.process_update({ "update_id" => 104, "edited_message" => {} }) }.not_to raise_error
+      expect(events).to be_empty
+    end
+
+    it "uses caption when message has files but no text" do
+      update = {
+        "update_id" => 105,
+        "message"   => {
+          "message_id" => 11,
+          "date"       => 1_700_000_004,
+          "chat"       => { "id" => 50, "type" => "private" },
+          "from"       => { "id" => 1004 },
+          "caption"    => "look at this",
+          "photo"      => []  # empty array → no actual download
+        }
+      }
+      adapter.process_update(update)
+      # Empty photo array means no file downloaded; caption alone is enough to deliver
+      expect(events.size).to eq(1)
+      expect(events[0][:text]).to eq("look at this")
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  describe "#split_message (private)" do
+    it "returns the input as a single chunk when within limit" do
+      expect(adapter.send(:split_message, "short text")).to eq(["short text"])
+    end
+
+    it "returns an empty array for empty input" do
+      expect(adapter.send(:split_message, "")).to eq([])
+    end
+
+    it "splits on paragraph boundary when possible" do
+      first  = "a" * 3500
+      second = "b" * 1000
+      input  = "#{first}\n\n#{second}"
+      chunks = adapter.send(:split_message, input)
+      expect(chunks.size).to eq(2)
+      expect(chunks[0]).to eq(first)
+      expect(chunks[1]).to eq(second)
+    end
+
+    it "hard-cuts at the limit when no boundary exists" do
+      input  = "a" * 5000
+      chunks = adapter.send(:split_message, input)
+      expect(chunks.size).to be >= 2
+      expect(chunks.first.length).to be <= described_class::MAX_MESSAGE_CHARS
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  describe "#detect_image_mime (private)" do
+    it "recognises PNG magic bytes" do
+      png = "\x89PNG\r\n\x1A\n".b + ("x" * 10)
+      expect(adapter.send(:detect_image_mime, png)).to eq("image/png")
+    end
+
+    it "recognises GIF magic bytes" do
+      gif = "GIF89a".b + ("x" * 10)
+      expect(adapter.send(:detect_image_mime, gif)).to eq("image/gif")
+    end
+
+    it "recognises WebP magic bytes" do
+      webp = "RIFF????WEBP".b
+      expect(adapter.send(:detect_image_mime, webp)).to eq("image/webp")
+    end
+
+    it "defaults to image/jpeg for unknown / JPEG-looking data" do
+      expect(adapter.send(:detect_image_mime, "\xFF\xD8\xFF\xE0".b + ("x" * 10))).to eq("image/jpeg")
+      expect(adapter.send(:detect_image_mime, nil)).to eq("image/jpeg")
+    end
+  end
+end

--- a/spec/clacky/server/channel/adapters/telegram/api_client_spec.rb
+++ b/spec/clacky/server/channel/adapters/telegram/api_client_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/channel/adapters/telegram/api_client"
+
+RSpec.describe Clacky::Channel::Adapters::Telegram::ApiClient do
+  let(:token)  { "123456789:test-token" }
+  let(:client) { described_class.new(token: token) }
+
+  describe "#unwrap (private)" do
+    it "returns result when ok is true" do
+      body = { "ok" => true, "result" => { "id" => 42 } }
+      expect(client.send(:unwrap, body, "getMe")).to eq({ "id" => 42 })
+    end
+
+    it "raises ApiError with code + description when ok is false" do
+      body = { "ok" => false, "error_code" => 401, "description" => "Unauthorized" }
+      expect { client.send(:unwrap, body, "getMe") }
+        .to raise_error(described_class::ApiError) { |e|
+          expect(e.code).to eq(401)
+          expect(e.description).to eq("getMe: Unauthorized")
+        }
+    end
+  end
+
+  describe "#mime_for (private)" do
+    it "maps common extensions" do
+      expect(client.send(:mime_for, "a.png")).to  eq("image/png")
+      expect(client.send(:mime_for, "a.jpg")).to  eq("image/jpeg")
+      expect(client.send(:mime_for, "a.jpeg")).to eq("image/jpeg")
+      expect(client.send(:mime_for, "a.gif")).to  eq("image/gif")
+      expect(client.send(:mime_for, "a.pdf")).to  eq("application/pdf")
+      expect(client.send(:mime_for, "a.txt")).to  eq("text/plain")
+    end
+
+    it "falls back to octet-stream for unknown" do
+      expect(client.send(:mime_for, "a.xyz")).to eq("application/octet-stream")
+    end
+  end
+
+  describe "#build_http (private)" do
+    it "enables SSL for https URLs and sets the requested read_timeout" do
+      uri = URI("https://api.telegram.org/bot/foo")
+      http = client.send(:build_http, uri, read_timeout: 99)
+      expect(http.use_ssl?).to eq(true)
+      expect(http.read_timeout).to eq(99)
+      expect(http.open_timeout).to eq(described_class::OPEN_TIMEOUT)
+    end
+  end
+
+  describe "#initialize" do
+    it "strips trailing slash from base_url" do
+      c = described_class.new(token: token, base_url: "https://example.com/")
+      expect(c.instance_variable_get(:@base_url)).to eq("https://example.com")
+    end
+
+    it "falls back to DEFAULT_BASE_URL when base_url is blank" do
+      c = described_class.new(token: token, base_url: "")
+      expect(c.instance_variable_get(:@base_url)).to eq(described_class::DEFAULT_BASE_URL)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a Telegram channel adapter as a peer to the existing Feishu / WeCom / Weixin adapters, so users can talk to their openclacky agent from Telegram.

- **Transport**: HTTPS long-poll (`getUpdates`) — no public domain required, no webhook hosting.
- **Auth**: a single bot token from [@BotFather](https://t.me/BotFather). The save endpoint validates it against `getMe` before persisting.
- **Outbound**: `sendMessage` (with parse_mode fallback when Markdown is malformed), `sendPhoto` for images, `sendDocument` for everything else, `editMessageText` for `supports_message_updates?` parity with Feishu.
- **Inbound**: text + photos + documents. Photos are downloaded and converted to `data:` URLs for the agent's vision pipeline. Documents are saved via `FileProcessor` for the existing file-parsing flow.
- **Group rule**: bots reply only when @-mentioned or replied to — matches Feishu's behaviour. Fail-closed when bot identity can't be fetched.
- **Network escape hatch**: `base_url` is configurable. Users on networks where `api.telegram.org` is blocked can point at a self-hosted [Bot API server](https://github.com/tdlib/telegram-bot-api).
- **Setup UX**: dramatically simpler than the other three. No browser automation, no QR — just paste a token. Documented in `channel-setup` SKILL.md.

## What this PR does NOT do

The original brief asked about streaming via `sendMessageDraft` (Bot API 9.3+). On reading `lib/clacky/agent/llm_caller.rb` we confirmed that the agent's LLM call is **non-streaming** (the comment at line 127 says so explicitly) and `UIInterface` has no token-delta hook — `show_assistant_message` is called once with the complete buffered text. Wiring `sendMessageDraft` end-to-end would require refactoring `LlmCaller` to consume SSE and adding a delta method across all five UI controllers, which is out of scope for a channel adapter. This PR ships the standard non-streaming reply path (matches the other three channels); a future PR can add real token streaming if/when `LlmCaller` is refactored.

## Test plan

- [x] `bundle exec rspec spec/clacky/server/channel/` — 67 examples, 0 failures (32 new specs cover inbound parsing, group @-mention filtering, allowed_users whitelist, message splitting, image-MIME detection, ApiError unwrap).
- [ ] `Clacky::Channel::Adapters.all.map(&:platform_id)` returns `[:feishu, :wecom, :weixin, :telegram]` — adapter is registered.
- [ ] Manual smoke: create a bot via @BotFather → POST to `/api/channels/telegram` → exchange a few private and group messages, including photo and document uploads.
- [ ] Manual smoke: point `base_url` at a self-hosted Bot API server and confirm long-poll still works.

## Files

- `lib/clacky/server/channel/adapters/telegram/api_client.rb` — HTTP Bot API client (Net::HTTP, hand-rolled multipart for file uploads, no extra gem dep)
- `lib/clacky/server/channel/adapters/telegram/adapter.rb` — adapter inheriting `Adapters::Base`
- `lib/clacky/server/channel.rb` — load adapter
- `lib/clacky/server/channel/channel_config.rb` — `when :telegram` branch
- `lib/clacky/server/http_server.rb` — `platform_safe_fields` for the Channels panel API
- `lib/clacky/default_skills/channel-setup/SKILL.md` — setup / status / doctor / send guidance for Telegram
- `lib/clacky/web/channels.js`, `lib/clacky/web/i18n.js`, `lib/clacky/web/app.css` — Channels panel card + en/zh strings + logo
- `spec/clacky/server/channel/adapters/telegram/` — 32 new specs

## Bot API references

- `sendMessage`: https://core.telegram.org/bots/api#sendmessage
- `sendPhoto`, `sendDocument`, `getFile`, `getUpdates`: https://core.telegram.org/bots/api
- Self-hosted Bot API: https://github.com/tdlib/telegram-bot-api