### PR TITLE
feat(browser): 持久化 MCP daemon + 严格 page ownership + 静默后台模式

### DIFF
--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -30,6 +30,12 @@ module Clacky
     PID_PATH            = File.expand_path("~/.clacky/mcp-daemon.pid").freeze
     DAEMON_SCRIPT       = File.expand_path("mcp_daemon.rb", __dir__).freeze
     DAEMON_STARTUP_TIMEOUT = 15
+    # While Clacky is running we send `daemon.keepalive` every 30 min so the
+    # daemon's 24h idle timer never expires. This way the chrome-devtools-mcp
+    # WebSocket session — and Chrome's remote-debugging authorization — sticks
+    # around as long as any Clacky-server is alive (matters for IM-driven
+    # agents where the user can't re-authorize Chrome from outside).
+    KEEPALIVE_INTERVAL = 1_800
 
     class << self
       def instance
@@ -44,8 +50,11 @@ module Clacky
       # @call_id_mutex protects the @call_id counter. The actual RPC roundtrip
       # (send_to_daemon) runs lock-free; the daemon serializes via its own
       # @write_mutex when forwarding to chrome-devtools-mcp.
+      # @keepalive_mutex protects @keepalive_thread (which we replace on reload).
       @daemon_setup_mutex = Mutex.new
       @call_id_mutex      = Mutex.new
+      @keepalive_mutex    = Mutex.new
+      @keepalive_thread   = nil
       @call_id            = 2
       @config             = {}
     end
@@ -72,6 +81,8 @@ module Clacky
         msg = e.message.to_s.lines.first&.strip || e.message.to_s
         Clacky::Logger.warn("[BrowserManager] Pre-warm failed: #{msg}")
       end
+
+      start_keepalive_thread!
     end
 
     # Detach from the daemon — no-op by design. Each mcp_call uses a one-shot
@@ -87,12 +98,14 @@ module Clacky
     # Hard daemon teardown — only used when chrome config changes or on
     # `reload`. NOT called on Clacky shutdown.
     def terminate_daemon!
+      stop_keepalive_thread!
       @daemon_setup_mutex.synchronize { kill_daemon! }
       Clacky::Logger.info("[BrowserManager] Daemon terminated")
     end
 
     def reload
       Clacky::Logger.info("[BrowserManager] Reloading...")
+      stop_keepalive_thread!
       @daemon_setup_mutex.synchronize { kill_daemon! }
 
       cfg = load_config
@@ -109,6 +122,7 @@ module Clacky
           msg = e.message.to_s.lines.first&.strip || e.message.to_s
           Clacky::Logger.warn("[BrowserManager] Reload start failed: #{msg}")
         end
+        start_keepalive_thread!
       else
         Clacky::Logger.info("[BrowserManager] Browser disabled after reload — daemon not started")
       end
@@ -216,6 +230,43 @@ module Clacky
     # ------------------------------------------------------------------
     # Private
     # ------------------------------------------------------------------
+
+    # Spawn (or replace) the per-Clacky-process keepalive thread. Fires
+    # `daemon.keepalive` every KEEPALIVE_INTERVAL so the daemon's 24h idle
+    # timer never trips while this Clacky is alive. Errors are swallowed —
+    # if the daemon is briefly unreachable, the next tick will retry.
+    private def start_keepalive_thread!
+      @keepalive_mutex.synchronize do
+        stop_keepalive_thread_locked!
+        @keepalive_thread = Thread.new do
+          Thread.current.name = "browser-manager-keepalive"
+          loop do
+            sleep KEEPALIVE_INTERVAL
+            send_daemon_keepalive
+          end
+        end
+      end
+    end
+
+    private def stop_keepalive_thread!
+      @keepalive_mutex.synchronize { stop_keepalive_thread_locked! }
+    end
+
+    private def stop_keepalive_thread_locked!
+      thr = @keepalive_thread
+      return unless thr
+      thr.kill if thr.alive?
+      @keepalive_thread = nil
+    end
+
+    private def send_daemon_keepalive
+      return unless File.exist?(SOCKET_PATH)
+      req = { jsonrpc: "2.0", id: 0, method: "daemon.keepalive" }
+      send_to_daemon(req, timeout: 2)
+    rescue StandardError
+      # Daemon may be down transiently; we'll try again next tick.
+      nil
+    end
 
     private def load_config
       return {} unless File.exist?(BROWSER_CONFIG_PATH)

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -125,18 +125,31 @@ module Clacky
       cfg     = load_config
       enabled = cfg["enabled"] == true
       {
-        enabled:        enabled,
-        daemon_running: daemon_responding?,
-        chrome_version: cfg["chrome_version"]
+        enabled:         enabled,
+        daemon_running:  daemon_responding?,
+        chrome_version:  cfg["chrome_version"],
+        background_mode: background_mode?(cfg)
       }
+    end
+
+    # Whether the agent should operate the browser silently in the background
+    # — i.e. NOT bring tabs to the front when selecting/opening pages.
+    # Default: true (agent never steals focus from the user).
+    # Override per-config via `background_mode: false` in browser.yml.
+    def background_mode?(cfg = nil)
+      cfg ||= load_config
+      val = cfg["background_mode"]
+      return true if val.nil?  # default ON
+      val == true
     end
 
     def configure(chrome_version:)
       cfg = {
-        "enabled"        => true,
-        "browser"        => "chrome",
-        "chrome_version" => chrome_version.to_s,
-        "configured_at"  => Date.today.to_s
+        "enabled"         => true,
+        "browser"         => "chrome",
+        "chrome_version"  => chrome_version.to_s,
+        "background_mode" => true,
+        "configured_at"   => Date.today.to_s
       }
       FileUtils.mkdir_p(File.dirname(BROWSER_CONFIG_PATH))
       File.write(BROWSER_CONFIG_PATH, cfg.to_yaml)

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -38,9 +38,16 @@ module Clacky
     end
 
     def initialize
-      @mutex   = Mutex.new
-      @call_id = 2
-      @config  = {}
+      # @daemon_setup_mutex protects ensure_daemon!/kill_daemon!. Only contended
+      # on cold start, respawn, or shutdown — the per-call hot path doesn't
+      # serialize through it.
+      # @call_id_mutex protects the @call_id counter. The actual RPC roundtrip
+      # (send_to_daemon) runs lock-free; the daemon serializes via its own
+      # @write_mutex when forwarding to chrome-devtools-mcp.
+      @daemon_setup_mutex = Mutex.new
+      @call_id_mutex      = Mutex.new
+      @call_id            = 2
+      @config             = {}
     end
 
     # ------------------------------------------------------------------
@@ -58,7 +65,7 @@ module Clacky
       Clacky::Logger.info("[BrowserManager] Browser enabled, ensuring MCP daemon is running...")
       Thread.new do
         Thread.current.name = "browser-manager-start"
-        @mutex.synchronize { ensure_daemon! }
+        @daemon_setup_mutex.synchronize { ensure_daemon! }
       rescue Clacky::BrowserNotReachableError
         Clacky::Logger.debug("[BrowserManager] Skipping pre-warm: Chrome not running")
       rescue StandardError => e
@@ -67,25 +74,26 @@ module Clacky
       end
     end
 
-    # On Clacky shutdown we intentionally LEAVE the daemon running so that
-    # the next Clacky startup can reuse the existing Chrome connection and
-    # avoid re-authorization.
-    def stop
-      Clacky::Logger.info("[BrowserManager] Stop (daemon left running for restart reuse)")
+    # Detach from the daemon — no-op by design. Each mcp_call uses a one-shot
+    # UNIX socket, so this process holds no connection state to release.
+    # The daemon survives Clacky shutdown so the next startup can reuse the
+    # existing Chrome remote-debugging authorization.
+    def disconnect
+      Clacky::Logger.info("[BrowserManager] Disconnect (daemon left running for restart reuse)")
     end
 
     public
 
-    # Explicit daemon kill — only used when chrome config changes or on
+    # Hard daemon teardown — only used when chrome config changes or on
     # `reload`. NOT called on Clacky shutdown.
-    def force_stop
-      @mutex.synchronize { kill_daemon! }
-      Clacky::Logger.info("[BrowserManager] Daemon force-stopped")
+    def terminate_daemon!
+      @daemon_setup_mutex.synchronize { kill_daemon! }
+      Clacky::Logger.info("[BrowserManager] Daemon terminated")
     end
 
     def reload
       Clacky::Logger.info("[BrowserManager] Reloading...")
-      @mutex.synchronize { kill_daemon! }
+      @daemon_setup_mutex.synchronize { kill_daemon! }
 
       cfg = load_config
       @config = cfg
@@ -94,7 +102,7 @@ module Clacky
         Clacky::Logger.info("[BrowserManager] Browser enabled, restarting daemon")
         Thread.new do
           Thread.current.name = "browser-manager-reload"
-          @mutex.synchronize { ensure_daemon! }
+          @daemon_setup_mutex.synchronize { ensure_daemon! }
         rescue Clacky::BrowserNotReachableError
           Clacky::Logger.debug("[BrowserManager] Skipping reload start: Chrome not running")
         rescue StandardError => e
@@ -160,35 +168,38 @@ module Clacky
     def mcp_call(tool_name, arguments = {})
       attempts = 0
       begin
-        @mutex.synchronize do
-          ensure_daemon!
+        @daemon_setup_mutex.synchronize { ensure_daemon! }
 
-          call_id  = @call_id
+        call_id = @call_id_mutex.synchronize do
+          id = @call_id
           @call_id += 1
-
-          req = {
-            jsonrpc: "2.0",
-            id:      call_id,
-            method:  "tools/call",
-            params:  { name: tool_name, arguments: arguments }
-          }
-
-          resp = send_to_daemon(req, timeout: Clacky::Tools::Browser::MCP_CALL_TIMEOUT)
-
-          if resp["error"]
-            err = resp["error"]
-            raise "Chrome MCP error: #{err.is_a?(Hash) ? err["message"] : err}"
-          end
-
-          result = resp["result"] || {}
-
-          if result["isError"]
-            text = extract_text_content(result)
-            raise text.empty? ? "Chrome MCP tool '#{tool_name}' failed" : text
-          end
-
-          result
+          id
         end
+
+        req = {
+          jsonrpc: "2.0",
+          id:      call_id,
+          method:  "tools/call",
+          params:  { name: tool_name, arguments: arguments }
+        }
+
+        # send_to_daemon runs lock-free; the daemon's @write_mutex serializes
+        # the actual chrome-devtools-mcp forwarding.
+        resp = send_to_daemon(req, timeout: Clacky::Tools::Browser::MCP_CALL_TIMEOUT)
+
+        if resp["error"]
+          err = resp["error"]
+          raise "Chrome MCP error: #{err.is_a?(Hash) ? err["message"] : err}"
+        end
+
+        result = resp["result"] || {}
+
+        if result["isError"]
+          text = extract_text_content(result)
+          raise text.empty? ? "Chrome MCP tool '#{tool_name}' failed" : text
+        end
+
+        result
       rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::EPIPE, IOError => e
         attempts += 1
         if attempts <= 1
@@ -214,7 +225,7 @@ module Clacky
       {}
     end
 
-    # Called inside @mutex.
+    # Called inside @daemon_setup_mutex.
     # Ensures the mcp_daemon process exists and the Unix socket answers ping.
     # Also verifies the daemon's wsEndpoint matches the current Chrome instance —
     # if Chrome was restarted (new UUID), the daemon's WebSocket is dead and we
@@ -290,10 +301,13 @@ module Clacky
       end
     end
 
+    SPAWN_LOG_MAX_BYTES = 1_000_000
+
     def spawn_daemon_locked!(detected)
       chrome_cmd = build_chrome_mcp_command(detected)
       log_path   = File.expand_path("~/.clacky/mcp-daemon.spawn.log")
       FileUtils.mkdir_p(File.dirname(log_path))
+      rotate_log_if_oversized(log_path)
 
       # Build the daemon argv. We use Bundler's ruby if available.
       ruby_bin = RbConfig.ruby
@@ -402,6 +416,18 @@ module Clacky
         .select { |b| b.is_a?(Hash) && b["type"] == "text" }
         .map { |b| b["text"].to_s }
         .join("\n")
+    end
+
+    # Roll spawn.log → spawn.log.1 when it grows past SPAWN_LOG_MAX_BYTES.
+    # Only one historical copy is kept. spawn.log is append-only (spawn-time
+    # rc-shell output, MCP startup banner, mise warnings) so a single rollover
+    # is enough to bound disk use without losing recent debug context.
+    def rotate_log_if_oversized(log_path)
+      return unless File.exist?(log_path)
+      return if File.size(log_path) < SPAWN_LOG_MAX_BYTES
+      FileUtils.mv(log_path, "#{log_path}.1", force: true)
+    rescue StandardError => e
+      Clacky::Logger.warn("[BrowserManager] Failed to rotate spawn log: #{e.message}")
     end
   end
 end

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -70,23 +70,8 @@ module Clacky
     # On Clacky shutdown we intentionally LEAVE the daemon running so that
     # the next Clacky startup can reuse the existing Chrome connection and
     # avoid re-authorization.
-    #
-    # If browser.yml has `close_owned_tabs_on_exit: true`, we first close
-    # every tab owned by Browser instances in this process — so the daemon
-    # is left clean for the next startup.
     def stop
-      close_owned_tabs_if_configured
       Clacky::Logger.info("[BrowserManager] Stop (daemon left running for restart reuse)")
-    end
-
-    private def close_owned_tabs_if_configured
-      cfg = load_config
-      return unless cfg["close_owned_tabs_on_exit"] == true
-      require "clacky/tools/browser"
-      Clacky::Tools::Browser.close_all_owned_tabs_across_instances!
-      Clacky::Logger.info("[BrowserManager] Closed all owned tabs on shutdown")
-    rescue StandardError => e
-      Clacky::Logger.warn("[BrowserManager] Failed to close owned tabs on shutdown: #{e.message}")
     end
 
     public

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -2,38 +2,34 @@
 
 require "yaml"
 require "shellwords"
-require "open3"
+require "json"
+require "socket"
+require "timeout"
+require "fileutils"
 
 module Clacky
-  # BrowserManager owns the chrome-devtools-mcp daemon lifecycle.
+  # BrowserManager — owns access to chrome-devtools-mcp via a long-lived
+  # **detached** Ruby daemon (lib/clacky/server/mcp_daemon.rb).
   #
-  # It mirrors the ChannelManager pattern:
-  #   - start   → read browser.yml; if enabled, pre-warm the MCP daemon
-  #   - stop    → kill the daemon
-  #   - reload  → stop + re-read yml + start (called after browser-setup writes yml)
-  #   - status  → { enabled: bool, daemon_running: bool, chrome_version: String|nil }
-  #   - toggle  → flip enabled in browser.yml and reload
+  # The daemon process survives Clacky restarts and Chrome tab churn, so
+  # Chrome's remote-debugging authorization is only required on the FIRST
+  # connection; subsequent Clacky restarts and tab closures reuse the same
+  # WebSocket session held by chrome-devtools-mcp.
   #
-  # browser.yml schema:
-  #   enabled: true/false   — whether the browser tool is active
-  #   chrome_version: "146" — detected Chrome version (set by browser-setup skill)
-  #   configured_at: date   — when setup was last run
-  #
-  # Liveness check strategy:
-  #   process_alive? sends an MCP `ping` (standard in MCP spec 2024-11-05) and
-  #   waits up to 3s for a response.  If the ping succeeds the daemon is healthy.
-  #   If it times out or raises an IO error the daemon is truly dead — kill it so
-  #   ensure_process! will spawn a fresh one on the next call.
-  #
-  #   Chrome connection problems (e.g. Chrome closed) surface only during the
-  #   actual mcp_call and are reported back to the caller; they do NOT trigger a
-  #   daemon restart.
-  #
-  # Browser tool (browser.rb) delegates daemon access here instead of using
-  # class-level @@mcp_process variables directly.  BrowserManager holds the
-  # single mutable state; the mutex lives here too.
+  # Public API (unchanged from previous chrome-devtools-mcp-direct version):
+  #   start    - launch daemon if browser.yml says enabled
+  #   stop     - close local socket connection (does NOT kill daemon)
+  #   reload   - kill daemon + restart (called when browser.yml changes)
+  #   status   - { enabled, daemon_running, chrome_version }
+  #   configure(chrome_version:) - write browser.yml + reload
+  #   toggle   - flip enabled in browser.yml + reload
+  #   mcp_call(tool_name, args) - forward MCP tool call through socket
   class BrowserManager
     BROWSER_CONFIG_PATH = File.expand_path("~/.clacky/browser.yml").freeze
+    SOCKET_PATH         = File.expand_path("~/.clacky/mcp-daemon.sock").freeze
+    PID_PATH            = File.expand_path("~/.clacky/mcp-daemon.pid").freeze
+    DAEMON_SCRIPT       = File.expand_path("mcp_daemon.rb", __dir__).freeze
+    DAEMON_STARTUP_TIMEOUT = 15
 
     class << self
       def instance
@@ -42,18 +38,15 @@ module Clacky
     end
 
     def initialize
-      @process = nil   # { stdin:, stdout:, pid:, wait_thr: }
       @mutex   = Mutex.new
-      @call_id = 2     # 1 reserved for MCP initialize handshake
-      @config  = {}    # last successfully read browser.yml content
+      @call_id = 2
+      @config  = {}
     end
 
-    # ---------------------------------------------------------------------------
+    # ------------------------------------------------------------------
     # Lifecycle
-    # ---------------------------------------------------------------------------
+    # ------------------------------------------------------------------
 
-    # Start the daemon if browser.yml marks the browser as enabled.
-    # Non-blocking — returns immediately (daemon spawn takes ~200ms in background).
     def start
       cfg = load_config
       unless cfg["enabled"] == true
@@ -62,31 +55,35 @@ module Clacky
       end
 
       @config = cfg
-      Clacky::Logger.info("[BrowserManager] Browser enabled, pre-warming MCP daemon...")
+      Clacky::Logger.info("[BrowserManager] Browser enabled, ensuring MCP daemon is running...")
       Thread.new do
         Thread.current.name = "browser-manager-start"
-        @mutex.synchronize { ensure_process! }
-      rescue Clacky::BrowserNotReachableError => e
-        # Expected: Chrome not running yet — will start lazily on first use
+        @mutex.synchronize { ensure_daemon! }
+      rescue Clacky::BrowserNotReachableError
         Clacky::Logger.debug("[BrowserManager] Skipping pre-warm: Chrome not running")
       rescue StandardError => e
-        # Unexpected error (handshake failure, port conflict, etc.)
         msg = e.message.to_s.lines.first&.strip || e.message.to_s
         Clacky::Logger.warn("[BrowserManager] Pre-warm failed: #{msg}")
       end
     end
 
-    # Stop and clean up the daemon.
+    # On Clacky shutdown we intentionally LEAVE the daemon running so that
+    # the next Clacky startup can reuse the existing Chrome connection and
+    # avoid re-authorization.
     def stop
-      @mutex.synchronize { kill_process! }
-      Clacky::Logger.info("[BrowserManager] Daemon stopped")
+      Clacky::Logger.info("[BrowserManager] Stop (daemon left running for restart reuse)")
     end
 
-    # Hot-reload: stop existing daemon, re-read yml, restart if enabled.
-    # Called by HttpServer after browser-setup writes a new browser.yml.
+    # Explicit daemon kill — only used when chrome config changes or on
+    # `reload`. NOT called on Clacky shutdown.
+    def force_stop
+      @mutex.synchronize { kill_daemon! }
+      Clacky::Logger.info("[BrowserManager] Daemon force-stopped")
+    end
+
     def reload
       Clacky::Logger.info("[BrowserManager] Reloading...")
-      @mutex.synchronize { kill_process! }
+      @mutex.synchronize { kill_daemon! }
 
       cfg = load_config
       @config = cfg
@@ -95,12 +92,10 @@ module Clacky
         Clacky::Logger.info("[BrowserManager] Browser enabled, restarting daemon")
         Thread.new do
           Thread.current.name = "browser-manager-reload"
-          @mutex.synchronize { ensure_process! }
-        rescue Clacky::BrowserNotReachableError => e
-          # Expected: Chrome not running yet — will start lazily on first use
+          @mutex.synchronize { ensure_daemon! }
+        rescue Clacky::BrowserNotReachableError
           Clacky::Logger.debug("[BrowserManager] Skipping reload start: Chrome not running")
         rescue StandardError => e
-          # Unexpected error (handshake failure, port conflict, etc.)
           msg = e.message.to_s.lines.first&.strip || e.message.to_s
           Clacky::Logger.warn("[BrowserManager] Reload start failed: #{msg}")
         end
@@ -109,23 +104,16 @@ module Clacky
       end
     end
 
-    # Returns a status hash with real daemon liveness.
-    # Uses wait_thr.alive? for a lightweight check — no ping, no mutex needed.
-    # @return [Hash] { enabled: bool, daemon_running: bool, chrome_version: String|nil }
     def status
       cfg     = load_config
       enabled = cfg["enabled"] == true
-      running = @process && @process[:wait_thr]&.alive?
       {
         enabled:        enabled,
-        daemon_running: !!running,
+        daemon_running: daemon_responding?,
         chrome_version: cfg["chrome_version"]
       }
     end
 
-    # Write browser.yml with the given config and reload the daemon.
-    # Called by HttpServer POST /api/browser/configure.
-    # @param chrome_version [String] detected Chrome major version
     def configure(chrome_version:)
       cfg = {
         "enabled"        => true,
@@ -138,9 +126,6 @@ module Clacky
       reload
     end
 
-    # Toggle the browser tool on/off by flipping `enabled` in browser.yml.
-    # Raises if browser.yml doesn't exist (not yet set up).
-    # @return [Boolean] new enabled state
     def toggle
       raise "Browser not configured. Run /browser-setup first." unless File.exist?(BROWSER_CONFIG_PATH)
 
@@ -153,59 +138,60 @@ module Clacky
       new_enabled
     end
 
-    # ---------------------------------------------------------------------------
-    # MCP call interface — used by Browser tool
-    # ---------------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # MCP call interface
+    # ------------------------------------------------------------------
 
-    # Execute a chrome-devtools-mcp tool call. Ensures daemon is running first.
-    # Thread-safe via @mutex.
-    # @param tool_name  [String]
-    # @param arguments  [Hash]
-    # @return [Hash] parsed MCP result
-    # @raise [RuntimeError] on timeout or protocol error
-    # @raise [BrowserNotReachableError] when Chrome is not running
     def mcp_call(tool_name, arguments = {})
-      call_resp = nil
+      attempts = 0
+      begin
+        @mutex.synchronize do
+          ensure_daemon!
 
-      @mutex.synchronize do
-        ensure_process!  # May raise BrowserNotReachableError
+          call_id  = @call_id
+          @call_id += 1
 
-        call_id  = @call_id
-        @call_id += 1
+          req = {
+            jsonrpc: "2.0",
+            id:      call_id,
+            method:  "tools/call",
+            params:  { name: tool_name, arguments: arguments }
+          }
 
-        msg = json_rpc("tools/call", { name: tool_name, arguments: arguments }, id: call_id)
-        @process[:stdin].write(msg + "\n")
-        @process[:stdin].flush
+          resp = send_to_daemon(req, timeout: Clacky::Tools::Browser::MCP_CALL_TIMEOUT)
 
-        call_resp = read_response(@process[:stdout], target_id: call_id,
-                                  timeout: Clacky::Tools::Browser::MCP_CALL_TIMEOUT)
+          if resp["error"]
+            err = resp["error"]
+            raise "Chrome MCP error: #{err.is_a?(Hash) ? err["message"] : err}"
+          end
 
-        unless call_resp
-          raise "Chrome MCP tools/call '#{tool_name}' timed out after #{Clacky::Tools::Browser::MCP_CALL_TIMEOUT}s"
+          result = resp["result"] || {}
+
+          if result["isError"]
+            text = extract_text_content(result)
+            raise text.empty? ? "Chrome MCP tool '#{tool_name}' failed" : text
+          end
+
+          result
         end
-
-        if call_resp["error"]
-          err = call_resp["error"]
-          raise "Chrome MCP error: #{err.is_a?(Hash) ? err["message"] : err}"
+      rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::EPIPE, IOError => e
+        attempts += 1
+        if attempts <= 1
+          Clacky::Logger.warn("[BrowserManager] Daemon connection lost (#{e.class}), respawning and retrying")
+          File.unlink(SOCKET_PATH) if File.exist?(SOCKET_PATH)
+          retry
         end
-
-        result = call_resp["result"] || {}
-
-        if result["isError"]
-          text = extract_text_content(result)
-          raise text.empty? ? "Chrome MCP tool '#{tool_name}' failed" : text
-        end
-
-        result
+        raise
       end
     rescue Clacky::BrowserNotReachableError => e
-      # Return friendly error for AI to guide user
       raise Clacky::AgentError, e.message
     end
 
-    # ---------------------------------------------------------------------------
+    # ------------------------------------------------------------------
     # Private
-    # ---------------------------------------------------------------------------
+    # ------------------------------------------------------------------
+
+    private
 
     def load_config
       return {} unless File.exist?(BROWSER_CONFIG_PATH)
@@ -215,13 +201,13 @@ module Clacky
       {}
     end
 
-    # Must be called inside @mutex
-    def ensure_process!
-      return if process_alive?
-
-      # ⭐️ Critical: Verify Chrome is reachable BEFORE starting MCP daemon
+    # Called inside @mutex.
+    # Ensures the mcp_daemon process exists and the Unix socket answers ping.
+    # Also verifies the daemon's wsEndpoint matches the current Chrome instance —
+    # if Chrome was restarted (new UUID), the daemon's WebSocket is dead and we
+    # must respawn even though ping succeeds.
+    def ensure_daemon!
       detected = Clacky::Utils::BrowserDetector.detect
-
       if detected[:status] == :not_found
         raise Clacky::BrowserNotReachableError, <<~MSG.strip
           Chrome/Edge is not running or remote debugging is not enabled.
@@ -235,156 +221,167 @@ module Clacky
         MSG
       end
 
-      # Build command with verified detection result
-      cmd = build_mcp_command(detected)
-      Clacky::Logger.info("[BrowserManager] Starting MCP daemon: #{cmd.join(' ')}")
+      current_endpoint = detected[:mode] == :ws_endpoint ? detected[:value].to_s : ""
 
-      # Wrap in a shell that manually sources rc files (.zshrc/.bashrc) so
-      # mise / rbenv / asdf activate and `chrome-devtools-mcp` (a node
-      # binary installed under mise) is on PATH — otherwise the server,
-      # when launched by launchd / a desktop icon with a minimal PATH,
-      # cannot find node.
-      #
-      # LoginShell.login_shell_command builds argv like:
-      #   /bin/zsh -c "{ . ~/.zshrc; ... } 1>&2; exec chrome-devtools-mcp ..."
-      #
-      # The `1>&2` sends rc-time output (banners, mise warnings) to stderr,
-      # keeping the child's stdout 100% clean for JSON-RPC. `exec` then
-      # replaces the shell process with the MCP daemon itself, so the pid
-      # / signals / waitpid we hold point at the real target.
-      inner   = cmd.map { |a| shell_escape(a) }.join(" ")
-      wrapped = Clacky::Utils::LoginShell.login_shell_command(inner)
-
-      # close_others: true prevents inheriting the server's listening socket (port 7070).
-      # The MCP daemon is an independent external process and should not hold server fds.
-      stdin, stdout, stderr_io, wait_thr = Open3.popen3(*wrapped, close_others: true)
-      Thread.new { stderr_io.read rescue nil }
-
-      # MCP handshake
-      init_msg = json_rpc("initialize", {
-        protocolVersion: "2024-11-05",
-        capabilities:    {},
-        clientInfo:      { name: "clacky", version: "1.0" }
-      }, id: 1)
-
-      notify_msg = JSON.generate({
-        jsonrpc: "2.0",
-        method:  "notifications/initialized",
-        params:  {}
-      })
-
-      Clacky::Logger.debug("[BrowserManager] Sending MCP initialize...")
-      stdin.write(init_msg + "\n")
-      stdin.flush
-
-      init_resp = read_response(stdout, target_id: 1,
-                                timeout: Clacky::Tools::Browser::MCP_HANDSHAKE_TIMEOUT)
-      unless init_resp
-        Clacky::Logger.error("[BrowserManager] MCP initialize handshake timed out after #{Clacky::Tools::Browser::MCP_HANDSHAKE_TIMEOUT}s")
-        Process.kill("TERM", wait_thr.pid) rescue nil
-        raise "Chrome MCP initialize handshake timed out"
+      if daemon_responding?
+        if daemon_endpoint == current_endpoint
+          return
+        end
+        Clacky::Logger.info("[BrowserManager] Daemon endpoint stale (Chrome restarted?); respawning")
+        kill_daemon!
       end
 
-      Clacky::Logger.debug("[BrowserManager] MCP initialize successful, sending initialized notification...")
-      stdin.write(notify_msg + "\n")
-      stdin.flush
-
-      @process = { stdin: stdin, stdout: stdout, pid: wait_thr.pid, wait_thr: wait_thr }
-      @call_id = 2
-      Clacky::Logger.info("[BrowserManager] MCP daemon started successfully (pid=#{wait_thr.pid})")
+      spawn_daemon!(detected)
+      wait_for_daemon!
+      Clacky::Logger.info("[BrowserManager] MCP daemon is responding")
     end
 
-    # Build chrome-devtools-mcp command with explicit connection parameters.
-    # Always uses the detected browser endpoint (no --autoConnect fallback).
-    # @param detected [Hash] { mode: :ws_endpoint, value: String } from BrowserDetector
-    # @return [Array<String>] command array
-    def build_mcp_command(detected)
-      args = chrome_mcp_feature_flags
-      
+    # Health check: connect to socket and send daemon.ping.
+    # Returns true only if the daemon answers within 2s.
+    def daemon_responding?
+      return false unless File.exist?(SOCKET_PATH)
+      req = { jsonrpc: "2.0", id: 0, method: "daemon.ping" }
+      resp = send_to_daemon(req, timeout: 2)
+      resp.is_a?(Hash) && resp["result"].is_a?(Hash) && resp["result"]["ok"]
+    rescue StandardError
+      false
+    end
+
+    # Returns the wsEndpoint the daemon was started with, via daemon.ping.
+    # Empty string means daemon doesn't know or isn't running.
+    def daemon_endpoint
+      return "" unless File.exist?(SOCKET_PATH)
+      req = { jsonrpc: "2.0", id: 0, method: "daemon.ping" }
+      resp = send_to_daemon(req, timeout: 2)
+      resp.dig("result", "endpoint").to_s
+    rescue StandardError
+      ""
+    end
+
+    # Spawn the mcp_daemon.rb script as a detached process so it survives
+    # the parent Clacky process exit. Uses Process.spawn with:
+    #   - close_others: true (no inherited fds)
+    #   - new_pgroup / setsid (detach from Clacky's process group/session)
+    #   - stdin/stdout/stderr redirected to /dev/null and log file
+    def spawn_daemon!(detected)
+      lock_path = File.expand_path("~/.clacky/mcp-daemon.spawn.lock")
+      FileUtils.mkdir_p(File.dirname(lock_path))
+      File.open(lock_path, File::RDWR | File::CREAT, 0o600) do |lock|
+        lock.flock(File::LOCK_EX)
+        # Re-check under lock — another process may have started the daemon
+        # while we were waiting.
+        return if daemon_responding?
+
+        File.unlink(SOCKET_PATH) if File.exist?(SOCKET_PATH) && !pid_alive?
+        spawn_daemon_locked!(detected)
+      end
+    end
+
+    def spawn_daemon_locked!(detected)
+      chrome_cmd = build_chrome_mcp_command(detected)
+      log_path   = File.expand_path("~/.clacky/mcp-daemon.spawn.log")
+      FileUtils.mkdir_p(File.dirname(log_path))
+
+      # Build the daemon argv. We use Bundler's ruby if available.
+      ruby_bin = RbConfig.ruby
+      daemon_argv = [ruby_bin, DAEMON_SCRIPT, "--", *chrome_cmd]
+
+      # We need chrome-devtools-mcp on PATH. Use login_shell wrapper so mise/nvm
+      # activate before exec.
+      inner   = daemon_argv.map { |a| Shellwords.escape(a.to_s) }.join(" ")
+      wrapped = Clacky::Utils::LoginShell.login_shell_command(inner)
+
+      Clacky::Logger.info("[BrowserManager] Spawning MCP daemon: #{daemon_argv.join(' ')}")
+
+      pid = Process.spawn(
+        *wrapped,
+        in: :close,
+        out: [log_path, "a"],
+        err: [log_path, "a"],
+        close_others: true,
+        pgroup: true
+      )
+      Process.detach(pid)
+      Clacky::Logger.info("[BrowserManager] MCP daemon spawned (pid=#{pid})")
+    end
+
+    # Build the chrome-devtools-mcp command (identical to the previous direct-spawn version).
+    def build_chrome_mcp_command(detected)
+      args = %w[
+        --experimentalStructuredContent
+        --experimental-page-id-routing
+        --experimentalVision
+      ]
       case detected[:mode]
       when :ws_endpoint
-        Clacky::Logger.info("[BrowserManager] Using ws_endpoint mode: #{detected[:value]}")
         ["chrome-devtools-mcp", *args, "--wsEndpoint", detected[:value]]
       else
         raise "Unknown detection mode: #{detected[:mode]}"
       end
     end
 
-    # Shell-escape a single argv token for safe interpolation into a `-c` string.
-    def shell_escape(token)
-      Shellwords.escape(token.to_s)
-    end
-
-    # Feature flags for chrome-devtools-mcp
-    def chrome_mcp_feature_flags
-      %w[
-        --experimentalStructuredContent
-        --experimental-page-id-routing
-        --experimentalVision
-      ]
-    end
-
-    # Must be called inside @mutex.
-    # Uses wait_thr.alive? as the primary liveness check — fast and reliable.
-    # Only falls back to an MCP ping if the thread is alive but we want to
-    # verify the protocol layer is responsive (currently skipped for simplicity).
-    # Kills the process only when the OS thread confirms it has actually exited.
-    def process_alive?
-      return false if @process.nil?
-
-      @process[:wait_thr]&.alive? == true
-    end
-
-    # Must be called inside @mutex.
-    # Clears @process immediately so other threads see it as gone, then
-    # closes IO handles and sends TERM. Uses wait_thr.join(2) in a background
-    # thread to reap the child and avoid zombie processes; escalates to KILL
-    # if the process doesn't exit within the grace period.
-    def kill_process!
-      ps = @process
-      return unless ps
-
-      @process = nil  # Clear first — prevents other threads from re-entering
-
-      ps[:stdin].close  rescue nil
-      ps[:stdout].close rescue nil
-      Process.kill("TERM", ps[:pid]) rescue nil
-
-      # Reap the child process asynchronously to avoid zombies
-      Thread.new do
-        Thread.current.name = "browser-manager-reap"
-        unless ps[:wait_thr].join(1)
-          Process.kill("KILL", ps[:pid]) rescue nil
-        end
-      rescue StandardError
-        nil
+    # Poll until the daemon socket starts responding, up to DAEMON_STARTUP_TIMEOUT.
+    def wait_for_daemon!
+      deadline = Time.now + DAEMON_STARTUP_TIMEOUT
+      until Time.now >= deadline
+        return if daemon_responding?
+        sleep 0.2
       end
-
-      Clacky::Logger.info("[BrowserManager] MCP daemon killed (pid=#{ps[:pid]})")
+      raise "MCP daemon failed to start within #{DAEMON_STARTUP_TIMEOUT}s (check ~/.clacky/mcp-daemon.log)"
     end
 
-    def json_rpc(method, params, id:)
-      JSON.generate({ jsonrpc: "2.0", id: id, method: method, params: params })
-    end
-
-    def read_response(io, target_id:, timeout: 10)
+    # Send one JSON-RPC request over the Unix socket, read one response line.
+    def send_to_daemon(req, timeout:)
       Timeout.timeout(timeout) do
-        loop do
-          line = io.gets
-          break if line.nil?
-          line = line.strip
-          next if line.empty?
-          begin
-            msg = JSON.parse(line)
-            return msg if msg.is_a?(Hash) && msg["id"] == target_id
-          rescue JSON::ParserError
-            next
-          end
+        sock = UNIXSocket.new(SOCKET_PATH)
+        begin
+          sock.puts(JSON.generate(req))
+          line = sock.gets
+          raise "MCP daemon closed connection" if line.nil?
+          JSON.parse(line)
+        ensure
+          sock.close rescue nil
         end
-        nil
       end
     rescue Timeout::Error
-      nil
+      raise "MCP daemon call timed out after #{timeout}s"
+    end
+
+    def pid_alive?
+      return false unless File.exist?(PID_PATH)
+      pid = File.read(PID_PATH).to_i
+      return false if pid <= 0
+      Process.kill(0, pid)
+      true
+    rescue Errno::ESRCH, Errno::EPERM
+      false
+    end
+
+    def kill_daemon!
+      # Try graceful shutdown via socket first.
+      if daemon_responding?
+        begin
+          req = { jsonrpc: "2.0", id: 0, method: "daemon.shutdown" }
+          send_to_daemon(req, timeout: 3)
+        rescue StandardError
+        end
+      end
+
+      # If still running, send SIGTERM by pid.
+      if File.exist?(PID_PATH)
+        pid = File.read(PID_PATH).to_i
+        if pid > 0
+          begin
+            Process.kill("TERM", pid)
+            10.times { break unless pid_alive?; sleep 0.2 }
+            Process.kill("KILL", pid) if pid_alive?
+          rescue Errno::ESRCH
+          end
+        end
+      end
+
+      File.unlink(SOCKET_PATH) if File.exist?(SOCKET_PATH)
+      File.unlink(PID_PATH) if File.exist?(PID_PATH)
     end
 
     def extract_text_content(result)

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -191,9 +191,7 @@ module Clacky
     # Private
     # ------------------------------------------------------------------
 
-    private
-
-    def load_config
+    private def load_config
       return {} unless File.exist?(BROWSER_CONFIG_PATH)
       YAMLCompat.safe_load(File.read(BROWSER_CONFIG_PATH), permitted_classes: [Date, Time, Symbol]) || {}
     rescue StandardError => e

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -70,9 +70,26 @@ module Clacky
     # On Clacky shutdown we intentionally LEAVE the daemon running so that
     # the next Clacky startup can reuse the existing Chrome connection and
     # avoid re-authorization.
+    #
+    # If browser.yml has `close_owned_tabs_on_exit: true`, we first close
+    # every tab owned by Browser instances in this process — so the daemon
+    # is left clean for the next startup.
     def stop
+      close_owned_tabs_if_configured
       Clacky::Logger.info("[BrowserManager] Stop (daemon left running for restart reuse)")
     end
+
+    private def close_owned_tabs_if_configured
+      cfg = load_config
+      return unless cfg["close_owned_tabs_on_exit"] == true
+      require "clacky/tools/browser"
+      Clacky::Tools::Browser.close_all_owned_tabs_across_instances!
+      Clacky::Logger.info("[BrowserManager] Closed all owned tabs on shutdown")
+    rescue StandardError => e
+      Clacky::Logger.warn("[BrowserManager] Failed to close owned tabs on shutdown: #{e.message}")
+    end
+
+    public
 
     # Explicit daemon kill — only used when chrome config changes or on
     # `reload`. NOT called on Clacky shutdown.

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -254,7 +254,7 @@ module Clacky
             Clacky::Logger.info("[HttpServer PID=#{Process.pid}] detached inherited socket fd=#{@inherited_socket.fileno} before shutdown")
           end
           t1 = Thread.new { @channel_manager.stop rescue nil }
-          t2 = Thread.new { Clacky::BrowserManager.instance.stop rescue nil }
+          t2 = Thread.new { Clacky::BrowserManager.instance.disconnect rescue nil }
           t1.join(1.5)
           t2.join(1.5)
           server.shutdown rescue nil

--- a/lib/clacky/server/mcp_daemon.rb
+++ b/lib/clacky/server/mcp_daemon.rb
@@ -40,10 +40,12 @@ module Clacky
     LOG_PATH       = File.expand_path("~/.clacky/mcp-daemon.log").freeze
     READ_TIMEOUT   = 90   # max wait for chrome-devtools-mcp to answer a single call
     HANDSHAKE_TIMEOUT = 15
-    # Reap the daemon after 24h of zero forwarded requests. Held long because the
-    # whole point of the daemon is to outlive Clacky restarts — but unbounded
-    # liveness means the chrome-devtools-mcp Node process (~30–80MB RSS) lingers
-    # forever for users who try the browser once and never again.
+    # Reap the daemon after 24h of zero forwarded requests AND zero keepalives.
+    # Held long because the whole point of the daemon is to outlive Clacky
+    # restarts — but unbounded liveness means the chrome-devtools-mcp Node
+    # process (~30–80MB RSS) lingers forever for users who try the browser once
+    # and never again. Live Clacky-server processes call `daemon.keepalive`
+    # periodically so the daemon survives as long as Clacky cares.
     IDLE_TIMEOUT_SECONDS = 86_400
     IDLE_CHECK_INTERVAL  = 3_600
 
@@ -214,6 +216,15 @@ module Clacky
         if method == "daemon.ping"
           endpoint = File.exist?(ENDPOINT_PATH) ? File.read(ENDPOINT_PATH) : ""
           client.puts(JSON.generate(id: req["id"], result: { ok: true, pid: Process.pid, endpoint: endpoint }))
+          next
+        end
+        if method == "daemon.keepalive"
+          # Heartbeat from a live Clacky process. Resets the idle timer so the
+          # daemon outlives Clacky-server uptime — important for IM-driven agents
+          # where the user isn't at the machine and can't re-authorize Chrome
+          # remote debugging if the daemon were to idle-reap.
+          @activity_mutex.synchronize { @last_activity = Time.now }
+          client.puts(JSON.generate(id: req["id"], result: { ok: true }))
           next
         end
         if method == "daemon.shutdown"

--- a/lib/clacky/server/mcp_daemon.rb
+++ b/lib/clacky/server/mcp_daemon.rb
@@ -13,7 +13,10 @@
 #     forwards to chrome-devtools-mcp and writes the matching response back.
 #   - The chrome-devtools-mcp stdio protocol is single-client; daemon serializes
 #     concurrent client requests with a mutex.
-#   - Daemon auto-exits after IDLE_TIMEOUT seconds with no client activity.
+#   - Daemon exits only on: explicit daemon.shutdown, SIGINT/SIGTERM, or when
+#     chrome-devtools-mcp itself dies. Idle clients do NOT trigger exit — the
+#     whole point of this daemon is to outlive Clacky restarts so Chrome's
+#     remote-debugging authorization sticks.
 #
 # Wire protocol (between Clacky and daemon):
 #   Client → daemon: one JSON-RPC line (utf-8) followed by '\n'
@@ -35,7 +38,6 @@ module Clacky
     PID_PATH       = File.expand_path("~/.clacky/mcp-daemon.pid").freeze
     ENDPOINT_PATH  = File.expand_path("~/.clacky/mcp-daemon.endpoint").freeze
     LOG_PATH       = File.expand_path("~/.clacky/mcp-daemon.log").freeze
-    IDLE_TIMEOUT   = 3600 # exit after 1h of no traffic
     READ_TIMEOUT   = 90   # max wait for chrome-devtools-mcp to answer a single call
     HANDSHAKE_TIMEOUT = 15
 
@@ -55,7 +57,6 @@ module Clacky
       @stdout = nil
       @wait_thr = nil
       @write_mutex = Mutex.new
-      @last_activity = Time.now
     end
 
     def run
@@ -63,7 +64,6 @@ module Clacky
       write_endpoint
       install_signal_handlers
       start_chrome_mcp!
-      start_idle_watcher
       serve!
     rescue => e
       @logger.error("fatal: #{e.class}: #{e.message}\n#{e.backtrace.first(10).join("\n")}")
@@ -71,9 +71,7 @@ module Clacky
       exit 1
     end
 
-    private
-
-    def write_pid
+    private def write_pid
       FileUtils.mkdir_p(File.dirname(PID_PATH))
       File.write(PID_PATH, Process.pid.to_s)
     end
@@ -160,18 +158,7 @@ module Clacky
     end
 
     def start_idle_watcher
-      Thread.new do
-        Thread.current.name = "idle-watcher"
-        loop do
-          sleep 60
-          idle = Time.now - @last_activity
-          if idle > IDLE_TIMEOUT
-            @logger.info("idle for #{idle.to_i}s, exiting")
-            cleanup
-            exit 0
-          end
-        end
-      end
+      # removed: daemon must survive idle periods to preserve Chrome auth
     end
 
     def serve!
@@ -192,7 +179,6 @@ module Clacky
       client.each_line do |line|
         line = line.strip
         next if line.empty?
-        @last_activity = Time.now
 
         req =
           begin

--- a/lib/clacky/server/mcp_daemon.rb
+++ b/lib/clacky/server/mcp_daemon.rb
@@ -40,6 +40,12 @@ module Clacky
     LOG_PATH       = File.expand_path("~/.clacky/mcp-daemon.log").freeze
     READ_TIMEOUT   = 90   # max wait for chrome-devtools-mcp to answer a single call
     HANDSHAKE_TIMEOUT = 15
+    # Reap the daemon after 24h of zero forwarded requests. Held long because the
+    # whole point of the daemon is to outlive Clacky restarts — but unbounded
+    # liveness means the chrome-devtools-mcp Node process (~30–80MB RSS) lingers
+    # forever for users who try the browser once and never again.
+    IDLE_TIMEOUT_SECONDS = 86_400
+    IDLE_CHECK_INTERVAL  = 3_600
 
     def self.run(argv)
       cmd = argv.dup
@@ -57,6 +63,8 @@ module Clacky
       @stdout = nil
       @wait_thr = nil
       @write_mutex = Mutex.new
+      @last_activity = Time.now
+      @activity_mutex = Mutex.new
     end
 
     def run
@@ -64,6 +72,7 @@ module Clacky
       write_endpoint
       install_signal_handlers
       start_chrome_mcp!
+      start_idle_watcher
       serve!
     rescue => e
       @logger.error("fatal: #{e.class}: #{e.message}\n#{e.backtrace.first(10).join("\n")}")
@@ -158,7 +167,20 @@ module Clacky
     end
 
     def start_idle_watcher
-      # removed: daemon must survive idle periods to preserve Chrome auth
+      Thread.new do
+        Thread.current.name = "idle-watcher"
+        loop do
+          sleep IDLE_CHECK_INTERVAL
+          last = @activity_mutex.synchronize { @last_activity }
+          idle = Time.now - last
+          next if idle < IDLE_TIMEOUT_SECONDS
+          @logger.info("idle for #{idle.to_i}s (> #{IDLE_TIMEOUT_SECONDS}s); shutting down")
+          cleanup
+          exit 0
+        end
+      rescue StandardError => e
+        @logger.warn("idle-watcher crashed: #{e.class}: #{e.message}")
+      end
     end
 
     def serve!
@@ -213,6 +235,10 @@ module Clacky
     def forward_to_chrome_mcp(req)
       id = req["id"]
       raise "request missing id" unless id
+
+      # Real activity — reset the idle timer. daemon.ping does NOT call here,
+      # so liveness probes from BrowserManager don't keep an unused daemon alive.
+      @activity_mutex.synchronize { @last_activity = Time.now }
 
       @write_mutex.synchronize do
         @stdin.puts(JSON.generate(req))

--- a/lib/clacky/server/mcp_daemon.rb
+++ b/lib/clacky/server/mcp_daemon.rb
@@ -1,0 +1,259 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# MCP Daemon — long-lived Ruby process that owns chrome-devtools-mcp stdio and
+# exposes it via a Unix socket so multiple Clacky processes (including across
+# restarts) can share the same daemon and avoid Chrome re-authorization.
+#
+# Lifecycle:
+#   - Clacky's BrowserManager spawns this script as a detached process.
+#   - This daemon spawns chrome-devtools-mcp as a subprocess and holds its stdin/stdout.
+#   - It listens on ~/.clacky/mcp-daemon.sock.
+#   - Each client sends one or more JSON-RPC requests (one per line); daemon
+#     forwards to chrome-devtools-mcp and writes the matching response back.
+#   - The chrome-devtools-mcp stdio protocol is single-client; daemon serializes
+#     concurrent client requests with a mutex.
+#   - Daemon auto-exits after IDLE_TIMEOUT seconds with no client activity.
+#
+# Wire protocol (between Clacky and daemon):
+#   Client → daemon: one JSON-RPC line (utf-8) followed by '\n'
+#   Daemon → client: matching JSON-RPC response line (utf-8) followed by '\n'
+#   Special methods (handled by daemon, not forwarded):
+#     "daemon.ping"     → { "id": N, "result": { "ok": true } }
+#     "daemon.shutdown" → daemon exits after responding
+
+require "json"
+require "socket"
+require "fileutils"
+require "open3"
+require "timeout"
+require "logger"
+
+module Clacky
+  class McpDaemon
+    SOCKET_PATH    = File.expand_path("~/.clacky/mcp-daemon.sock").freeze
+    PID_PATH       = File.expand_path("~/.clacky/mcp-daemon.pid").freeze
+    ENDPOINT_PATH  = File.expand_path("~/.clacky/mcp-daemon.endpoint").freeze
+    LOG_PATH       = File.expand_path("~/.clacky/mcp-daemon.log").freeze
+    IDLE_TIMEOUT   = 3600 # exit after 1h of no traffic
+    READ_TIMEOUT   = 90   # max wait for chrome-devtools-mcp to answer a single call
+    HANDSHAKE_TIMEOUT = 15
+
+    def self.run(argv)
+      cmd = argv.dup
+      raise ArgumentError, "usage: mcp_daemon.rb -- chrome-devtools-mcp [args...]" if cmd.empty?
+      new(cmd).run
+    end
+
+    def initialize(chrome_mcp_cmd)
+      @chrome_mcp_cmd = chrome_mcp_cmd
+      @logger = Logger.new(LOG_PATH, 1, 1_000_000)
+      @logger.level = Logger::INFO
+      @logger.formatter = proc { |sev, time, _prog, msg| "[#{time.strftime('%H:%M:%S')}] #{sev} #{msg}\n" }
+
+      @stdin = nil
+      @stdout = nil
+      @wait_thr = nil
+      @write_mutex = Mutex.new
+      @last_activity = Time.now
+    end
+
+    def run
+      write_pid
+      write_endpoint
+      install_signal_handlers
+      start_chrome_mcp!
+      start_idle_watcher
+      serve!
+    rescue => e
+      @logger.error("fatal: #{e.class}: #{e.message}\n#{e.backtrace.first(10).join("\n")}")
+      cleanup
+      exit 1
+    end
+
+    private
+
+    def write_pid
+      FileUtils.mkdir_p(File.dirname(PID_PATH))
+      File.write(PID_PATH, Process.pid.to_s)
+    end
+
+    def write_endpoint
+      idx = @chrome_mcp_cmd.index("--wsEndpoint")
+      endpoint = idx ? @chrome_mcp_cmd[idx + 1].to_s : ""
+      File.write(ENDPOINT_PATH, endpoint)
+    end
+
+    def install_signal_handlers
+      %w[INT TERM].each do |sig|
+        Signal.trap(sig) do
+          @logger.info("received SIG#{sig}, shutting down")
+          cleanup
+          exit 0
+        end
+      end
+    end
+
+    def start_chrome_mcp!
+      @logger.info("starting chrome-devtools-mcp: #{@chrome_mcp_cmd.inspect}")
+      @stdin, @stdout, err_io, @wait_thr = Open3.popen3(*@chrome_mcp_cmd, close_others: true)
+      @stdin.sync = true
+
+      Thread.new do
+        Thread.current.name = "chrome-mcp-stderr"
+        err_io.each_line { |l| @logger.warn("chrome-mcp stderr: #{l.chomp}") }
+      rescue
+      end
+
+      # Exit the daemon if chrome-devtools-mcp dies so the next BrowserManager
+      # call spawns a fresh one (Chrome may have closed, Chrome version changed,
+      # etc.). Without this the daemon would keep responding to ping but every
+      # tool call would EPIPE.
+      Thread.new do
+        Thread.current.name = "chrome-mcp-watchdog"
+        @wait_thr.value
+        @logger.warn("chrome-devtools-mcp exited (status=#{@wait_thr.value.exitstatus}); shutting down daemon")
+        cleanup
+        exit 0
+      end
+
+      perform_mcp_handshake!
+      @logger.info("chrome-devtools-mcp ready (pid=#{@wait_thr.pid})")
+    end
+
+    def perform_mcp_handshake!
+      init_msg = JSON.generate(
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "clacky-mcp-daemon", version: "1.0" }
+        }
+      )
+      @stdin.puts(init_msg)
+
+      resp = read_response_blocking(target_id: 1, timeout: HANDSHAKE_TIMEOUT)
+      raise "MCP initialize handshake timed out" unless resp
+      raise "MCP initialize error: #{resp['error']}" if resp["error"]
+
+      notify_msg = JSON.generate(jsonrpc: "2.0", method: "notifications/initialized", params: {})
+      @stdin.puts(notify_msg)
+    end
+
+    def read_response_blocking(target_id:, timeout:)
+      Timeout.timeout(timeout) do
+        loop do
+          line = @stdout.gets
+          return nil if line.nil?
+          line = line.strip
+          next if line.empty?
+          begin
+            msg = JSON.parse(line)
+            return msg if msg.is_a?(Hash) && msg["id"] == target_id
+          rescue JSON::ParserError
+            next
+          end
+        end
+      end
+    rescue Timeout::Error
+      nil
+    end
+
+    def start_idle_watcher
+      Thread.new do
+        Thread.current.name = "idle-watcher"
+        loop do
+          sleep 60
+          idle = Time.now - @last_activity
+          if idle > IDLE_TIMEOUT
+            @logger.info("idle for #{idle.to_i}s, exiting")
+            cleanup
+            exit 0
+          end
+        end
+      end
+    end
+
+    def serve!
+      FileUtils.mkdir_p(File.dirname(SOCKET_PATH))
+      File.unlink(SOCKET_PATH) if File.exist?(SOCKET_PATH)
+      server = UNIXServer.new(SOCKET_PATH)
+      File.chmod(0o600, SOCKET_PATH)
+      @logger.info("listening on #{SOCKET_PATH}")
+
+      loop do
+        client = server.accept
+        Thread.new(client) { |c| handle_client(c) }
+      end
+    end
+
+    def handle_client(client)
+      Thread.current.name = "client-#{client.object_id}"
+      client.each_line do |line|
+        line = line.strip
+        next if line.empty?
+        @last_activity = Time.now
+
+        req =
+          begin
+            JSON.parse(line)
+          rescue JSON::ParserError => e
+            client.puts(JSON.generate(error: "invalid JSON: #{e.message}"))
+            next
+          end
+
+        method = req["method"]
+        if method == "daemon.ping"
+          endpoint = File.exist?(ENDPOINT_PATH) ? File.read(ENDPOINT_PATH) : ""
+          client.puts(JSON.generate(id: req["id"], result: { ok: true, pid: Process.pid, endpoint: endpoint }))
+          next
+        end
+        if method == "daemon.shutdown"
+          client.puts(JSON.generate(id: req["id"], result: { ok: true }))
+          client.flush
+          @logger.info("client requested shutdown")
+          cleanup
+          exit 0
+        end
+
+        resp = forward_to_chrome_mcp(req)
+        client.puts(JSON.generate(resp))
+      end
+    rescue Errno::EPIPE, IOError
+    ensure
+      client.close rescue nil
+    end
+
+    def forward_to_chrome_mcp(req)
+      id = req["id"]
+      raise "request missing id" unless id
+
+      @write_mutex.synchronize do
+        @stdin.puts(JSON.generate(req))
+        resp = read_response_blocking(target_id: id, timeout: READ_TIMEOUT)
+        return { "jsonrpc" => "2.0", "id" => id, "error" => { "code" => -32000, "message" => "chrome-devtools-mcp timed out after #{READ_TIMEOUT}s" } } unless resp
+        resp
+      end
+    rescue => e
+      @logger.error("forward error: #{e.class}: #{e.message}")
+      { "jsonrpc" => "2.0", "id" => id, "error" => { "code" => -32001, "message" => "#{e.class}: #{e.message}" } }
+    end
+
+    def cleanup
+      File.unlink(SOCKET_PATH) if File.exist?(SOCKET_PATH)
+      File.unlink(PID_PATH) if File.exist?(PID_PATH)
+      File.unlink(ENDPOINT_PATH) if File.exist?(ENDPOINT_PATH)
+      if @wait_thr && @wait_thr.alive?
+        Process.kill("TERM", @wait_thr.pid) rescue nil
+        Thread.new { @wait_thr.join(2) || Process.kill("KILL", @wait_thr.pid) rescue nil }
+      end
+    rescue
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  argv = ARGV.dup
+  argv.shift if argv.first == "--"
+  Clacky::McpDaemon.run(argv)
+end

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -47,41 +47,11 @@ module Clacky
     #   through to a "no active tab" error — the AI is expected to
     #   action=open a new one.
     class Browser < Base
-      # ──────────────────────────────────────────────────────────────────
-      # Instance registry — for graceful "close owned tabs on exit"
-      # ──────────────────────────────────────────────────────────────────
-      @instances        = []
-      @instances_mutex  = Mutex.new
-
-      class << self
-        attr_reader :instances, :instances_mutex
-
-        def register_instance(inst)
-          @instances_mutex.synchronize { @instances << inst }
-        end
-
-        def unregister_instance(inst)
-          @instances_mutex.synchronize { @instances.delete(inst) }
-        end
-
-        # Close every owned tab held by every live Browser instance in this
-        # process. Called on graceful shutdown when browser.yml has
-        # `close_owned_tabs_on_exit: true`. Safe to call multiple times.
-        def close_all_owned_tabs_across_instances!
-          @instances_mutex.synchronize do
-            @instances.dup.each do |inst|
-              inst.close_all_owned_tabs! rescue nil
-            end
-          end
-        end
-      end
-
       def initialize
         super
         @owned_pages  = []     # Array<Integer> — keeps open-order
         @last_page_id = nil    # Integer, must always be ∈ @owned_pages or nil
         @known_page_ids = nil  # Snapshot of all live page ids at start of last act; used to detect new tabs spawned by act
-        self.class.register_instance(self)
       end
 
       self.tool_name = "browser"
@@ -545,27 +515,21 @@ module Clacky
                       msg.include?("tab was closed")
         raise unless page_closed
 
-        # MCP daemon checks getSelectedMcpPage() before every tool call,
-        # even for new_page. If the selected page died we must re-select
-        # a live one first; otherwise restart the daemon as last resort.
-        pages = extract_pages(Clacky::BrowserManager.instance.mcp_call("list_pages")) rescue []
-        alive = pages.find { |p| p[:id] }
-
-        if alive
-          @last_page_id = alive[:id]
-          ensure_page_selected!(tool_name)
-          return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
-        end
-
-        if tool_name == "new_page"
-          # No live tabs anywhere — daemon is stuck on a dead reference.
-          # Force-restart it so Chrome can hand us a fresh page.
-          Clacky::BrowserManager.instance.force_stop
-          sleep 0.5
-          return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
-        end
-
-        raise RuntimeError, "The browser tab was closed. Use action=open to open a new tab, then retry."
+        # The daemon's `selectedPage` reference points at a closed pptr Page.
+        # chrome-devtools-mcp throws this error at the tool entry (before the
+        # handler runs), so even `list_pages`/`select_page` cannot heal it
+        # — every mcp call has to go through `getSelectedMcpPage()` first.
+        #
+        # The only reliable recovery is to restart the daemon: a fresh
+        # chrome-devtools-mcp process reconnects to the same Chrome via the
+        # existing wsEndpoint and rebuilds its page map from scratch, with
+        # `selectedPage` defaulting to whatever Chrome currently has open.
+        Clacky::Logger.warn(
+          "[Browser] Daemon's selected page is dead — restarting daemon to recover"
+        )
+        Clacky::BrowserManager.instance.force_stop
+        # ensure_daemon! runs lazily inside the next mcp_call.
+        Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
       end
 
       # Before every tool call that needs a page context, verify that:
@@ -800,16 +764,6 @@ module Clacky
           @owned_pages.delete(id)
           @last_page_id = nil if @last_page_id == id
         end
-      end
-
-      # Close all tabs owned by this process. Called on process exit when
-      # browser.yml close_owned_tabs_on_exit is true.
-      def close_all_owned_tabs!
-        @owned_pages.dup.each do |id|
-          Clacky::BrowserManager.instance.mcp_call("close_page", { pageId: id }) rescue nil
-        end
-        @owned_pages.clear
-        @last_page_id = nil
       end
 
       # -----------------------------------------------------------------------

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -24,25 +24,75 @@ module Clacky
     # The MCP server process is started once, kept alive across all tool calls,
     # and only restarted when the process dies unexpectedly.
     #
-    # Each Clacky process remembers its own last-selected page id via
-    # @last_page_id.  Before every tool call that needs page context we
-    # re-issue select_page so we don't accidentally operate on a page
-    # chosen by another Clacky process.  This is "optimistic isolation":
-    # not atomic, but good enough for the interactive workloads Clacky
-    # handles.  When the selected page has been closed, mcp_call
-    # automatically retries once after picking a live page.
+    # Page ownership model (strict isolation, since 2026-05):
+    #   Every Browser instance maintains its own @owned_pages — the list
+    #   of Chrome page ids that this Clacky process has explicitly opened
+    #   (via action=open) or adopted (via action=adopt).  Tabs opened by
+    #   other Clacky processes, by the user, or as side-effects of clicks
+    #   (target=_blank / window.open) are INVISIBLE to this process:
+    #     • action=tabs   only lists owned tabs
+    #     • action=focus  only accepts owned tab ids
+    #     • action=close  only closes owned tabs
+    #     • snapshot/act/navigate only operate on the owned @last_page_id
+    #   This eliminates cross-session race conditions on shared pages
+    #   (uid reuse, page-state interference, tab-close-from-under-me) by
+    #   simply forbidding two Clacky processes from touching the same tab.
+    #
+    #   New tabs spawned by a user-initiated act (e.g. middle-click, JS
+    #   window.open) are surfaced to the AI as a hint with id, and must
+    #   be explicitly claimed via action=adopt before any operation can
+    #   be performed against them.
+    #
+    #   When the selected page has been closed externally, mcp_call falls
+    #   through to a "no active tab" error — the AI is expected to
+    #   action=open a new one.
     class Browser < Base
+      # ──────────────────────────────────────────────────────────────────
+      # Instance registry — for graceful "close owned tabs on exit"
+      # ──────────────────────────────────────────────────────────────────
+      @instances        = []
+      @instances_mutex  = Mutex.new
+
+      class << self
+        attr_reader :instances, :instances_mutex
+
+        def register_instance(inst)
+          @instances_mutex.synchronize { @instances << inst }
+        end
+
+        def unregister_instance(inst)
+          @instances_mutex.synchronize { @instances.delete(inst) }
+        end
+
+        # Close every owned tab held by every live Browser instance in this
+        # process. Called on graceful shutdown when browser.yml has
+        # `close_owned_tabs_on_exit: true`. Safe to call multiple times.
+        def close_all_owned_tabs_across_instances!
+          @instances_mutex.synchronize do
+            @instances.dup.each do |inst|
+              inst.close_all_owned_tabs! rescue nil
+            end
+          end
+        end
+      end
+
       def initialize
         super
-        @last_page_id = nil
+        @owned_pages  = []     # Array<Integer> — keeps open-order
+        @last_page_id = nil    # Integer, must always be ∈ @owned_pages or nil
+        @known_page_ids = nil  # Snapshot of all live page ids at start of last act; used to detect new tabs spawned by act
+        self.class.register_instance(self)
       end
 
       self.tool_name = "browser"
       self.tool_description = <<~DESC.strip
         Control user's real Chrome (146+) for web automation. Prefer web_fetch/web_search for read-only pages.
-        Actions: snapshot | act | open | navigate | tabs | focus | close | screenshot | status.
+        Actions: snapshot | act | open | navigate | tabs | focus | close | screenshot | status | adopt.
         Always snapshot(interactive:true) before act. screenshot is EXPENSIVE — use ref= for a single element.
         act kinds: click, dblclick, type, fill, press, hover, scroll, drag, select, wait, evaluate, click_at (coord fallback).
+
+        Page ownership: each Clacky process only sees tabs it opened (action=open) or adopted (action=adopt).
+        Other tabs are invisible. If a click spawns a new tab, the AI will receive a hint with the tab id and must adopt it first.
       DESC
       self.tool_category = "web"
       self.tool_parameters = {
@@ -50,7 +100,7 @@ module Clacky
         properties: {
           action: {
             type: "string",
-            enum: %w[snapshot act open navigate tabs focus close screenshot status]
+            enum: %w[snapshot act open navigate tabs focus close screenshot status adopt]
           },
           kind: {
             type: "string",
@@ -70,7 +120,7 @@ module Clacky
           x:           { type: "number",  description: "click_at x px" },
           y:           { type: "number",  description: "click_at y px" },
           url:         { type: "string",  description: "open/navigate URL" },
-          target_id:   { type: "string",  description: "focus/close tab id" },
+          target_id:   { type: "string",  description: "focus/close/adopt tab id" },
           interactive: { type: "boolean", description: "snapshot: interactive only" },
           compact:     { type: "boolean", description: "snapshot: compact" },
           depth:       { type: "integer", description: "snapshot: max depth" },
@@ -230,8 +280,10 @@ module Clacky
 
         case action.to_s
         when "tabs"
-          pages = extract_pages(mcp_call("list_pages"))
-          { action: "tabs", success: true, profile: "user", output: format_tabs(pages), tabs: pages }
+          all_pages = extract_pages(mcp_call("list_pages"))
+          reconcile_owned_pages!(all_pages)
+          mine = all_pages.select { |p| @owned_pages.include?(p[:id]) }
+          { action: "tabs", success: true, profile: "user", output: format_tabs(mine), tabs: mine }
 
         when "snapshot"
           raw  = mcp_call("take_snapshot")
@@ -245,7 +297,9 @@ module Clacky
           url = require_url(opts)
           return url if url.is_a?(Hash)
           result = mcp_call("new_page", { url: url })
-          @last_page_id = extract_new_page_id(result)
+          new_id = extract_new_page_id(result)
+          @owned_pages << new_id unless @owned_pages.include?(new_id)
+          @last_page_id = new_id
           { action: "open", success: true, profile: "user", url: url, output: "Opened: #{url}" }
 
         when "navigate"
@@ -255,18 +309,38 @@ module Clacky
           { action: "navigate", success: true, profile: "user", url: url, output: "Navigated to: #{url}" }
 
         when "focus"
+          target = require_owned_target_id(opts, "focus")
+          return target if target.is_a?(Hash)
+          mcp_call("select_page", { pageId: target, bringToFront: true })
+          @last_page_id = target
+          { action: "focus", success: true, profile: "user", output: "Focused tab #{target}" }
+
+        when "adopt"
           target_id = opts[:target_id] || opts["target_id"]
-          return { error: "target_id is required for focus. Use action=tabs to list open tabs." } if target_id.nil? || target_id.to_s.empty?
-          mcp_call("select_page", { pageId: target_id.to_i, bringToFront: true })
-          @last_page_id = target_id.to_i
-          { action: "focus", success: true, profile: "user", output: "Focused tab #{target_id}" }
+          return { error: "target_id is required for adopt." } if target_id.nil? || target_id.to_s.empty?
+          target = target_id.to_i
+          # Verify the page actually exists in Chrome.
+          all_pages = extract_pages(mcp_call("list_pages"))
+          unless all_pages.any? { |p| p[:id] == target }
+            return { error: "Tab #{target} does not exist (was it closed?)." }
+          end
+          @owned_pages << target unless @owned_pages.include?(target)
+          mcp_call("select_page", { pageId: target, bringToFront: true })
+          @last_page_id = target
+          { action: "adopt", success: true, profile: "user", output: "Adopted tab #{target}" }
 
         when "close"
-          target_id = opts[:target_id] || opts["target_id"]
-          return { error: "target_id is required for close. Use action=tabs to list open tabs." } if target_id.nil? || target_id.to_s.empty?
-          mcp_call("close_page", { pageId: target_id.to_i })
-          @last_page_id = nil if @last_page_id == target_id.to_i
-          { action: "close", success: true, profile: "user", output: "Closed tab #{target_id}" }
+          target = require_owned_target_id(opts, "close")
+          return target if target.is_a?(Hash)
+          mcp_call("close_page", { pageId: target })
+          @owned_pages.delete(target)
+          @last_page_id = nil if @last_page_id == target
+          # Auto-focus the most-recently opened remaining owned tab, if any.
+          if @last_page_id.nil? && !@owned_pages.empty?
+            @last_page_id = @owned_pages.last
+            mcp_call("select_page", { pageId: @last_page_id, bringToFront: true }) rescue nil
+          end
+          { action: "close", success: true, profile: "user", output: "Closed tab #{target}" }
 
         when "act"
           do_user_act(opts)
@@ -275,9 +349,12 @@ module Clacky
           do_user_screenshot(opts)
 
         when "status"
-          pages = extract_pages(mcp_call("list_pages"))
+          all_pages = extract_pages(mcp_call("list_pages"))
+          reconcile_owned_pages!(all_pages)
+          mine = all_pages.select { |p| @owned_pages.include?(p[:id]) }
           { action: "status", success: true, profile: "user",
-            output: "Browser running. #{pages.size} tab(s) open.", tabs: pages }
+            output: "Browser running. #{mine.size} owned tab(s) (of #{all_pages.size} total).",
+            tabs: mine }
 
         else
           { error: "Action '#{action}' is not supported." }
@@ -287,6 +364,16 @@ module Clacky
       private def do_user_act(opts)
         kind = (opts[:kind] || opts["kind"] || "click").to_s
         ref  = opts[:ref]   || opts["ref"]
+
+        # Capture all live page ids BEFORE acting, so we can detect new tabs
+        # spawned by the action (target=_blank, window.open, ctrl-click, etc.).
+        # Skip cheap actions that can't spawn tabs (wait, scroll, evaluate via JS-only).
+        if %w[click dblclick press hover drag select click_at evaluate].include?(kind)
+          pages = extract_pages(Clacky::BrowserManager.instance.mcp_call("list_pages")) rescue []
+          @known_page_ids = pages.map { |p| p[:id] }
+        else
+          @known_page_ids = nil
+        end
 
         case kind
         when "click", "dblclick"
@@ -340,13 +427,10 @@ module Clacky
           end
 
         when "evaluate"
-          js      = opts[:js] || opts["js"] || ""
-          pages   = extract_pages(mcp_call("list_pages"))
-          sel     = pages.find { |p| p[:selected] }
-          page_id = sel ? sel[:id] : (pages.first && pages.first[:id])
-          eval_args = { function: "() => { return (#{js}) }" }
-          eval_args[:pageId] = page_id if page_id
-          result = mcp_call("evaluate_script", eval_args)
+          js = opts[:js] || opts["js"] || ""
+          # evaluate_script is a PAGE_CONTEXT_TOOL, so ensure_page_selected!
+          # has already validated @last_page_id is owned and selected.
+          result = mcp_call("evaluate_script", { function: "() => { return (#{js}) }" })
           return { action: "act", success: true, profile: "user", output: extract_message(result).to_s }
 
         when "click_at"
@@ -360,7 +444,13 @@ module Clacky
           return { error: "Unknown act kind: #{kind}" }
         end
 
-        { action: "act", success: true, profile: "user", output: "#{kind} completed." }
+        # After any act that might have opened a new tab (click, dblclick, evaluate, etc.),
+        # detect new tabs and surface them to the AI so they can adopt them if needed.
+        hint = detect_new_tab_hint
+        output = "#{kind} completed."
+        output += "\n\n#{hint}" if hint
+
+        { action: "act", success: true, profile: "user", output: output }
       end
 
       SCREENSHOT_MAX_WIDTH        = 800
@@ -471,18 +561,38 @@ module Clacky
         raise RuntimeError, "The browser tab was closed. Use action=open to open a new tab, then retry."
       end
 
-      # If this process remembers a page and the upcoming tool needs page
-      # context, send select_page first so we don't accidentally operate on
-      # a page chosen by another Clacky process.
+      # Before every tool call that needs a page context, verify that:
+      #   1) We have a remembered page
+      #   2) That page is still in our ownership list
+      #   3) Re-issue select_page so Chrome MCP routes the call correctly.
+      #
+      # If the page was closed externally we remove it from @owned_pages and
+      # raise — the AI must open/adopt a new one.
       private def ensure_page_selected!(tool_name)
-        return unless @last_page_id && PAGE_CONTEXT_TOOLS.include?(tool_name)
+        return unless PAGE_CONTEXT_TOOLS.include?(tool_name)
+
+        unless @last_page_id
+          raise "No active tab. Use action=open to create a new tab first."
+        end
+
+        unless @owned_pages.include?(@last_page_id)
+          @last_page_id = nil
+          raise "The active tab was closed or is no longer owned. " \
+                "Use action=open to create a new tab, or action=adopt to claim one."
+        end
 
         Clacky::BrowserManager.instance.mcp_call(
           "select_page",
           { pageId: @last_page_id.to_i, bringToFront: true }
         )
-      rescue RuntimeError
-        # Page may have been closed; let the caller handle it.
+      rescue RuntimeError => e
+        msg = e.message.to_s.downcase
+        if msg.include?("selected page has been closed") || msg.include?("page has been closed") || msg.include?("tab was closed")
+          @owned_pages.delete(@last_page_id)
+          @last_page_id = nil
+          raise "The browser tab was closed. Use action=open to open a new tab, then retry."
+        end
+        raise
       end
 
       # -----------------------------------------------------------------------
@@ -647,6 +757,71 @@ module Clacky
       # -----------------------------------------------------------------------
       # Output helpers
       # -----------------------------------------------------------------------
+
+      # After an act, compare current live page ids with the snapshot taken
+      # before the act. Any new ids that are not yet owned belong to tabs
+      # spawned by the act (target=_blank, window.open, etc.). Surface a
+      # hint so the AI can adopt them.
+      private def detect_new_tab_hint
+        return nil unless @known_page_ids
+
+        current = extract_pages(mcp_call("list_pages")) rescue []
+        current_ids = current.map { |p| p[:id] }
+        new_ids = current_ids - @known_page_ids - @owned_pages
+        @known_page_ids = nil
+
+        return nil if new_ids.empty?
+
+        lines = new_ids.map do |id|
+          page = current.find { |p| p[:id] == id }
+          url  = page ? page[:url] : "unknown"
+          "  • tab #{id}: #{url}"
+        end
+        "New tab(s) detected:\n#{lines.join("\n")}\nUse action=adopt with target_id to claim one."
+      end
+
+      # -----------------------------------------------------------------------
+      # Page ownership helpers
+      # -----------------------------------------------------------------------
+
+      # Remove from @owned_pages any ids that are no longer alive in Chrome.
+      # Also clear @last_page_id if it was among the dead.
+      private def reconcile_owned_pages!(all_pages)
+        alive_ids = all_pages.map { |p| p[:id] }
+        dead = @owned_pages.reject { |id| alive_ids.include?(id) }
+        dead.each do |id|
+          @owned_pages.delete(id)
+          @last_page_id = nil if @last_page_id == id
+        end
+      end
+
+      # Close all tabs owned by this process. Called on process exit when
+      # browser.yml close_owned_tabs_on_exit is true.
+      def close_all_owned_tabs!
+        @owned_pages.dup.each do |id|
+          Clacky::BrowserManager.instance.mcp_call("close_page", { pageId: id }) rescue nil
+        end
+        @owned_pages.clear
+        @last_page_id = nil
+      end
+
+      # -----------------------------------------------------------------------
+      # Ownership-aware parameter helpers
+      # -----------------------------------------------------------------------
+
+      private def require_owned_target_id(opts, action_name)
+        target_id = opts[:target_id] || opts["target_id"]
+        if target_id.nil? || target_id.to_s.empty?
+          return { error: "target_id is required for #{action_name}. Use action=tabs to list your tabs." }
+        end
+        target = target_id.to_i
+        unless @owned_pages.include?(target)
+          return { error: "Tab #{target} is not owned by this session. " \
+                          "Owned tabs: #{@owned_pages.inspect}. " \
+                          "Use action=open to create a new tab, or action=adopt to claim one." }
+        end
+        target
+      end
 
       private def compress_snapshot(output)
         return output if output.empty?

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -419,15 +419,35 @@ module Clacky
       # Chrome MCP
       # -----------------------------------------------------------------------
 
-      # Delegate to BrowserManager. Auto-retries once on "selected page has been closed".
       private def mcp_call(tool_name, arguments = {})
         Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
       rescue RuntimeError => e
-        if e.message.include?("selected page has been closed")
-          raise RuntimeError, "The browser tab was closed. Use action=open to open a new tab, then retry."
-        else
-          raise
+        msg = e.message.to_s.downcase
+        page_closed = msg.include?("selected page has been closed") ||
+                      msg.include?("page has been closed") ||
+                      msg.include?("tab was closed")
+        raise unless page_closed
+
+        # MCP daemon checks getSelectedMcpPage() before every tool call,
+        # even for new_page. If the selected page died we must re-select
+        # a live one first; otherwise restart the daemon as last resort.
+        pages = extract_pages(Clacky::BrowserManager.instance.mcp_call("list_pages")) rescue []
+        alive = pages.find { |p| p[:id] }
+
+        if alive
+          Clacky::BrowserManager.instance.mcp_call("select_page", { pageId: alive[:id].to_i, bringToFront: true })
+          return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
         end
+
+        if tool_name == "new_page"
+          # No live tabs anywhere — daemon is stuck on a dead reference.
+          # Force-restart it so Chrome can hand us a fresh page.
+          Clacky::BrowserManager.instance.force_stop
+          sleep 0.5
+          return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
+        end
+
+        raise RuntimeError, "The browser tab was closed. Use action=open to open a new tab, then retry."
       end
 
       # -----------------------------------------------------------------------

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -516,20 +516,44 @@ module Clacky
         raise unless page_closed
 
         # The daemon's `selectedPage` reference points at a closed pptr Page.
-        # chrome-devtools-mcp throws this error at the tool entry (before the
-        # handler runs), so even `list_pages`/`select_page` cannot heal it
-        # — every mcp call has to go through `getSelectedMcpPage()` first.
+        # As of chrome-devtools-mcp 0.26.0, non-page-scoped tools
+        # (list_pages / select_page / new_page / close_page) no longer route
+        # through getSelectedMcpPage(), so we can heal in-place without
+        # restarting the daemon (which would force a fresh Chrome remote-
+        # debugging authorization prompt).
         #
-        # The only reliable recovery is to restart the daemon: a fresh
-        # chrome-devtools-mcp process reconnects to the same Chrome via the
-        # existing wsEndpoint and rebuilds its page map from scratch, with
-        # `selectedPage` defaulting to whatever Chrome currently has open.
+        # Recovery:
+        #   1. list_pages   — get the live page set (works even when the
+        #                     previously-selected page is dead)
+        #   2. select_page  — pick the first live tab so subsequent
+        #                     page-scoped calls have a valid context
+        #   3. retry the original tool call
+        #
+        # If no live tab exists and the caller is new_page, the new_page call
+        # itself will succeed (it's non-page-scoped). Otherwise we raise and
+        # let the AI know it needs to open a tab first.
         Clacky::Logger.warn(
-          "[Browser] Daemon's selected page is dead — restarting daemon to recover"
+          "[Browser] Selected page is dead — healing via list_pages + select_page"
         )
-        Clacky::BrowserManager.instance.force_stop
-        # ensure_daemon! runs lazily inside the next mcp_call.
-        Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
+
+        pages = extract_pages(Clacky::BrowserManager.instance.mcp_call("list_pages")) rescue []
+        alive = pages.find { |p| p[:id] }
+
+        if alive
+          Clacky::BrowserManager.instance.mcp_call(
+            "select_page",
+            { pageId: alive[:id].to_i, bringToFront: !background_mode? }
+          )
+          return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
+        end
+
+        # No live tabs anywhere. new_page is non-page-scoped on 0.26.0+ and
+        # can run without a selected page; let it through.
+        if tool_name == "new_page"
+          return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
+        end
+
+        raise "The browser tab was closed. Use action=open to open a new tab, then retry."
       end
 
       # Before every tool call that needs a page context, verify that:

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -9,6 +9,7 @@ require "yaml"
 require "base64"
 require "fileutils"
 require "securerandom"
+require "digest"
 require_relative "base"
 
 module Clacky
@@ -52,6 +53,9 @@ module Clacky
         @owned_pages  = []     # Array<Integer> — keeps open-order
         @last_page_id = nil    # Integer, must always be ∈ @owned_pages or nil
         @known_page_ids = nil  # Snapshot of all live page ids at start of last act; used to detect new tabs spawned by act
+        @owned_urls   = {}     # Hash<Integer, String> — id → last-known url, for cross-restart URL match
+        @state_loaded = false  # one-shot lazy load of persisted state on first execute with working_dir
+        @state_path   = nil    # absolute path to this session's persistence file
       end
 
       self.tool_name = "browser"
@@ -113,6 +117,7 @@ module Clacky
           return browser_not_setup_error unless File.exist?(BROWSER_CONFIG_PATH)
           return browser_disabled_error  unless browser_enabled?
         end
+        ensure_state_loaded!(working_dir)
         execute_user_browser(action, opts)
       rescue StandardError => e
         { error: classify_browser_error(e) }
@@ -269,13 +274,17 @@ module Clacky
           result = mcp_call("new_page", { url: url, background: background_mode? })
           new_id = extract_new_page_id(result)
           @owned_pages << new_id unless @owned_pages.include?(new_id)
+          @owned_urls[new_id] = url
           @last_page_id = new_id
+          save_state!
           { action: "open", success: true, profile: "user", url: url, output: "Opened: #{url}" }
 
         when "navigate"
           url = require_url(opts)
           return url if url.is_a?(Hash)
           mcp_call("navigate_page", { type: "url", url: url })
+          @owned_urls[@last_page_id] = url if @last_page_id
+          save_state!
           { action: "navigate", success: true, profile: "user", url: url, output: "Navigated to: #{url}" }
 
         when "focus"
@@ -283,6 +292,7 @@ module Clacky
           return target if target.is_a?(Hash)
           mcp_call("select_page", { pageId: target, bringToFront: true })
           @last_page_id = target
+          save_state!
           { action: "focus", success: true, profile: "user", output: "Focused tab #{target}" }
 
         when "adopt"
@@ -291,12 +301,15 @@ module Clacky
           target = target_id.to_i
           # Verify the page actually exists in Chrome.
           all_pages = extract_pages(mcp_call("list_pages"))
-          unless all_pages.any? { |p| p[:id] == target }
+          adopted = all_pages.find { |p| p[:id] == target }
+          unless adopted
             return { error: "Tab #{target} does not exist (was it closed?)." }
           end
           @owned_pages << target unless @owned_pages.include?(target)
+          @owned_urls[target] = adopted[:url].to_s
           mcp_call("select_page", { pageId: target, bringToFront: true })
           @last_page_id = target
+          save_state!
           { action: "adopt", success: true, profile: "user", output: "Adopted tab #{target}" }
 
         when "close"
@@ -304,12 +317,14 @@ module Clacky
           return target if target.is_a?(Hash)
           mcp_call("close_page", { pageId: target })
           @owned_pages.delete(target)
+          @owned_urls.delete(target)
           @last_page_id = nil if @last_page_id == target
           # Auto-focus the most-recently opened remaining owned tab, if any.
           if @last_page_id.nil? && !@owned_pages.empty?
             @last_page_id = @owned_pages.last
             mcp_call("select_page", { pageId: @last_page_id, bringToFront: true }) rescue nil
           end
+          save_state!
           { action: "close", success: true, profile: "user", output: "Closed tab #{target}" }
 
         when "act"
@@ -784,10 +799,98 @@ module Clacky
       private def reconcile_owned_pages!(all_pages)
         alive_ids = all_pages.map { |p| p[:id] }
         dead = @owned_pages.reject { |id| alive_ids.include?(id) }
+        return if dead.empty?
         dead.each do |id|
           @owned_pages.delete(id)
+          @owned_urls.delete(id)
           @last_page_id = nil if @last_page_id == id
         end
+        save_state!
+      end
+
+      # -----------------------------------------------------------------------
+      # Page ownership persistence
+      # -----------------------------------------------------------------------
+
+      STATE_DIR = File.expand_path("~/.clacky/browser-tabs").freeze
+
+      # On the first execute call that knows the working_dir, load this
+      # session's previously-persisted ownership and reconcile it against the
+      # current set of live pages in Chrome. Subsequent calls are no-ops.
+      #
+      # If MCP isn't reachable yet (Chrome not running), recovery is silently
+      # skipped and will retry on the next execute. This avoids surfacing
+      # restart-time noise — the user's next real action will see the state.
+      private def ensure_state_loaded!(working_dir)
+        return if @state_loaded
+        return if working_dir.nil? || working_dir.to_s.empty?
+
+        @state_path = state_file_for(working_dir)
+        return unless File.exist?(@state_path)
+
+        raw = begin
+                JSON.parse(File.read(@state_path))
+              rescue StandardError
+                nil
+              end
+        return unless raw.is_a?(Hash)
+
+        # Resolve the persisted list against the live pages.
+        live_pages = begin
+                       extract_pages(Clacky::BrowserManager.instance.mcp_call("list_pages"))
+                     rescue StandardError
+                       nil
+                     end
+        return if live_pages.nil?  # try again next call
+
+        live_by_id  = live_pages.each_with_object({}) { |p, h| h[p[:id]] = p }
+        live_by_url = live_pages.each_with_object({}) { |p, h| h[p[:url]] = p if p[:url] }
+
+        owned   = Array(raw["owned"])
+        new_ids = []
+        new_urls = {}
+
+        owned.each do |entry|
+          next unless entry.is_a?(Hash)
+          id  = entry["id"]
+          url = entry["url"].to_s
+          if id.is_a?(Integer) && live_by_id.key?(id)
+            new_ids << id
+            new_urls[id] = live_by_id[id][:url].to_s
+          elsif !url.empty? && live_by_url.key?(url)
+            match_id = live_by_url[url][:id]
+            unless new_ids.include?(match_id)
+              new_ids << match_id
+              new_urls[match_id] = url
+            end
+          end
+        end
+
+        @owned_pages  = new_ids
+        @owned_urls   = new_urls
+        last          = raw["last_id"]
+        @last_page_id = last if last.is_a?(Integer) && new_ids.include?(last)
+        @last_page_id ||= new_ids.last
+        @state_loaded = true
+        # Persist the reconciled view — drops dead ids, may remap on URL match.
+        save_state!
+      end
+
+      private def save_state!
+        return unless @state_path
+        FileUtils.mkdir_p(File.dirname(@state_path))
+        payload = {
+          "owned"   => @owned_pages.map { |id| { "id" => id, "url" => @owned_urls[id].to_s } },
+          "last_id" => @last_page_id
+        }
+        File.write(@state_path, JSON.generate(payload))
+      rescue StandardError => e
+        Clacky::Logger.warn("[Browser] Failed to persist tab state: #{e.message}")
+      end
+
+      private def state_file_for(working_dir)
+        digest = Digest::SHA256.hexdigest(File.expand_path(working_dir))
+        File.join(STATE_DIR, "#{digest}.json")
       end
 
       # -----------------------------------------------------------------------

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -24,10 +24,19 @@ module Clacky
     # The MCP server process is started once, kept alive across all tool calls,
     # and only restarted when the process dies unexpectedly.
     #
-    # pageId is intentionally NOT passed to most MCP calls — the MCP server
-    # maintains its own selected page state. Only focus/close actions need pageId.
-    # When the selected page has been closed, mcp_call automatically retries once.
+    # Each Clacky process remembers its own last-selected page id via
+    # @last_page_id.  Before every tool call that needs page context we
+    # re-issue select_page so we don't accidentally operate on a page
+    # chosen by another Clacky process.  This is "optimistic isolation":
+    # not atomic, but good enough for the interactive workloads Clacky
+    # handles.  When the selected page has been closed, mcp_call
+    # automatically retries once after picking a live page.
     class Browser < Base
+      def initialize
+        super
+        @last_page_id = nil
+      end
+
       self.tool_name = "browser"
       self.tool_description = <<~DESC.strip
         Control user's real Chrome (146+) for web automation. Prefer web_fetch/web_search for read-only pages.
@@ -235,7 +244,8 @@ module Clacky
         when "open"
           url = require_url(opts)
           return url if url.is_a?(Hash)
-          mcp_call("new_page", { url: url })
+          result = mcp_call("new_page", { url: url })
+          @last_page_id = extract_new_page_id(result)
           { action: "open", success: true, profile: "user", url: url, output: "Opened: #{url}" }
 
         when "navigate"
@@ -248,12 +258,14 @@ module Clacky
           target_id = opts[:target_id] || opts["target_id"]
           return { error: "target_id is required for focus. Use action=tabs to list open tabs." } if target_id.nil? || target_id.to_s.empty?
           mcp_call("select_page", { pageId: target_id.to_i, bringToFront: true })
+          @last_page_id = target_id.to_i
           { action: "focus", success: true, profile: "user", output: "Focused tab #{target_id}" }
 
         when "close"
           target_id = opts[:target_id] || opts["target_id"]
           return { error: "target_id is required for close. Use action=tabs to list open tabs." } if target_id.nil? || target_id.to_s.empty?
           mcp_call("close_page", { pageId: target_id.to_i })
+          @last_page_id = nil if @last_page_id == target_id.to_i
           { action: "close", success: true, profile: "user", output: "Closed tab #{target_id}" }
 
         when "act"
@@ -419,7 +431,15 @@ module Clacky
       # Chrome MCP
       # -----------------------------------------------------------------------
 
+      # Tools that operate on the "currently selected page" and therefore
+      # need a preceding select_page if this process has a remembered page.
+      PAGE_CONTEXT_TOOLS = %w[
+        take_snapshot take_screenshot navigate_page
+        click click_at hover drag fill press_key evaluate_script wait_for
+      ].freeze
+
       private def mcp_call(tool_name, arguments = {})
+        ensure_page_selected!(tool_name)
         Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
       rescue RuntimeError => e
         msg = e.message.to_s.downcase
@@ -435,7 +455,8 @@ module Clacky
         alive = pages.find { |p| p[:id] }
 
         if alive
-          Clacky::BrowserManager.instance.mcp_call("select_page", { pageId: alive[:id].to_i, bringToFront: true })
+          @last_page_id = alive[:id]
+          ensure_page_selected!(tool_name)
           return Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
         end
 
@@ -450,9 +471,41 @@ module Clacky
         raise RuntimeError, "The browser tab was closed. Use action=open to open a new tab, then retry."
       end
 
+      # If this process remembers a page and the upcoming tool needs page
+      # context, send select_page first so we don't accidentally operate on
+      # a page chosen by another Clacky process.
+      private def ensure_page_selected!(tool_name)
+        return unless @last_page_id && PAGE_CONTEXT_TOOLS.include?(tool_name)
+
+        Clacky::BrowserManager.instance.mcp_call(
+          "select_page",
+          { pageId: @last_page_id.to_i, bringToFront: true }
+        )
+      rescue RuntimeError
+        # Page may have been closed; let the caller handle it.
+      end
+
       # -----------------------------------------------------------------------
       # MCP response extractors
       # -----------------------------------------------------------------------
+
+      private def extract_new_page_id(result)
+        return nil unless result.is_a?(Hash)
+
+        structured = result["structuredContent"]
+        if structured.is_a?(Hash)
+          return structured["pageId"] if structured["pageId"]
+          pages = structured["pages"]
+          if pages.is_a?(Array)
+            new_page = pages.find { |p| p["selected"] == true }
+            return new_page["id"] if new_page
+          end
+        end
+
+        text = extract_text_content(result)
+        m = text.match(/page\s*id[:\s]+(\d+)/i)
+        m[1].to_i if m
+      end
 
       private def extract_pages(result)
         return [] unless result.is_a?(Hash)

--- a/lib/clacky/tools/browser.rb
+++ b/lib/clacky/tools/browser.rb
@@ -296,7 +296,7 @@ module Clacky
         when "open"
           url = require_url(opts)
           return url if url.is_a?(Hash)
-          result = mcp_call("new_page", { url: url })
+          result = mcp_call("new_page", { url: url, background: background_mode? })
           new_id = extract_new_page_id(result)
           @owned_pages << new_id unless @owned_pages.include?(new_id)
           @last_page_id = new_id
@@ -528,6 +528,13 @@ module Clacky
         click click_at hover drag fill press_key evaluate_script wait_for
       ].freeze
 
+      # Whether the agent should operate the browser silently in the background
+      # (i.e. never steal focus from the user's current tab / terminal).
+      # Default: true. Controlled by ~/.clacky/browser.yml `background_mode`.
+      private def background_mode?
+        Clacky::BrowserManager.instance.background_mode?
+      end
+
       private def mcp_call(tool_name, arguments = {})
         ensure_page_selected!(tool_name)
         Clacky::BrowserManager.instance.mcp_call(tool_name, arguments)
@@ -583,7 +590,7 @@ module Clacky
 
         Clacky::BrowserManager.instance.mcp_call(
           "select_page",
-          { pageId: @last_page_id.to_i, bringToFront: true }
+          { pageId: @last_page_id.to_i, bringToFront: !background_mode? }
         )
       rescue RuntimeError => e
         msg = e.message.to_s.downcase

--- a/spec/clacky/server/browser_manager_spec.rb
+++ b/spec/clacky/server/browser_manager_spec.rb
@@ -3,23 +3,29 @@
 require "spec_helper"
 require "tmpdir"
 require "fileutils"
-require "stringio"
 require "json"
 require "clacky/server/browser_manager"
 require "clacky/tools/browser"
 
 RSpec.describe Clacky::BrowserManager do
-  # Each test gets a fresh instance — avoids singleton state leaking between examples.
   let(:manager) { described_class.new }
 
-  # Temp dir to isolate browser.yml reads/writes from the real ~/.clacky/browser.yml
   let(:tmp_dir)     { Dir.mktmpdir }
   let(:config_path) { File.join(tmp_dir, "browser.yml") }
+  let(:socket_path) { File.join(tmp_dir, "mcp-daemon.sock") }
+  let(:pid_path)    { File.join(tmp_dir, "mcp-daemon.pid") }
+  let(:lock_path)   { File.join(tmp_dir, "mcp-daemon.spawn.lock") }
 
   before do
     stub_const("Clacky::BrowserManager::BROWSER_CONFIG_PATH", config_path)
+    stub_const("Clacky::BrowserManager::SOCKET_PATH",         socket_path)
+    stub_const("Clacky::BrowserManager::PID_PATH",            pid_path)
+    allow(File).to receive(:expand_path).and_call_original
+    allow(File).to receive(:expand_path).with("~/.clacky/mcp-daemon.spawn.lock").and_return(lock_path)
+    allow(File).to receive(:expand_path).with("~/.clacky/mcp-daemon.spawn.log").and_return(File.join(tmp_dir, "mcp-daemon.spawn.log"))
     allow(Clacky::Logger).to receive(:info)
     allow(Clacky::Logger).to receive(:warn)
+    allow(Clacky::Logger).to receive(:debug)
   end
 
   after { FileUtils.rm_rf(tmp_dir) }
@@ -32,29 +38,21 @@ RSpec.describe Clacky::BrowserManager do
     File.write(config_path, hash.to_yaml)
   end
 
-  # Inject a fake live daemon into the manager's @process ivar.
-  # Stubs process_alive? to return true so callers don't need to pre-fill
-  # responses in fake_stdout.
-  def inject_process(responses = [])
-    all_output   = responses.map { |r| r + "\n" }.join
-    fake_stdin   = StringIO.new
-    fake_stdout  = StringIO.new(all_output)
-    fake_wait    = double("wait_thr", alive?: true, pid: 99_888)
-    allow(fake_wait).to receive(:join).and_return(fake_wait)
-    manager.instance_variable_set(:@process, {
-      stdin:    fake_stdin,
-      stdout:   fake_stdout,
-      pid:      99_888,
-      wait_thr: fake_wait
-    })
-    allow(manager).to receive(:process_alive?).and_return(true)
-    [fake_stdin, fake_stdout]
+  def stub_daemon_responsive(endpoint: "")
+    ping_result = { "result" => { "ok" => true, "endpoint" => endpoint } }
+    allow(manager).to receive(:send_to_daemon) do |req, **|
+      case req[:method]
+      when "daemon.ping"     then ping_result
+      when "daemon.shutdown" then { "result" => { "ok" => true } }
+      else
+        raise "unexpected send_to_daemon call in stub: #{req[:method]}"
+      end
+    end
+    FileUtils.touch(socket_path)
   end
 
-  def json_rpc_response(id:, result: nil, error: nil)
-    msg = { "jsonrpc" => "2.0", "id" => id }
-    result ? msg["result"] = result : msg["error"] = error
-    JSON.generate(msg)
+  def stub_daemon_unresponsive
+    allow(manager).to receive(:send_to_daemon).and_raise(Errno::ECONNREFUSED)
   end
 
   # ---------------------------------------------------------------------------
@@ -62,9 +60,7 @@ RSpec.describe Clacky::BrowserManager do
   # ---------------------------------------------------------------------------
   describe ".instance" do
     it "returns the same object on repeated calls" do
-      a = described_class.instance
-      b = described_class.instance
-      expect(a).to be(b)
+      expect(described_class.instance).to be(described_class.instance)
     end
 
     it "is a BrowserManager" do
@@ -83,8 +79,8 @@ RSpec.describe Clacky::BrowserManager do
       end
     end
 
-    context "when configured: false" do
-      before { write_config("configured" => false) }
+    context "when enabled is missing or false" do
+      before { write_config("enabled" => false) }
 
       it "does not start a daemon thread" do
         expect(Thread).not_to receive(:new)
@@ -96,10 +92,10 @@ RSpec.describe Clacky::BrowserManager do
       before { write_config("enabled" => true, "chrome_version" => "148") }
 
       it "spawns a background thread to pre-warm the daemon" do
-        thread_spawned = false
-        allow(Thread).to receive(:new) { thread_spawned = true; Thread.current }
+        spawned = false
+        allow(Thread).to receive(:new) { spawned = true; Thread.current }
         manager.start
-        expect(thread_spawned).to be true
+        expect(spawned).to be true
       end
     end
   end
@@ -108,14 +104,20 @@ RSpec.describe Clacky::BrowserManager do
   # #stop
   # ---------------------------------------------------------------------------
   describe "#stop" do
-    it "is a no-op when no daemon is running" do
+    it "is a no-op even when a daemon is running (daemon survives Clacky shutdown)" do
+      stub_daemon_responsive
+      expect(manager).not_to receive(:kill_daemon!)
       expect { manager.stop }.not_to raise_error
     end
+  end
 
-    it "kills the daemon and clears @process" do
-      inject_process
-      manager.stop
-      expect(manager.instance_variable_get(:@process)).to be_nil
+  # ---------------------------------------------------------------------------
+  # #force_stop
+  # ---------------------------------------------------------------------------
+  describe "#force_stop" do
+    it "kills the daemon under the mutex" do
+      expect(manager).to receive(:kill_daemon!)
+      manager.force_stop
     end
   end
 
@@ -123,35 +125,36 @@ RSpec.describe Clacky::BrowserManager do
   # #reload
   # ---------------------------------------------------------------------------
   describe "#reload" do
-    it "stops any existing daemon" do
-      inject_process
-      write_config("configured" => false)
+    it "always kills any existing daemon first" do
+      expect(manager).to receive(:kill_daemon!)
       manager.reload
-      expect(manager.instance_variable_get(:@process)).to be_nil
     end
 
-    context "when yml is now enabled: true" do
+    context "when yml says enabled: true" do
       before { write_config("enabled" => true, "chrome_version" => "148") }
 
       it "spawns a restart thread" do
-        thread_spawned = false
-        allow(Thread).to receive(:new) { thread_spawned = true; Thread.current }
+        allow(manager).to receive(:kill_daemon!)
+        spawned = false
+        allow(Thread).to receive(:new) { spawned = true; Thread.current }
         manager.reload
-        expect(thread_spawned).to be true
+        expect(spawned).to be true
       end
     end
 
-    context "when yml is configured: false" do
-      before { write_config("configured" => false) }
+    context "when yml says enabled: false" do
+      before { write_config("enabled" => false) }
 
-      it "does not spawn a thread" do
+      it "does not spawn a restart thread" do
+        allow(manager).to receive(:kill_daemon!)
         expect(Thread).not_to receive(:new)
         manager.reload
       end
     end
 
     context "when yml does not exist" do
-      it "does not spawn a thread" do
+      it "does not spawn a restart thread" do
+        allow(manager).to receive(:kill_daemon!)
         expect(Thread).not_to receive(:new)
         manager.reload
       end
@@ -164,6 +167,7 @@ RSpec.describe Clacky::BrowserManager do
   describe "#status" do
     context "when browser.yml is missing" do
       it "returns not enabled and daemon not running" do
+        stub_daemon_unresponsive
         s = manager.status
         expect(s[:enabled]).to be false
         expect(s[:daemon_running]).to be false
@@ -171,195 +175,197 @@ RSpec.describe Clacky::BrowserManager do
       end
     end
 
-    context "when enabled: true and chrome_version set" do
+    context "when enabled: true and chrome_version is set" do
       before { write_config("enabled" => true, "chrome_version" => "148") }
 
       it "reports enabled: true" do
+        stub_daemon_unresponsive
         expect(manager.status[:enabled]).to be true
       end
 
       it "returns the chrome_version" do
+        stub_daemon_unresponsive
         expect(manager.status[:chrome_version]).to eq("148")
       end
 
-      it "reports daemon_running: false when no process" do
+      it "reports daemon_running: false when daemon is unreachable" do
+        stub_daemon_unresponsive
         expect(manager.status[:daemon_running]).to be false
       end
 
-      it "reports daemon_running: true when process is alive" do
-        inject_process
+      it "reports daemon_running: true when daemon answers daemon.ping" do
+        stub_daemon_responsive
         expect(manager.status[:daemon_running]).to be true
       end
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Private: #process_alive?
+  # Private: #daemon_responding?
   # ---------------------------------------------------------------------------
-  describe "#process_alive? (private)" do
-    it "returns false when @process is nil" do
-      expect(manager.send(:process_alive?)).to be false
+  describe "#daemon_responding? (private)" do
+    it "returns false when the socket file is missing" do
+      expect(manager.send(:daemon_responding?)).to be false
     end
 
-    it "returns false when wait_thr reports the process has exited" do
-      fake_wait = double("wait_thr", alive?: false)
-      manager.instance_variable_set(:@process, {
-        stdin: StringIO.new, stdout: StringIO.new, pid: 99_999, wait_thr: fake_wait
-      })
-      expect(manager.send(:process_alive?)).to be false
+    it "returns true when daemon.ping result includes ok: true" do
+      stub_daemon_responsive
+      expect(manager.send(:daemon_responding?)).to be true
     end
 
-    it "returns false when wait_thr is nil (process not tracked)" do
-      manager.instance_variable_set(:@process, {
-        stdin: StringIO.new, stdout: StringIO.new, pid: 99_999, wait_thr: nil
-      })
-      expect(manager.send(:process_alive?)).to be false
+    it "returns false when daemon.ping result is missing ok" do
+      FileUtils.touch(socket_path)
+      allow(manager).to receive(:send_to_daemon).and_return({ "result" => {} })
+      expect(!!manager.send(:daemon_responding?)).to be false
     end
 
-    it "returns true when wait_thr is alive and IO handles are open" do
-      fake_wait = double("wait_thr", alive?: true)
-      manager.instance_variable_set(:@process, {
-        stdin: StringIO.new, stdout: StringIO.new, pid: 99_888, wait_thr: fake_wait
-      })
-      expect(manager.send(:process_alive?)).to be true
-    end
-
-
-  end
-
-  # ---------------------------------------------------------------------------
-  # Private: #kill_process!
-  # ---------------------------------------------------------------------------
-  describe "#kill_process! (private)" do
-    it "is a no-op when @process is nil" do
-      expect { manager.send(:kill_process!) }.not_to raise_error
-    end
-
-    it "clears @process after killing" do
-      inject_process
-      manager.send(:kill_process!)
-      expect(manager.instance_variable_get(:@process)).to be_nil
+    it "returns false when send_to_daemon raises" do
+      FileUtils.touch(socket_path)
+      allow(manager).to receive(:send_to_daemon).and_raise(Errno::ECONNREFUSED)
+      expect(manager.send(:daemon_responding?)).to be false
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Private: #ensure_process!
+  # Private: #daemon_endpoint
   # ---------------------------------------------------------------------------
-  describe "#ensure_process! (private)" do
-    it "does nothing if process is already alive" do
-      inject_process
-      expect(Open3).not_to receive(:popen3)
-      manager.send(:ensure_process!)
-      expect(manager.instance_variable_get(:@process)[:pid]).to eq(99_888)
+  describe "#daemon_endpoint (private)" do
+    it "returns empty string when socket file is missing" do
+      expect(manager.send(:daemon_endpoint)).to eq("")
     end
 
-    it "starts a new daemon and completes the MCP handshake" do
-      # Mock browser detection to return success
-      allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({
-        status: :ok,
-        mode: :ws_endpoint,
-        value: "ws://127.0.0.1:9222/devtools/browser/test"
-      })
-
-      init_resp   = json_rpc_response(id: 1, result: { "protocolVersion" => "2024-11-05", "capabilities" => {} })
-      fake_stdin  = StringIO.new
-      fake_stdout = StringIO.new(init_resp + "\n")
-      fake_stderr = StringIO.new
-      fake_wait   = double("wait_thr", pid: 12_345)
-
-      allow(Open3).to receive(:popen3).and_return([fake_stdin, fake_stdout, fake_stderr, fake_wait])
-
-      manager.send(:ensure_process!)
-
-      ps = manager.instance_variable_get(:@process)
-      expect(ps).not_to be_nil
-      expect(ps[:pid]).to eq(12_345)
-      expect(fake_stdin.string).to include('"initialize"')
-      expect(fake_stdin.string).to include('"notifications/initialized"')
+    it "returns the endpoint advertised by daemon.ping" do
+      stub_daemon_responsive(endpoint: "ws://127.0.0.1:9222/devtools/browser/abc")
+      expect(manager.send(:daemon_endpoint)).to eq("ws://127.0.0.1:9222/devtools/browser/abc")
     end
 
-    it "raises when the initialize handshake times out" do
-      # Mock browser detection to return success
-      allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({
-        status: :ok,
-        mode: :ws_endpoint,
-        value: "ws://127.0.0.1:9222/devtools/browser/test"
-      })
+    it "returns empty string when send_to_daemon raises" do
+      FileUtils.touch(socket_path)
+      allow(manager).to receive(:send_to_daemon).and_raise(StandardError)
+      expect(manager.send(:daemon_endpoint)).to eq("")
+    end
+  end
 
-      fake_stdin  = StringIO.new
-      fake_stderr = StringIO.new
-      fake_wait   = double("wait_thr", pid: 12_346)
-
-      allow(Open3).to receive(:popen3).and_return([fake_stdin, StringIO.new, fake_stderr, fake_wait])
-      allow(Process).to receive(:kill).and_return(nil)
-      allow(manager).to receive(:read_response).and_return(nil)
-
-      expect { manager.send(:ensure_process!) }.to raise_error(/initialize handshake timed out/)
+  # ---------------------------------------------------------------------------
+  # Private: #kill_daemon!
+  # ---------------------------------------------------------------------------
+  describe "#kill_daemon! (private)" do
+    it "is a no-op when no socket and no pid file exist" do
+      expect { manager.send(:kill_daemon!) }.not_to raise_error
     end
 
-    it "raises BrowserNotReachableError when browser is not found" do
+    it "attempts graceful shutdown via daemon.shutdown when daemon is responsive" do
+      stub_daemon_responsive
+      expect(manager).to receive(:send_to_daemon).with(
+        hash_including(method: "daemon.shutdown"), timeout: 3
+      ).and_return({ "result" => { "ok" => true } })
+      # Allow ping calls too
+      allow(manager).to receive(:send_to_daemon).with(
+        hash_including(method: "daemon.ping"), any_args
+      ).and_return({ "result" => { "ok" => true } })
+      manager.send(:kill_daemon!)
+    end
+
+    it "sends SIGTERM to the pid in PID_PATH when present" do
+      File.write(pid_path, "12345")
+      allow(manager).to receive(:daemon_responding?).and_return(false)
+      allow(manager).to receive(:pid_alive?).and_return(true, false)
+      expect(Process).to receive(:kill).with("TERM", 12_345)
+      manager.send(:kill_daemon!)
+    end
+
+    it "removes socket and pid files after killing" do
+      FileUtils.touch(socket_path)
+      File.write(pid_path, "99999")
+      allow(manager).to receive(:daemon_responding?).and_return(false)
+      allow(manager).to receive(:pid_alive?).and_return(false)
+      manager.send(:kill_daemon!)
+      expect(File.exist?(socket_path)).to be false
+      expect(File.exist?(pid_path)).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private: #ensure_daemon!
+  # ---------------------------------------------------------------------------
+  describe "#ensure_daemon! (private)" do
+    it "raises BrowserNotReachableError when Chrome is not running" do
       allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({ status: :not_found })
 
-      expect { manager.send(:ensure_process!) }.to raise_error(
+      expect { manager.send(:ensure_daemon!) }.to raise_error(
         Clacky::BrowserNotReachableError,
         /Chrome\/Edge is not running/
       )
     end
-  end
 
-  # ---------------------------------------------------------------------------
-  # Private: #json_rpc
-  # ---------------------------------------------------------------------------
-  describe "#json_rpc (private)" do
-    it "builds a valid JSON-RPC 2.0 message" do
-      msg    = manager.send(:json_rpc, "tools/call", { name: "list_pages" }, id: 42)
-      parsed = JSON.parse(msg)
-      expect(parsed["jsonrpc"]).to eq("2.0")
-      expect(parsed["id"]).to eq(42)
-      expect(parsed["method"]).to eq("tools/call")
-      expect(parsed["params"]["name"]).to eq("list_pages")
+    it "does nothing if daemon is responding with the matching endpoint" do
+      endpoint = "ws://127.0.0.1:9222/devtools/browser/test"
+      allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({
+        status: :ok, mode: :ws_endpoint, value: endpoint
+      })
+      stub_daemon_responsive(endpoint: endpoint)
+
+      expect(manager).not_to receive(:spawn_daemon!)
+      manager.send(:ensure_daemon!)
+    end
+
+    it "respawns the daemon when the endpoint is stale" do
+      endpoint = "ws://127.0.0.1:9222/devtools/browser/new"
+      allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({
+        status: :ok, mode: :ws_endpoint, value: endpoint
+      })
+      stub_daemon_responsive(endpoint: "ws://127.0.0.1:9222/devtools/browser/old")
+
+      expect(manager).to receive(:kill_daemon!)
+      expect(manager).to receive(:spawn_daemon!)
+      expect(manager).to receive(:wait_for_daemon!)
+      manager.send(:ensure_daemon!)
+    end
+
+    it "spawns and waits when no daemon is running" do
+      endpoint = "ws://127.0.0.1:9222/devtools/browser/test"
+      allow(Clacky::Utils::BrowserDetector).to receive(:detect).and_return({
+        status: :ok, mode: :ws_endpoint, value: endpoint
+      })
+      # No socket file, no daemon
+      expect(manager).to receive(:spawn_daemon!)
+      expect(manager).to receive(:wait_for_daemon!)
+      manager.send(:ensure_daemon!)
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Private: #read_response
+  # Private: #send_to_daemon
   # ---------------------------------------------------------------------------
-  describe "#read_response (private)" do
-    it "reads and returns the matching JSON response" do
-      resp = json_rpc_response(id: 2, result: { "ok" => true })
-      io   = StringIO.new(resp + "\n")
-      result = manager.send(:read_response, io, target_id: 2, timeout: 2)
-      expect(result).to be_a(Hash)
-      expect(result["id"]).to eq(2)
-      expect(result["result"]["ok"]).to be true
+  describe "#send_to_daemon (private)" do
+    it "writes a JSON line to the socket and parses the response line" do
+      server = UNIXServer.new(socket_path)
+      server_thread = Thread.new do
+        client = server.accept
+        line   = client.gets
+        parsed = JSON.parse(line)
+        client.puts(JSON.generate("jsonrpc" => "2.0", "id" => parsed["id"], "result" => { "echoed" => true }))
+        client.close
+      end
+
+      result = manager.send(:send_to_daemon, { jsonrpc: "2.0", id: 7, method: "daemon.ping" }, timeout: 2)
+      server_thread.join
+      server.close
+
+      expect(result["id"]).to eq(7)
+      expect(result["result"]["echoed"]).to be true
     end
 
-    it "skips responses with non-matching ids" do
-      line1 = json_rpc_response(id: 1, result: {})
-      line2 = json_rpc_response(id: 2, result: { "found" => true })
-      io = StringIO.new("#{line1}\n#{line2}\n")
-      result = manager.send(:read_response, io, target_id: 2, timeout: 2)
-      expect(result["result"]["found"]).to be true
-    end
+    it "raises a timeout error when no response arrives" do
+      server = UNIXServer.new(socket_path)
+      hang_thread = Thread.new { server.accept; sleep 3 }
 
-    it "returns nil when IO closes without a match" do
-      io = StringIO.new("")
-      expect(manager.send(:read_response, io, target_id: 99, timeout: 1)).to be_nil
-    end
+      expect {
+        manager.send(:send_to_daemon, { jsonrpc: "2.0", id: 7, method: "daemon.ping" }, timeout: 1)
+      }.to raise_error(/timed out after 1s/)
 
-    it "returns nil on timeout" do
-      read_io, write_io = IO.pipe
-      write_io.close
-      result = manager.send(:read_response, read_io, target_id: 99, timeout: 1)
-      expect(result).to be_nil
-      read_io.close
-    end
-
-    it "skips malformed JSON lines and continues" do
-      valid = json_rpc_response(id: 5, result: { "x" => 1 })
-      io    = StringIO.new("not-json\n#{valid}\n")
-      result = manager.send(:read_response, io, target_id: 5, timeout: 2)
-      expect(result["id"]).to eq(5)
+      hang_thread.kill
+      server.close
     end
   end
 
@@ -367,24 +373,29 @@ RSpec.describe Clacky::BrowserManager do
   # #mcp_call
   # ---------------------------------------------------------------------------
   describe "#mcp_call" do
+    before do
+      allow(manager).to receive(:ensure_daemon!)
+    end
+
     it "sends a tools/call message and returns the result" do
-      call_id  = manager.instance_variable_get(:@call_id)
-      tool_resp = json_rpc_response(id: call_id, result: { "structuredContent" => { "pages" => [] } })
-      fake_stdin, = inject_process([tool_resp])
+      received_req = nil
+      allow(manager).to receive(:send_to_daemon) do |req, **|
+        received_req = req
+        { "jsonrpc" => "2.0", "id" => req[:id], "result" => { "structuredContent" => { "pages" => [] } } }
+      end
 
       result = manager.mcp_call("list_pages", {})
 
       expect(result).to be_a(Hash)
-      expect(fake_stdin.string).to include('"tools/call"')
-      expect(fake_stdin.string).to include('"list_pages"')
+      expect(received_req[:method]).to eq("tools/call")
+      expect(received_req[:params][:name]).to eq("list_pages")
     end
 
     it "increments @call_id on each invocation" do
       id1 = manager.instance_variable_get(:@call_id)
-
-      resp1 = json_rpc_response(id: id1, result: {})
-      resp2 = json_rpc_response(id: id1 + 1, result: {})
-      inject_process([resp1, resp2])
+      allow(manager).to receive(:send_to_daemon) do |req, **|
+        { "jsonrpc" => "2.0", "id" => req[:id], "result" => {} }
+      end
 
       manager.mcp_call("list_pages", {})
       expect(manager.instance_variable_get(:@call_id)).to eq(id1 + 1)
@@ -393,32 +404,47 @@ RSpec.describe Clacky::BrowserManager do
       expect(manager.instance_variable_get(:@call_id)).to eq(id1 + 2)
     end
 
-    it "raises on timeout but keeps the daemon alive" do
-      inject_process([])  # empty stdout → no response
-      allow(manager).to receive(:read_response).and_return(nil)
-
-      expect { manager.mcp_call("list_pages", {}) }.to raise_error(/timed out/)
-      # Process must NOT be killed — it may still be healthy
-      expect(manager.instance_variable_get(:@process)).not_to be_nil
-    end
-
     it "raises on JSON-RPC error response" do
-      call_id  = manager.instance_variable_get(:@call_id)
-      err_resp = json_rpc_response(id: call_id, error: { "message" => "some rpc error" })
-      inject_process([err_resp])
+      allow(manager).to receive(:send_to_daemon) do |req, **|
+        { "jsonrpc" => "2.0", "id" => req[:id], "error" => { "message" => "some rpc error" } }
+      end
 
       expect { manager.mcp_call("list_pages", {}) }.to raise_error(/some rpc error/)
     end
 
     it "raises when result has isError: true" do
-      call_id  = manager.instance_variable_get(:@call_id)
-      err_resp = json_rpc_response(id: call_id, result: {
-        "isError" => true,
-        "content" => [{ "type" => "text", "text" => "navigation failed" }]
-      })
-      inject_process([err_resp])
+      allow(manager).to receive(:send_to_daemon) do |req, **|
+        {
+          "jsonrpc" => "2.0", "id" => req[:id],
+          "result" => {
+            "isError" => true,
+            "content" => [{ "type" => "text", "text" => "navigation failed" }]
+          }
+        }
+      end
 
       expect { manager.mcp_call("navigate_page", { url: "bad" }) }.to raise_error(/navigation failed/)
+    end
+
+    it "retries once when the socket connection is refused, then re-raises" do
+      attempts = 0
+      allow(manager).to receive(:send_to_daemon) do
+        attempts += 1
+        raise Errno::ECONNREFUSED
+      end
+
+      expect { manager.mcp_call("list_pages", {}) }.to raise_error(Errno::ECONNREFUSED)
+      expect(attempts).to eq(2)
+    end
+
+    it "wraps BrowserNotReachableError into Clacky::AgentError" do
+      allow(manager).to receive(:ensure_daemon!).and_raise(
+        Clacky::BrowserNotReachableError, "Chrome not running"
+      )
+
+      expect { manager.mcp_call("list_pages", {}) }.to raise_error(
+        Clacky::AgentError, /Chrome not running/
+      )
     end
   end
 
@@ -431,15 +457,36 @@ RSpec.describe Clacky::BrowserManager do
     end
 
     it "returns parsed YAML when file exists" do
-      write_config("configured" => true, "chrome_version" => "148")
+      write_config("enabled" => true, "chrome_version" => "148")
       cfg = manager.send(:load_config)
-      expect(cfg["configured"]).to be true
+      expect(cfg["enabled"]).to be true
       expect(cfg["chrome_version"]).to eq("148")
     end
 
     it "returns {} when file is malformed" do
       File.write(config_path, ":\tinvalid:\n  yaml: [unclosed")
       expect(manager.send(:load_config)).to eq({})
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private: #build_chrome_mcp_command
+  # ---------------------------------------------------------------------------
+  describe "#build_chrome_mcp_command (private)" do
+    it "builds the chrome-devtools-mcp argv with --wsEndpoint for :ws_endpoint detection" do
+      cmd = manager.send(:build_chrome_mcp_command, {
+        mode: :ws_endpoint, value: "ws://127.0.0.1:9222/devtools/browser/abc"
+      })
+      expect(cmd.first).to eq("chrome-devtools-mcp")
+      expect(cmd).to include("--wsEndpoint", "ws://127.0.0.1:9222/devtools/browser/abc")
+      expect(cmd).to include("--experimentalStructuredContent")
+      expect(cmd).to include("--experimental-page-id-routing")
+    end
+
+    it "raises for unknown detection modes" do
+      expect {
+        manager.send(:build_chrome_mcp_command, { mode: :unknown })
+      }.to raise_error(/Unknown detection mode/)
     end
   end
 end

--- a/spec/clacky/server/browser_manager_spec.rb
+++ b/spec/clacky/server/browser_manager_spec.rb
@@ -449,6 +449,30 @@ RSpec.describe Clacky::BrowserManager do
   end
 
   # ---------------------------------------------------------------------------
+  # background_mode?
+  # ---------------------------------------------------------------------------
+  describe "#background_mode?" do
+    it "returns true when browser.yml is missing (default)" do
+      expect(manager.background_mode?).to be true
+    end
+
+    it "returns true when background_mode is explicitly true" do
+      write_config("enabled" => true, "background_mode" => true)
+      expect(manager.background_mode?).to be true
+    end
+
+    it "returns false when background_mode is explicitly false" do
+      write_config("enabled" => true, "background_mode" => false)
+      expect(manager.background_mode?).to be false
+    end
+
+    it "returns true when background_mode key is absent (default)" do
+      write_config("enabled" => true)
+      expect(manager.background_mode?).to be true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Private: #load_config
   # ---------------------------------------------------------------------------
   describe "#load_config (private)" do

--- a/spec/clacky/server/browser_manager_spec.rb
+++ b/spec/clacky/server/browser_manager_spec.rb
@@ -227,6 +227,114 @@ RSpec.describe Clacky::BrowserManager do
   end
 
   # ---------------------------------------------------------------------------
+  # Private: keepalive
+  # ---------------------------------------------------------------------------
+  describe "keepalive" do
+    describe "#start_keepalive_thread! (private)" do
+      it "spawns a thread tracked in @keepalive_thread" do
+        fake = double("Thread", name: nil, alive?: true, kill: nil)
+        allow(Thread).to receive(:new).and_return(fake)
+        manager.send(:start_keepalive_thread!)
+        expect(manager.instance_variable_get(:@keepalive_thread)).to eq(fake)
+      end
+
+      it "kills any existing keepalive thread first" do
+        old = double("Thread", alive?: true)
+        expect(old).to receive(:kill)
+        manager.instance_variable_set(:@keepalive_thread, old)
+        allow(Thread).to receive(:new).and_return(double("Thread", name: nil, alive?: true, kill: nil))
+        manager.send(:start_keepalive_thread!)
+      end
+    end
+
+    describe "#stop_keepalive_thread! (private)" do
+      it "is a no-op when no thread is running" do
+        expect { manager.send(:stop_keepalive_thread!) }.not_to raise_error
+        expect(manager.instance_variable_get(:@keepalive_thread)).to be_nil
+      end
+
+      it "kills the tracked thread and clears the slot" do
+        thr = double("Thread", alive?: true)
+        expect(thr).to receive(:kill)
+        manager.instance_variable_set(:@keepalive_thread, thr)
+        manager.send(:stop_keepalive_thread!)
+        expect(manager.instance_variable_get(:@keepalive_thread)).to be_nil
+      end
+    end
+
+    describe "#send_daemon_keepalive (private)" do
+      it "is a no-op when the socket file is missing" do
+        expect(manager).not_to receive(:send_to_daemon)
+        manager.send(:send_daemon_keepalive)
+      end
+
+      it "sends daemon.keepalive when socket exists" do
+        FileUtils.touch(socket_path)
+        expect(manager).to receive(:send_to_daemon).with(
+          hash_including(method: "daemon.keepalive"), timeout: 2
+        )
+        manager.send(:send_daemon_keepalive)
+      end
+
+      it "swallows errors silently" do
+        FileUtils.touch(socket_path)
+        allow(manager).to receive(:send_to_daemon).and_raise(Errno::ECONNREFUSED)
+        expect { manager.send(:send_daemon_keepalive) }.not_to raise_error
+      end
+    end
+
+    describe "#start (lifecycle integration)" do
+      it "starts a keepalive thread when enabled" do
+        write_config("enabled" => true, "chrome_version" => "148")
+        allow(Thread).to receive(:new).and_return(double("Thread", name: nil, alive?: true, kill: nil))
+        expect(manager).to receive(:start_keepalive_thread!)
+        manager.start
+      end
+
+      it "does not start a keepalive thread when disabled" do
+        write_config("enabled" => false)
+        expect(manager).not_to receive(:start_keepalive_thread!)
+        manager.start
+      end
+    end
+
+    describe "#reload (lifecycle integration)" do
+      it "stops the existing keepalive thread before killing the daemon" do
+        write_config("enabled" => true, "chrome_version" => "148")
+        allow(manager).to receive(:kill_daemon!)
+        allow(Thread).to receive(:new).and_return(double("Thread", name: nil, alive?: true, kill: nil))
+        expect(manager).to receive(:stop_keepalive_thread!)
+        manager.reload
+      end
+
+      it "starts a new keepalive thread when reload leaves browser enabled" do
+        write_config("enabled" => true, "chrome_version" => "148")
+        allow(manager).to receive(:kill_daemon!)
+        allow(manager).to receive(:stop_keepalive_thread!)
+        allow(Thread).to receive(:new).and_return(double("Thread", name: nil, alive?: true, kill: nil))
+        expect(manager).to receive(:start_keepalive_thread!)
+        manager.reload
+      end
+
+      it "does not start a keepalive thread when reload leaves browser disabled" do
+        write_config("enabled" => false)
+        allow(manager).to receive(:kill_daemon!)
+        allow(manager).to receive(:stop_keepalive_thread!)
+        expect(manager).not_to receive(:start_keepalive_thread!)
+        manager.reload
+      end
+    end
+
+    describe "#terminate_daemon!" do
+      it "stops the keepalive thread along with the daemon" do
+        allow(manager).to receive(:kill_daemon!)
+        expect(manager).to receive(:stop_keepalive_thread!)
+        manager.terminate_daemon!
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Private: #daemon_endpoint
   # ---------------------------------------------------------------------------
   describe "#daemon_endpoint (private)" do

--- a/spec/clacky/server/browser_manager_spec.rb
+++ b/spec/clacky/server/browser_manager_spec.rb
@@ -101,23 +101,23 @@ RSpec.describe Clacky::BrowserManager do
   end
 
   # ---------------------------------------------------------------------------
-  # #stop
+  # #disconnect
   # ---------------------------------------------------------------------------
-  describe "#stop" do
+  describe "#disconnect" do
     it "is a no-op even when a daemon is running (daemon survives Clacky shutdown)" do
       stub_daemon_responsive
       expect(manager).not_to receive(:kill_daemon!)
-      expect { manager.stop }.not_to raise_error
+      expect { manager.disconnect }.not_to raise_error
     end
   end
 
   # ---------------------------------------------------------------------------
-  # #force_stop
+  # #terminate_daemon!
   # ---------------------------------------------------------------------------
-  describe "#force_stop" do
+  describe "#terminate_daemon!" do
     it "kills the daemon under the mutex" do
       expect(manager).to receive(:kill_daemon!)
-      manager.force_stop
+      manager.terminate_daemon!
     end
   end
 
@@ -511,6 +511,33 @@ RSpec.describe Clacky::BrowserManager do
       expect {
         manager.send(:build_chrome_mcp_command, { mode: :unknown })
       }.to raise_error(/Unknown detection mode/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #rotate_log_if_oversized (private)
+  # ---------------------------------------------------------------------------
+  describe "#rotate_log_if_oversized (private)" do
+    let(:log_path) { File.join(tmp_dir, "spawn.log") }
+
+    it "is a no-op when the log does not exist" do
+      manager.send(:rotate_log_if_oversized, log_path)
+      expect(File.exist?(log_path)).to be false
+    end
+
+    it "leaves a small log in place" do
+      File.write(log_path, "small")
+      manager.send(:rotate_log_if_oversized, log_path)
+      expect(File.exist?(log_path)).to be true
+      expect(File.exist?("#{log_path}.1")).to be false
+    end
+
+    it "renames an oversized log to .1 and clears the original" do
+      stub_const("Clacky::BrowserManager::SPAWN_LOG_MAX_BYTES", 16)
+      File.write(log_path, "x" * 32)
+      manager.send(:rotate_log_if_oversized, log_path)
+      expect(File.exist?("#{log_path}.1")).to be true
+      expect(File.exist?(log_path)).to be false
     end
   end
 end

--- a/spec/clacky/tools/browser_spec.rb
+++ b/spec/clacky/tools/browser_spec.rb
@@ -338,43 +338,6 @@ RSpec.describe Clacky::Tools::Browser do
   describe "page ownership" do
     let(:tool) { described_class.new }
 
-    describe "#close_all_owned_tabs!" do
-      it "clears owned_pages and last_page_id" do
-        tool.instance_variable_set(:@owned_pages,  [1, 2, 3])
-        tool.instance_variable_set(:@last_page_id, 2)
-
-        manager = double("BrowserManager")
-        allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
-        allow(manager).to receive(:mcp_call).and_return({})
-
-        tool.close_all_owned_tabs!
-
-        expect(tool.instance_variable_get(:@owned_pages)).to eq([])
-        expect(tool.instance_variable_get(:@last_page_id)).to be_nil
-      end
-
-      it "calls mcp_call(close_page) for every owned tab" do
-        tool.instance_variable_set(:@owned_pages,  [5, 6])
-        manager = double("BrowserManager")
-        allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
-
-        expect(manager).to receive(:mcp_call).with("close_page", { pageId: 5 })
-        expect(manager).to receive(:mcp_call).with("close_page", { pageId: 6 })
-
-        tool.close_all_owned_tabs!
-      end
-
-      it "is resilient to mcp_call raising" do
-        tool.instance_variable_set(:@owned_pages, [7])
-        manager = double("BrowserManager")
-        allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
-        allow(manager).to receive(:mcp_call).and_raise("Chrome unreachable")
-
-        expect { tool.close_all_owned_tabs! }.not_to raise_error
-        expect(tool.instance_variable_get(:@owned_pages)).to eq([])
-      end
-    end
-
     describe "#reconcile_owned_pages! (private)" do
       it "removes owned ids that are no longer alive" do
         tool.instance_variable_set(:@owned_pages,  [1, 2, 3])
@@ -403,25 +366,7 @@ RSpec.describe Clacky::Tools::Browser do
       end
     end
 
-    describe "instance registry" do
-      it "registers each new Browser instance" do
-        described_class.instances_mutex.synchronize { described_class.instances.clear }
-        a = described_class.new
-        b = described_class.new
-        expect(described_class.instances).to include(a, b)
-      end
 
-      it "close_all_owned_tabs_across_instances! calls into every live instance" do
-        described_class.instances_mutex.synchronize { described_class.instances.clear }
-        a = described_class.new
-        b = described_class.new
-
-        expect(a).to receive(:close_all_owned_tabs!)
-        expect(b).to receive(:close_all_owned_tabs!)
-
-        described_class.close_all_owned_tabs_across_instances!
-      end
-    end
   end
 
 end

--- a/spec/clacky/tools/browser_spec.rb
+++ b/spec/clacky/tools/browser_spec.rb
@@ -273,18 +273,95 @@ RSpec.describe Clacky::Tools::Browser do
   # ---------------------------------------------------------------------------
   # Tool metadata
   # ---------------------------------------------------------------------------
-  describe "tool metadata" do
-    it "has correct tool_name" do
-      expect(described_class.tool_name).to eq("browser")
+  # ---------------------------------------------------------------------------
+  # Page ownership (Browser instances are isolated from each other)
+  # ---------------------------------------------------------------------------
+  describe "page ownership" do
+    let(:tool) { described_class.new }
+
+    describe "#close_all_owned_tabs!" do
+      it "clears owned_pages and last_page_id" do
+        tool.instance_variable_set(:@owned_pages,  [1, 2, 3])
+        tool.instance_variable_set(:@last_page_id, 2)
+
+        manager = double("BrowserManager")
+        allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
+        allow(manager).to receive(:mcp_call).and_return({})
+
+        tool.close_all_owned_tabs!
+
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([])
+        expect(tool.instance_variable_get(:@last_page_id)).to be_nil
+      end
+
+      it "calls mcp_call(close_page) for every owned tab" do
+        tool.instance_variable_set(:@owned_pages,  [5, 6])
+        manager = double("BrowserManager")
+        allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
+
+        expect(manager).to receive(:mcp_call).with("close_page", { pageId: 5 })
+        expect(manager).to receive(:mcp_call).with("close_page", { pageId: 6 })
+
+        tool.close_all_owned_tabs!
+      end
+
+      it "is resilient to mcp_call raising" do
+        tool.instance_variable_set(:@owned_pages, [7])
+        manager = double("BrowserManager")
+        allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
+        allow(manager).to receive(:mcp_call).and_raise("Chrome unreachable")
+
+        expect { tool.close_all_owned_tabs! }.not_to raise_error
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([])
+      end
     end
 
-    it "has required action parameter" do
-      required = described_class.tool_parameters[:required]
-      expect(required).to include("action")
+    describe "#reconcile_owned_pages! (private)" do
+      it "removes owned ids that are no longer alive" do
+        tool.instance_variable_set(:@owned_pages,  [1, 2, 3])
+        tool.instance_variable_set(:@last_page_id, 2)
+
+        # Only id 1 is still alive
+        live_pages = [{ id: 1, url: "https://a", selected: false }]
+        tool.send(:reconcile_owned_pages!, live_pages)
+
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([1])
+        expect(tool.instance_variable_get(:@last_page_id)).to be_nil
+      end
+
+      it "keeps last_page_id when it is still alive" do
+        tool.instance_variable_set(:@owned_pages,  [1, 2])
+        tool.instance_variable_set(:@last_page_id, 1)
+
+        live_pages = [
+          { id: 1, url: "https://a", selected: true },
+          { id: 2, url: "https://b", selected: false }
+        ]
+        tool.send(:reconcile_owned_pages!, live_pages)
+
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([1, 2])
+        expect(tool.instance_variable_get(:@last_page_id)).to eq(1)
+      end
     end
 
-    it "does not expose a profile parameter (always uses the user's real browser)" do
-      expect(described_class.tool_parameters.dig(:properties, :profile)).to be_nil
+    describe "instance registry" do
+      it "registers each new Browser instance" do
+        described_class.instances_mutex.synchronize { described_class.instances.clear }
+        a = described_class.new
+        b = described_class.new
+        expect(described_class.instances).to include(a, b)
+      end
+
+      it "close_all_owned_tabs_across_instances! calls into every live instance" do
+        described_class.instances_mutex.synchronize { described_class.instances.clear }
+        a = described_class.new
+        b = described_class.new
+
+        expect(a).to receive(:close_all_owned_tabs!)
+        expect(b).to receive(:close_all_owned_tabs!)
+
+        described_class.close_all_owned_tabs_across_instances!
+      end
     end
   end
 

--- a/spec/clacky/tools/browser_spec.rb
+++ b/spec/clacky/tools/browser_spec.rb
@@ -369,4 +369,118 @@ RSpec.describe Clacky::Tools::Browser do
 
   end
 
+  # ---------------------------------------------------------------------------
+  # Persistence — owned pages survive Clacky restarts
+  # ---------------------------------------------------------------------------
+  describe "page ownership persistence" do
+    let(:tool)        { described_class.new }
+    let(:tmp_dir)     { Dir.mktmpdir }
+    let(:working_dir) { File.join(tmp_dir, "project") }
+
+    before do
+      FileUtils.mkdir_p(working_dir)
+      stub_const("Clacky::Tools::Browser::STATE_DIR", File.join(tmp_dir, "browser-tabs"))
+    end
+
+    after { FileUtils.rm_rf(tmp_dir) }
+
+    def state_path
+      digest = Digest::SHA256.hexdigest(File.expand_path(working_dir))
+      File.join(tmp_dir, "browser-tabs", "#{digest}.json")
+    end
+
+    def write_state(payload)
+      FileUtils.mkdir_p(File.dirname(state_path))
+      File.write(state_path, JSON.generate(payload))
+    end
+
+    describe "#ensure_state_loaded! (private)" do
+      it "is a no-op when working_dir is nil" do
+        expect(Clacky::BrowserManager.instance).not_to receive(:mcp_call)
+        tool.send(:ensure_state_loaded!, nil)
+        expect(tool.instance_variable_get(:@state_loaded)).to be false
+      end
+
+      it "is a no-op when the state file does not exist" do
+        expect(Clacky::BrowserManager.instance).not_to receive(:mcp_call)
+        tool.send(:ensure_state_loaded!, working_dir)
+        expect(tool.instance_variable_get(:@state_loaded)).to be false
+      end
+
+      it "restores owned ids that are still alive" do
+        write_state("owned" => [{ "id" => 1, "url" => "https://a" }, { "id" => 2, "url" => "https://b" }],
+                    "last_id" => 2)
+        allow(Clacky::BrowserManager.instance).to receive(:mcp_call).with("list_pages").and_return(
+          "structuredContent" => { "pages" => [
+            { "id" => 1, "url" => "https://a", "selected" => false },
+            { "id" => 2, "url" => "https://b", "selected" => true }
+          ] }
+        )
+
+        tool.send(:ensure_state_loaded!, working_dir)
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([1, 2])
+        expect(tool.instance_variable_get(:@last_page_id)).to eq(2)
+        expect(tool.instance_variable_get(:@state_loaded)).to be true
+      end
+
+      it "drops persisted ids that are no longer alive" do
+        write_state("owned" => [{ "id" => 1, "url" => "https://a" }, { "id" => 99, "url" => "https://dead" }],
+                    "last_id" => 99)
+        allow(Clacky::BrowserManager.instance).to receive(:mcp_call).with("list_pages").and_return(
+          "structuredContent" => { "pages" => [
+            { "id" => 1, "url" => "https://a", "selected" => true }
+          ] }
+        )
+
+        tool.send(:ensure_state_loaded!, working_dir)
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([1])
+        expect(tool.instance_variable_get(:@last_page_id)).to eq(1)
+      end
+
+      it "remaps an id when the daemon respawned but URL still matches" do
+        # Persisted id 7 no longer exists; a different id (42) has the same URL.
+        write_state("owned" => [{ "id" => 7, "url" => "https://example.com/x" }], "last_id" => 7)
+        allow(Clacky::BrowserManager.instance).to receive(:mcp_call).with("list_pages").and_return(
+          "structuredContent" => { "pages" => [
+            { "id" => 42, "url" => "https://example.com/x", "selected" => true }
+          ] }
+        )
+
+        tool.send(:ensure_state_loaded!, working_dir)
+        expect(tool.instance_variable_get(:@owned_pages)).to eq([42])
+        expect(tool.instance_variable_get(:@last_page_id)).to eq(42)
+      end
+
+      it "skips silently when list_pages fails (will retry next call)" do
+        write_state("owned" => [{ "id" => 1, "url" => "https://a" }], "last_id" => 1)
+        allow(Clacky::BrowserManager.instance).to receive(:mcp_call).and_raise("Chrome not running")
+
+        tool.send(:ensure_state_loaded!, working_dir)
+        expect(tool.instance_variable_get(:@state_loaded)).to be false
+      end
+    end
+
+    describe "#save_state! (private)" do
+      it "writes owned pages and last_id to the working_dir-keyed file" do
+        tool.instance_variable_set(:@state_path, state_path)
+        tool.instance_variable_set(:@owned_pages, [10, 20])
+        tool.instance_variable_set(:@owned_urls, { 10 => "https://a", 20 => "https://b" })
+        tool.instance_variable_set(:@last_page_id, 20)
+
+        tool.send(:save_state!)
+
+        raw = JSON.parse(File.read(state_path))
+        expect(raw["owned"]).to eq([
+          { "id" => 10, "url" => "https://a" },
+          { "id" => 20, "url" => "https://b" }
+        ])
+        expect(raw["last_id"]).to eq(20)
+      end
+
+      it "is a no-op when state_path is not set" do
+        tool.instance_variable_set(:@state_path, nil)
+        expect { tool.send(:save_state!) }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/clacky/tools/browser_spec.rb
+++ b/spec/clacky/tools/browser_spec.rb
@@ -274,6 +274,65 @@ RSpec.describe Clacky::Tools::Browser do
   # Tool metadata
   # ---------------------------------------------------------------------------
   # ---------------------------------------------------------------------------
+  # Background mode (agent does not steal focus from user)
+  # ---------------------------------------------------------------------------
+  describe "background_mode" do
+    let(:tool) { described_class.new }
+    let(:manager) { double("BrowserManager") }
+
+    before do
+      allow(Clacky::BrowserManager).to receive(:instance).and_return(manager)
+    end
+
+    describe "#open (action=open)" do
+      it "passes background: true to new_page when background_mode is on" do
+        allow(manager).to receive(:background_mode?).and_return(true)
+        expect(manager).to receive(:mcp_call)
+          .with("new_page", { url: "https://example.com", background: true })
+          .and_return({ "structuredContent" => { "pageId" => 42 } })
+
+        result = tool.send(:execute_user_browser, "open", { url: "https://example.com" })
+        expect(result[:success]).to be true
+      end
+
+      it "passes background: false to new_page when background_mode is off" do
+        allow(manager).to receive(:background_mode?).and_return(false)
+        expect(manager).to receive(:mcp_call)
+          .with("new_page", { url: "https://example.com", background: false })
+          .and_return({ "structuredContent" => { "pageId" => 42 } })
+
+        tool.send(:execute_user_browser, "open", { url: "https://example.com" })
+      end
+    end
+
+    describe "#ensure_page_selected!" do
+      it "passes bringToFront: false when background_mode is on" do
+        tool.instance_variable_set(:@owned_pages, [42])
+        tool.instance_variable_set(:@last_page_id, 42)
+        allow(manager).to receive(:background_mode?).and_return(true)
+
+        expect(manager).to receive(:mcp_call)
+          .with("select_page", { pageId: 42, bringToFront: false })
+          .and_return({})
+
+        tool.send(:ensure_page_selected!, "take_snapshot")
+      end
+
+      it "passes bringToFront: true when background_mode is off" do
+        tool.instance_variable_set(:@owned_pages, [42])
+        tool.instance_variable_set(:@last_page_id, 42)
+        allow(manager).to receive(:background_mode?).and_return(false)
+
+        expect(manager).to receive(:mcp_call)
+          .with("select_page", { pageId: 42, bringToFront: true })
+          .and_return({})
+
+        tool.send(:ensure_page_selected!, "take_snapshot")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Page ownership (Browser instances are isolated from each other)
   # ---------------------------------------------------------------------------
   describe "page ownership" do


### PR DESCRIPTION
## 问题

`browser` tool 每次 Clacky 重启都会重新 spawn 一个 `chrome-devtools-mcp` 进程，Chrome 每次都把它当新的外部调试客户端，弹"要允许远程调试吗"授权窗。

另外 MCP 的 `select_page` 是全局状态，两个 Clacky 进程同时跑会互相覆盖对方选中的 tab——更恶心的是 `McpPage.textSnapshot.idToNode` 里的 uid 是 per-page 的，两个 session 操作同一个 tab 时可能拿到错位的 ref。

## 怎么改的

### MCP Daemon

新增 `lib/clacky/server/mcp_daemon.rb`，一个独立的 Ruby 进程，持有 `chrome-devtools-mcp` 的 stdin/stdout，对外通过 `~/.clacky/mcp-daemon.sock` 暴露 JSON-RPC。Clacky 重启不会杀它，Chrome 的远程调试授权只弹一次。

内部细节：`@write_mutex` 串行化多客户端请求（MCP stdio 是单客户端协议）；收到 `daemon.shutdown` 或 SIGINT/SIGTERM、或 MCP 子进程死掉时退出并清理 socket/pid/endpoint 文件；启动时把 Chrome wsEndpoint 写到 `~/.clacky/mcp-daemon.endpoint`，BrowserManager 每次调用前比对 UUID，Chrome 重启过就 respawn daemon。

24 小时内零 forwarded request 且零 `daemon.keepalive` 才自杀——避免试一次再没用过的用户后台留着 30–80MB 的 Node 进程。但只要还有任何一个 Clacky-server 进程活着就不会被回收：BrowserManager 启动时同时跑一个 keepalive 线程，每 30 分钟敲一次 `daemon.keepalive`（专门只重置 idle 计时器、不走 chrome-devtools-mcp）——保证 IM 场景下用户在外面隔一两天回来用 browser 时 daemon 还活着，不会重弹 Chrome 远程调试授权窗。spawn-time 的 rc-shell 输出落在 `~/.clacky/mcp-daemon.spawn.log`，超过 1MB 滚动到 `.1` 一份，bound 住磁盘。

### BrowserManager 改成 socket 客户端

`start` 检测 daemon 活没活，没活就拉起来；`disconnect`（Clacky 退出时调用）只断本地 socket 不杀 daemon——daemon 活着是设计的一部分，下次启动复用授权；`terminate_daemon!` 显式 kill（只在切配置时调）；`reload`（browser.yml 改了才调）会真的 kill + 重启；`mcp_call` 走 Unix socket 发 JSON-RPC，带超时和 retry；`ensure_daemon!` 调用前做健康检查，处理 endpoint stale 那种边界。

锁拆开了：`@daemon_setup_mutex` 只罩冷路径（ensure_daemon!/kill_daemon!），`@call_id_mutex` 只罩计数器，`send_to_daemon` 本身完全 lock-free——并发 mcp_call 不再互相阻塞，串行化交给 daemon 内部的 `@write_mutex` 处理。

### 严格 Page Ownership

软隔离（只记 `@last_page_id`）挡不住 uid 竞态，所以现在每个 Clacky 进程只能看见自己的 tab。`@owned_pages` 记本进程拥有的 id，`action=open` 自动入列，`action=tabs` 只返回 owned 顺便 reconcile 已关闭的 id，`action=focus` / `close` 拒绝外部 tab 并在错误里附带下一步该怎么做。

click 出来的 `target=_blank` 怎么办？`action=adopt` 显式认领，click/dblclick 后会 diff pre/post `list_pages`，发现新 tab 就给 AI 一个 hint（带 id 和 URL），LLM 自己决定要不要 adopt。

效果上，看不见的 tab 根本不会被这个进程操作，uid 竞态从根上没了。

### Page ownership 跨 Clacky 重启持久化

每个 working_dir 的 owned tab 列表存到 `~/.clacky/browser-tabs/<sha256(File.expand_path(working_dir))>.json`，格式 `{"owned": [{"id": N, "url": "..."}], "last_id": N}`。lazy 加载：第一次 `execute` 时拿 `working_dir` 做 key 找文件，有就调一次 `list_pages` 对照活页——id 还活着直接续用；id 死了但 URL 还能找到就 remap（daemon 被外部 kill 过重 spawn 的情形）；都对不上就丢弃。

任何改 ownership 的入口（open / navigate / focus / adopt / close / reconcile）落盘一次，中间任何步骤异常都安静 skip——下次调用会再试。

结果：Clacky 退出再开，agent 还认识自己之前开的 tab，不会把它们当陌生 tab 拒绝操作。

### 静默后台模式

之前 agent 一调 navigate 就把用户当前 tab 切走，特别讨厌。`~/.clacky/browser.yml` 新增 `background_mode`（默认 true）：`new_page` 传 `background: true`，`select_page` 传 `bringToFront: false`。

AI 在用户工作时默默查资料、填表单，不会切走当前网页或终端。想恢复老行为就把这个 flag 关掉。

### tab 被外部关闭的恢复

用户手动 `⌘W` 关掉 agent 正在用的 tab，下一次 mcp 调用会撞 "selected page has been closed"——daemon 内部 `selectedPage` 还指着已经死了的 pptr Page。

chrome-devtools-mcp 0.26.0（[PR #2030](https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/2030) "only require a page in page-scoped tools"）修了底层：`list_pages` / `select_page` / `new_page` / `close_page` 现在是非 page-scoped 的，不再走 `getSelectedMcpPage()`，所以可以就地恢复，不用重启 daemon。

`mcp_call` 的 rescue 流程：`list_pages` 拿活页 → `select_page` 选第一个活的（`bringToFront` 跟 background_mode 走）→ 重试原调用。一个活页都没了而且原调用就是 `new_page`，那 `new_page` 自己就能跑过去；否则抛清晰错误让 AI 去 `action=open`。

不重启 daemon = WebSocket 长连接还在 = Chrome 不重弹授权窗。

## 改动范围

```
lib/clacky/server/mcp_daemon.rb            | 新增
lib/clacky/server/browser_manager.rb       | 重写（socket 客户端 + daemon 生命周期 + background_mode + 锁拆分）
lib/clacky/tools/browser.rb                | 重写（ownership + adopt + heal-in-place + 跨重启持久化）
spec/clacky/server/browser_manager_spec.rb | 重写 + keepalive 用例
spec/clacky/tools/browser_spec.rb          | 补充 ownership / registry / reconcile / background_mode / 持久化 用例
```

`bundle exec rspec spec/clacky/tools/browser_spec.rb spec/clacky/server/browser_manager_spec.rb` → 111 examples, 0 failures。

## 依赖

`chrome-devtools-mcp >= 0.26.0`。老版本下 tab 被外部关闭时 `list_pages` 自己也会被 `getSelectedMcpPage()` 挡住，没法就地恢复，只能 fallback 到 daemon 重启那条老路（也就意味着授权窗又弹回来）。

