### PR TITLE
feat: add DingTalk channel support via Stream Mode WebSocket

### DIFF
--- a/lib/clacky/default_skills/channel-setup/SKILL.md
+++ b/lib/clacky/default_skills/channel-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: channel-setup
 description: |
-  Configure IM platform channels (Feishu, WeCom, Weixin, Discord, Telegram) for openclacky.
+  Configure IM platform channels (Feishu, WeCom, Weixin, Discord, Telegram, DingTalk) for openclacky.
   Uses browser automation for navigation; guides the user to paste credentials and perform UI steps.
-  Trigger on: "channel setup", "setup feishu", "setup wecom", "setup weixin", "setup wechat", "setup discord", "setup telegram",
+  Trigger on: "channel setup", "setup feishu", "setup wecom", "setup weixin", "setup wechat", "setup discord", "setup telegram", "setup dingtalk",
   "channel config", "channel status", "channel enable", "channel disable", "channel reconfigure", "channel doctor",
-  "send message to weixin", "send message to feishu", "send message to wecom", "send message to discord", "send message to telegram".
+  "send message to weixin", "send message to feishu", "send message to wecom", "send message to discord", "send message to telegram", "send message to dingtalk".
   Subcommands: setup, status, enable <platform>, disable <platform>, reconfigure, doctor, send.
 argument-hint: "setup | status | enable <platform> | disable <platform> | reconfigure | doctor | send <platform> <message>"
 allowed-tools:
@@ -28,13 +28,13 @@ Configure IM platform channels for openclacky.
 
 | User says | Subcommand |
 |---|---|
-| `channel setup`, `setup feishu`, `setup wecom`, `setup weixin`, `setup wechat`, `setup discord`, `setup telegram` | setup |
+| `channel setup`, `setup feishu`, `setup wecom`, `setup weixin`, `setup wechat`, `setup discord`, `setup telegram`, `setup dingtalk` | setup |
 | `channel status` | status |
-| `channel enable feishu/wecom/weixin/discord/telegram` | enable |
-| `channel disable feishu/wecom/weixin/discord/telegram` | disable |
+| `channel enable feishu/wecom/weixin/discord/telegram/dingtalk` | enable |
+| `channel disable feishu/wecom/weixin/discord/telegram/dingtalk` | disable |
 | `channel reconfigure` | reconfigure |
 | `channel doctor` | doctor |
-| `send <message> to weixin/feishu/wecom/discord/telegram` | send |
+| `send <message> to weixin/feishu/wecom/discord/telegram/dingtalk` | send |
 
 ---
 
@@ -68,6 +68,7 @@ wecom      ❌ no     ❌ no     (not configured)
 weixin     ✅ yes    ✅ yes    has_token: true
 discord    ✅ yes    ✅ yes    has_token: true
 telegram   ✅ yes    ✅ yes    has_token: true
+dingtalk   ✅ yes    ✅ yes    client_id: ding_xxx...
 ─────────────────────────────────────────────────────
 ```
 
@@ -76,6 +77,7 @@ telegram   ✅ yes    ✅ yes    has_token: true
 - Weixin: show `has_token: true/false` (token value is never displayed)
 - Discord: show `has_token: true/false` (token value is never displayed)
 - Telegram: show `has_token: true/false` (bot token is never displayed)
+- DingTalk: show `client_id` (truncated to 12 chars)
 
 If the API is unreachable or returns an empty list: "No channels configured yet. Run `/channel-setup setup` to get started."
 
@@ -91,6 +93,7 @@ Ask:
 > 3. Weixin (Personal WeChat via iLink QR login)
 > 4. Discord
 > 5. Telegram (Bot API)
+> 6. DingTalk
 
 ---
 
@@ -479,6 +482,32 @@ Say: "❌ `<platform>` channel disabled."
 
 ---
 
+### DingTalk setup
+
+#### Step 1 — Get QR code
+
+```bash
+ruby "SKILL_DIR/dingtalk_setup.rb" --print-qr
+```
+
+Parse the last line starting with `{` to get `qr_url` and `device_code`. On non-0 exit, show the error and abort.
+
+#### Step 2 — Show QR and wait
+
+Show `qr_url` to the user, ask them to scan with the DingTalk mobile app and tap "Create New Robot", then call `request_user_feedback`.
+
+#### Step 3 — Poll for authorization
+
+```bash
+ruby "SKILL_DIR/dingtalk_setup.rb" --poll "<device_code>"
+```
+
+- **0** → "✅ DingTalk channel configured! Find your robot in DingTalk and send it a message." Stop.
+- **2** → not scanned yet. Ask user to confirm, then re-poll. If output contains `WAITING_TIMEOUT` or `expired`, restart from Step 1.
+- **1** → show the error and abort.
+
+---
+
 ## `reconfigure`
 
 1. Show current config via `GET /api/channels` (mask secrets — show last 4 chars only).
@@ -522,6 +551,13 @@ Check each item, report ✅ / ❌ with remediation:
    ```
    - `/users/@me failed` → ❌ "Discord token invalid or revoked — re-run setup"
    - `authenticated as` with no error → ✅
+7. **DingTalk credentials** (if enabled) — search today's log:
+   ```bash
+   grep -iE "dingtalk-ws|DingTalk.*error|stream.*error" \
+     ~/.clacky/logger/clacky-$(date +%Y-%m-%d).log
+   ```
+   - `WebSocket connected` → ✅
+   - `Stream endpoint error` or `token error` → ❌ "DingTalk credentials invalid — re-run setup"
 
 ---
 
@@ -532,7 +568,7 @@ Proactively send a message to a user via an IM channel adapter.
 ### Parse the request
 
 Extract two things from the user's instruction:
-- **platform** — one of `weixin`, `feishu`, `wecom`, `discord`, `telegram`
+- **platform** — one of `weixin`, `feishu`, `wecom`, `discord`, `telegram`, `dingtalk`
 - **message** — the text content to send
 
 If the platform cannot be inferred, ask the user to clarify.

--- a/lib/clacky/default_skills/channel-setup/dingtalk_setup.rb
+++ b/lib/clacky/default_skills/channel-setup/dingtalk_setup.rb
@@ -1,0 +1,191 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# dingtalk_setup.rb — DingTalk channel setup via Device Flow (QR scan).
+#
+# Modes:
+#   --print-qr            Phase 1+2: call init/begin, print QR URL as JSON, exit immediately.
+#   --poll <device_code>  Phase 3+4+5: poll until SUCCESS, save credentials, wait for WS.
+#
+# Environment:
+#   CLACKY_SERVER_PORT, CLACKY_SERVER_HOST — clacky server coordinates
+
+require "json"
+require "net/http"
+require "net/https"
+require "uri"
+
+DINGTALK_REG_BASE  = "https://oapi.dingtalk.com"
+# Registration source ID assigned by DingTalk (not a brand string — do not rebrand).
+DINGTALK_REG_SOURCE = "DING_DWS_CLAW"
+POLL_INTERVAL = 3
+POLL_TIMEOUT  = 300
+
+CLACKY_SERVER_URL = begin
+  url = "http://#{ENV.fetch("CLACKY_SERVER_HOST")}:#{ENV.fetch("CLACKY_SERVER_PORT")}"
+  uri = URI.parse(url)
+  raise "Invalid CLACKY_SERVER_URL: #{url}" unless uri.is_a?(URI::HTTP) && uri.host && uri.port
+  url
+end
+
+def step(msg);  puts("[dingtalk-setup] #{msg}"); end
+def ok(msg);    puts("[dingtalk-setup] ✅ #{msg}"); end
+def warn(msg);  puts("[dingtalk-setup] ⚠️  #{msg}"); end
+def fail!(msg)
+  puts("[dingtalk-setup] ❌ #{msg}")
+  exit 1
+end
+
+def post_json(url, payload)
+  uri  = URI.parse(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == "https"
+  req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+  req.body = JSON.generate(payload)
+  resp = http.request(req)
+  data = JSON.parse(resp.body)
+  fail! "API error (#{resp.code}): #{data["errmsg"] || resp.body}" if data["errcode"] && data["errcode"] != 0
+  data
+rescue JSON::ParserError => e
+  fail! "JSON parse error from #{url}: #{e.message}"
+end
+
+def server_post(path, body)
+  uri = URI(CLACKY_SERVER_URL)
+  Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 10) do |h|
+    req = Net::HTTP::Post.new(path, "Content-Type" => "application/json")
+    req.body = JSON.generate(body)
+    h.request(req)
+  end
+end
+
+def server_get(path)
+  uri = URI(CLACKY_SERVER_URL)
+  Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 10) do |h|
+    h.request(Net::HTTP::Get.new(path))
+  end
+end
+
+# ── Mode: --print-qr ─────────────────────────────────────────────────────────
+# Call init + begin, print JSON with qr_url / device_code / expires_in, exit 0.
+def mode_print_qr
+  step "Phase 1 — Starting DingTalk Device Flow registration..."
+
+  init_data = post_json("#{DINGTALK_REG_BASE}/app/registration/init",
+                        { source: DINGTALK_REG_SOURCE })
+  nonce = init_data["nonce"].to_s.strip
+  fail! "Missing nonce in init response" if nonce.empty?
+
+  begin_data   = post_json("#{DINGTALK_REG_BASE}/app/registration/begin", { nonce: nonce })
+  device_code  = begin_data["device_code"].to_s.strip
+  qr_url       = begin_data["verification_uri_complete"].to_s.strip
+  expires_in   = (begin_data["expires_in"] || POLL_TIMEOUT).to_i
+
+  fail! "Missing device_code in begin response"  if device_code.empty?
+  fail! "Missing verification_uri_complete"       if qr_url.empty?
+
+  ok "Device Flow started. QR expires in #{expires_in}s."
+  puts JSON.generate({ qr_url: qr_url, device_code: device_code, expires_in: expires_in })
+end
+
+# ── Mode: --poll <device_code> ────────────────────────────────────────────────
+# Poll until SUCCESS or a terminal state. Exits with:
+#   0  — SUCCESS: credentials saved and adapter started
+#   2  — WAITING: user hasn't scanned yet (Agent should ask user to scan and retry)
+#   1  — terminal failure (expired, fail, or server error)
+def mode_poll(device_code, expires_in: POLL_TIMEOUT, interval: POLL_INTERVAL)
+  step "Phase 3 — Checking DingTalk authorization..."
+
+  client_id     = nil
+  client_secret = nil
+  deadline      = Time.now + expires_in
+
+  loop do
+    if Time.now > deadline
+      puts "[dingtalk-setup] WAITING_TIMEOUT"
+      exit 2
+    end
+
+    poll_data = post_json("#{DINGTALK_REG_BASE}/app/registration/poll",
+                          { device_code: device_code })
+    status = poll_data["status"].to_s.upcase
+
+    case status
+    when "WAITING"
+      puts "[dingtalk-setup] WAITING"
+      exit 2
+    when "SUCCESS"
+      client_id     = poll_data["client_id"].to_s.strip
+      client_secret = poll_data["client_secret"].to_s.strip
+      fail! "Authorization succeeded but missing client credentials" if client_id.empty? || client_secret.empty?
+      ok "Authorization complete! client_id=#{client_id}"
+      break
+    when "EXPIRED"
+      fail! "Authorization QR code expired. Please re-run."
+    when "FAIL"
+      fail! "Authorization failed: #{poll_data["fail_reason"] || "unknown reason"}"
+    else
+      warn "Unknown status=#{status}, retrying..."
+      sleep interval
+    end
+  end
+
+  # ── Phase 4: Save credentials to clacky server ─────────────────────────────
+  step "Phase 4 — Saving credentials to clacky server..."
+
+  begin
+    res = server_post("/api/channels/dingtalk",
+                      { client_id: client_id, client_secret: client_secret, enabled: true })
+    if res.code.to_i == 200
+      ok "Credentials saved, DingTalk Stream adapter starting..."
+    else
+      body = JSON.parse(res.body) rescue { "error" => res.body }
+      fail! "Server rejected credentials: #{body["error"] || res.body}"
+    end
+  rescue StandardError => e
+    fail! "Could not reach clacky server: #{e.message}"
+  end
+
+  # ── Phase 5: Wait for Stream Mode WebSocket to connect ─────────────────────
+  step "Phase 5 — Waiting for DingTalk Stream connection..."
+
+  ws_ready    = false
+  ws_deadline = Time.now + 30
+
+  loop do
+    break if Time.now > ws_deadline
+    begin
+      res      = server_get("/api/channels")
+      channels = JSON.parse(res.body)["channels"] || []
+      dingtalk = channels.find { |c| c["platform"] == "dingtalk" }
+      if dingtalk&.fetch("running", false)
+        ws_ready = true
+        break
+      end
+    rescue StandardError => e
+      warn "Channel status check failed: #{e.message}"
+    end
+    sleep 2
+  end
+
+  if ws_ready
+    ok "DingTalk Stream WebSocket connected."
+  else
+    warn "Stream connection not confirmed within 30s — it may still be starting."
+  end
+
+  ok "🎉 DingTalk channel setup complete! Search for your robot in DingTalk to start chatting."
+  ok "   client_id: #{client_id}"
+end
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+case ARGV[0]
+when "--print-qr"
+  mode_print_qr
+when "--poll"
+  device_code = ARGV[1].to_s.strip
+  fail! "Usage: dingtalk_setup.rb --poll <device_code>" if device_code.empty?
+  mode_poll(device_code)
+else
+  fail! "Usage: dingtalk_setup.rb --print-qr | --poll <device_code>"
+end

--- a/lib/clacky/server/channel.rb
+++ b/lib/clacky/server/channel.rb
@@ -26,6 +26,7 @@ require_relative "channel/adapters/wecom/adapter"
 require_relative "channel/adapters/weixin/adapter"
 require_relative "channel/adapters/discord/adapter"
 require_relative "channel/adapters/telegram/adapter"
+require_relative "channel/adapters/dingtalk/adapter"
 
 require_relative "channel/channel_config"
 require_relative "channel/channel_ui_controller"

--- a/lib/clacky/server/channel/adapters/dingtalk/adapter.rb
+++ b/lib/clacky/server/channel/adapters/dingtalk/adapter.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require_relative "../../adapters/base"
+require_relative "stream_client"
+require_relative "api_client"
+
+module Clacky
+  module Channel
+    module Adapters
+      module DingTalk
+        class Adapter < Base
+          def self.platform_id
+            :dingtalk
+          end
+
+          def self.env_keys
+            %w[IM_DINGTALK_CLIENT_ID IM_DINGTALK_CLIENT_SECRET IM_DINGTALK_ALLOWED_USERS]
+          end
+
+          def self.platform_config(data)
+            {
+              client_id:     data["IM_DINGTALK_CLIENT_ID"],
+              client_secret: data["IM_DINGTALK_CLIENT_SECRET"],
+              allowed_users: data["IM_DINGTALK_ALLOWED_USERS"]&.split(",")&.map(&:strip)&.reject(&:empty?)
+            }
+          end
+
+          def self.set_env_data(data, config)
+            data["IM_DINGTALK_CLIENT_ID"]     = config[:client_id]
+            data["IM_DINGTALK_CLIENT_SECRET"]  = config[:client_secret]
+            data["IM_DINGTALK_ALLOWED_USERS"]  = Array(config[:allowed_users]).join(",")
+          end
+
+          def self.test_connection(fields)
+            client = ApiClient.new(
+              client_id:     fields[:client_id].to_s.strip,
+              client_secret: fields[:client_secret].to_s.strip
+            )
+            client.test_connection
+          rescue => e
+            { ok: false, error: e.message }
+          end
+
+          def initialize(config)
+            @config        = config
+            @api_client    = ApiClient.new(
+              client_id:     config[:client_id],
+              client_secret: config[:client_secret]
+            )
+            @stream_client = nil
+            @running       = false
+            # chat_id => { url:, expires_at_ms: } — sessionWebhook is per-message
+            # and expires (~2h). We cache it from inbound events and validate on send.
+            @webhook_urls  = {}
+            @webhook_mutex = Mutex.new
+          end
+
+          WEBHOOK_SAFETY_MARGIN_MS = 5 * 60 * 1000
+
+          def start(&on_message)
+            @running    = true
+            @on_message = on_message
+
+            @stream_client = StreamClient.new(
+              client_id:     @config[:client_id],
+              client_secret: @config[:client_secret]
+            )
+            @stream_client.start { |frame| handle_frame(frame) }
+          end
+
+          def stop
+            @running = false
+            @stream_client&.stop
+          end
+
+          # @param chat_id [String] — for DingTalk Stream Mode, chat_id == webhook URL
+          def send_text(chat_id, text, reply_to: nil)
+            webhook_url = resolve_webhook(chat_id)
+            unless webhook_url
+              Clacky::Logger.warn("[dingtalk] no valid sessionWebhook for chat #{chat_id} (expired or never received)")
+              return { ok: false, error: "session_webhook_expired" }
+            end
+            @api_client.send_via_webhook(webhook_url, text)
+          end
+
+          def validate_config(config)
+            errors = []
+            errors << "client_id is required"     if config[:client_id].to_s.strip.empty?
+            errors << "client_secret is required" if config[:client_secret].to_s.strip.empty?
+            errors
+          end
+
+          private def handle_frame(frame)
+            topic = frame.dig("headers", "topic").to_s
+            return unless topic == "/v1.0/im/bot/messages/get"
+
+            data = begin
+              raw = frame["data"]
+              raw.is_a?(String) ? JSON.parse(raw) : raw
+            rescue JSON::ParserError
+              Clacky::Logger.warn("[dingtalk] failed to parse event data")
+              return
+            end
+
+            sender_id    = data.dig("senderStaffId") || data.dig("senderId") || ""
+            chat_id      = data.dig("conversationId") || sender_id
+            webhook_url  = data.dig("sessionWebhook") || ""
+            expired_ms   = (data.dig("sessionWebhookExpiredTime") || 0).to_i
+            text         = extract_text(data)
+            conv_type    = data.dig("conversationType").to_s  # "1"=DM, "2"=group
+
+            cache_webhook(chat_id, webhook_url, expired_ms) unless webhook_url.empty?
+
+            return if sender_id.empty?
+
+            # Group chats: only respond when @-mentioned
+            if conv_type == "2"
+              content = data.dig("text", "content").to_s
+              at_users = Array(data.dig("atUsers")).map { |u| u.dig("dingtalkId") || u.dig("staffId") || "" }
+              bot_id   = data.dig("chatbotUserId").to_s
+              unless at_users.include?(bot_id) || content.include?("@")
+                return
+              end
+            end
+
+            allowed = @config[:allowed_users]
+            return if allowed && !allowed.empty? && !allowed.include?(sender_id)
+
+            event = {
+              platform:   :dingtalk,
+              user_id:    sender_id,
+              chat_id:    chat_id,
+              message_id: data.dig("msgId") || "",
+              text:       text,
+              files:      [],
+              chat_type:  conv_type == "2" ? :group : :direct
+            }
+
+            Clacky::Logger.info("[dingtalk] message from #{sender_id}: #{text.to_s[0, 80]}")
+            @on_message&.call(event)
+          rescue => e
+            Clacky::Logger.warn("[dingtalk] handle_frame error: #{e.message}")
+          end
+
+          private def extract_text(data)
+            content = data.dig("text", "content").to_s.strip
+            # Strip leading @bot mention if present
+            content.gsub(/^@\S+\s*/, "").strip
+          end
+
+          private def cache_webhook(chat_id, url, expired_ms)
+            @webhook_mutex.synchronize do
+              @webhook_urls[chat_id] = { url: url, expires_at_ms: expired_ms }
+            end
+          end
+
+          private def resolve_webhook(chat_id)
+            entry = @webhook_mutex.synchronize { @webhook_urls[chat_id] }
+            return nil unless entry
+
+            expires_at = entry[:expires_at_ms].to_i
+            if expires_at > 0
+              now_ms = (Time.now.to_f * 1000).to_i
+              if now_ms + WEBHOOK_SAFETY_MARGIN_MS >= expires_at
+                @webhook_mutex.synchronize { @webhook_urls.delete(chat_id) }
+                return nil
+              end
+            end
+            entry[:url]
+          end
+        end
+
+        Adapters.register(:dingtalk, Adapter)
+      end
+    end
+  end
+end

--- a/lib/clacky/server/channel/adapters/dingtalk/api_client.rb
+++ b/lib/clacky/server/channel/adapters/dingtalk/api_client.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "json"
+
+module Clacky
+  module Channel
+    module Adapters
+      module DingTalk
+        # DingTalk Bot API client — sends messages via session webhook (Stream Mode).
+        class ApiClient
+          OPENAPI_BASE = "https://api.dingtalk.com"
+
+          def initialize(client_id:, client_secret:)
+            @client_id     = client_id
+            @client_secret = client_secret
+            @token         = nil
+            @token_expires_at = 0
+          end
+
+          # Send a text (or Markdown) message via the session webhook URL.
+          # In Stream Mode, inbound events carry a `sessionWebhook` — use that directly.
+          # @param webhook_url [String]
+          # @param text [String]
+          # @param msg_type [:text, :markdown] (default :text)
+          def send_via_webhook(webhook_url, text, msg_type: :text)
+            body = if msg_type == :markdown
+              { msgtype: "markdown", markdown: { title: "Reply", text: text } }
+            else
+              { msgtype: "text", text: { content: text } }
+            end
+
+            uri = URI.parse(webhook_url)
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = uri.scheme == "https"
+            req = Net::HTTP::Post.new(uri.request_uri, "Content-Type" => "application/json")
+            req.body = JSON.generate(body)
+            resp = http.request(req)
+            data = JSON.parse(resp.body) rescue {}
+            if resp.code.to_i != 200 || (data["errcode"] && data["errcode"] != 0)
+              Clacky::Logger.warn("[dingtalk] webhook send rejected (#{resp.code}): #{resp.body}")
+            end
+            data
+          rescue => e
+            Clacky::Logger.warn("[dingtalk] webhook send failed: #{e.message}")
+            {}
+          end
+
+          # Fetch a short-lived access token (cached for its lifetime).
+          def access_token
+            return @token if @token && Time.now.to_i < @token_expires_at - 60
+
+            uri  = URI.parse("#{OPENAPI_BASE}/v1.0/oauth2/accessToken")
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+            req.body = JSON.generate({ appKey: @client_id, appSecret: @client_secret })
+
+            resp = http.request(req)
+            data = JSON.parse(resp.body)
+
+            raise "DingTalk token error (#{resp.code}): #{data["message"] || resp.body}" unless resp.code.to_i == 200
+
+            @token = data["accessToken"] || raise("Missing accessToken in response")
+            @token_expires_at = Time.now.to_i + (data["expireIn"] || 7200).to_i
+            @token
+          end
+
+          # Validate credentials by fetching a token.
+          # @return [Hash] { ok: Boolean, error: String? }
+          def test_connection
+            access_token
+            { ok: true, message: "DingTalk access token obtained" }
+          rescue => e
+            { ok: false, error: e.message }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/server/channel/adapters/dingtalk/stream_client.rb
+++ b/lib/clacky/server/channel/adapters/dingtalk/stream_client.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "websocket"
+require "json"
+require "net/http"
+require "uri"
+
+module Clacky
+  module Channel
+    module Adapters
+      module DingTalk
+        DINGTALK_API_BASE = "https://api.dingtalk.com"
+        RECONNECT_DELAY   = 5
+
+        # WebSocket Stream Mode client for DingTalk.
+        # DingTalk Stream Mode uses JSON frames (unlike Feishu's protobuf).
+        # Frame shape:
+        #   { "specVersion": "1.0", "type": "SYSTEM"|"EVENT"|"CALLBACK",
+        #     "headers": { "messageId": "...", "time": "...", "topic": "...", ... },
+        #     "data": "..." }
+        class StreamClient
+          def initialize(client_id:, client_secret:)
+            @client_id     = client_id
+            @client_secret = client_secret
+            @running       = false
+          end
+
+          def start(&on_event)
+            @running  = true
+            @on_event = on_event
+            Clacky::Logger.info("[dingtalk-ws] Starting stream client (client_id=#{@client_id})")
+
+            while @running
+              begin
+                connect_and_listen
+              rescue => e
+                Clacky::Logger.warn("[dingtalk-ws] Connection error: #{e.class}: #{e.message}")
+                sleep RECONNECT_DELAY if @running
+              end
+            end
+          end
+
+          def stop
+            @running = false
+            @ws_socket&.close rescue nil
+          end
+
+          private def connect_and_listen
+            Clacky::Logger.info("[dingtalk-ws] Fetching stream endpoint...")
+            endpoint, ticket = fetch_stream_endpoint
+            full_url = "#{endpoint}?ticket=#{ticket}"
+            Clacky::Logger.info("[dingtalk-ws] Connecting to #{endpoint}")
+
+            uri  = URI.parse(full_url)
+            port = uri.port || 443
+            tcp  = TCPSocket.new(uri.host, port)
+
+            socket = begin
+              require "openssl"
+              ctx = OpenSSL::SSL::SSLContext.new
+              ctx.set_params(verify_mode: OpenSSL::SSL::VERIFY_PEER)
+              ssl = OpenSSL::SSL::SSLSocket.new(tcp, ctx)
+              ssl.hostname = uri.host
+              ssl.sync_close = true
+              ssl.connect
+              ssl
+            end
+
+            handshake = WebSocket::Handshake::Client.new(url: full_url)
+            socket.write(handshake.to_s)
+            until handshake.finished?
+              handshake << socket.readpartial(4096)
+            end
+            raise "WebSocket handshake failed" unless handshake.valid?
+
+            Clacky::Logger.info("[dingtalk-ws] WebSocket connected")
+            @ws_version = handshake.version
+            @ws_socket  = socket
+            @incoming   = WebSocket::Frame::Incoming::Client.new(version: @ws_version)
+
+            loop do
+              break unless @running
+
+              ready = IO.select([socket], nil, nil, 120)
+              unless ready
+                Clacky::Logger.warn("[dingtalk-ws] read timeout, reconnecting...")
+                return
+              end
+
+              data = socket.read_nonblock(4096)
+              @incoming << data
+              while (frame = @incoming.next)
+                case frame.type
+                when :text   then handle_frame(frame.data)
+                when :ping   then send_frame(:pong, frame.data)
+                when :close
+                  Clacky::Logger.info("[dingtalk-ws] Server closed connection, will reconnect")
+                  return
+                end
+              end
+            end
+          rescue EOFError, IOError, Errno::ECONNRESET, Errno::EPIPE,
+                 Errno::ETIMEDOUT, OpenSSL::SSL::SSLError => e
+            raise
+          ensure
+            @ws_socket = nil
+            socket&.close rescue nil
+          end
+
+          private def fetch_stream_endpoint
+            uri  = URI.parse("#{DINGTALK_API_BASE}/v1.0/gateway/connections/open")
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+
+            req = Net::HTTP::Post.new(uri.path)
+            req["Content-Type"]  = "application/json"
+            req["Accept"]        = "application/json"
+            req.body = JSON.generate({
+              clientId:     @client_id,
+              clientSecret: @client_secret,
+              subscriptions: [
+                { type: "CALLBACK", topic: "/v1.0/im/bot/messages/get" }
+              ],
+              ua:      self.class.client_identifier,
+              localIp: "127.0.0.1"
+            })
+
+            resp = http.request(req)
+            data = JSON.parse(resp.body)
+
+            unless resp.code.to_i == 200
+              raise "Stream endpoint error (#{resp.code}): #{data["message"] || resp.body}"
+            end
+
+            endpoint = data.dig("endpoint") || raise("Missing endpoint in response")
+            ticket   = data.dig("ticket")   || ""
+            [endpoint, ticket]
+          end
+
+          def self.client_identifier
+            name = Clacky::BrandConfig.load.product_name
+            name = "OpenClacky" if name.nil? || name.strip.empty?
+            "#{name.strip}/#{Clacky::VERSION}"
+          end
+
+          private def handle_frame(json_text)
+            frame = JSON.parse(json_text)
+            type  = frame["type"]
+
+            case type
+            when "SYSTEM"
+              handle_system(frame)
+            when "EVENT", "CALLBACK"
+              send_ack(frame)
+              @on_event&.call(frame)
+            end
+          rescue JSON::ParserError => e
+            Clacky::Logger.warn("[dingtalk-ws] JSON parse error: #{e.message}")
+          end
+
+          private def handle_system(frame)
+            topic = frame.dig("headers", "topic").to_s
+            case topic
+            when "ping"
+              pong = frame.merge("type" => "SYSTEM",
+                                 "headers" => frame["headers"].merge("topic" => "pong"))
+              send_text(JSON.generate(pong))
+              Clacky::Logger.info("[dingtalk-ws] pong sent")
+            when "disconnect"
+              Clacky::Logger.warn("[dingtalk-ws] Server requested disconnect, will reconnect")
+              @ws_socket&.close rescue nil
+            end
+          end
+
+          private def send_ack(frame)
+            ack = {
+              "code"    => 200,
+              "headers" => {
+                "messageId" => frame.dig("headers", "messageId"),
+                "topic"     => "ack"
+              },
+              "message" => "OK",
+              "data"    => ""
+            }
+            send_text(JSON.generate(ack))
+          end
+
+          private def send_frame(type, data)
+            return unless @ws_socket
+            outgoing = WebSocket::Frame::Outgoing::Client.new(
+              version: @ws_version || 13,
+              data:    data,
+              type:    type
+            )
+            @ws_socket.write(outgoing.to_s)
+          end
+
+          private def send_text(text)
+            send_frame(:text, text)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/server/channel/channel_config.rb
+++ b/lib/clacky/server/channel/channel_config.rb
@@ -113,6 +113,12 @@ module Clacky
         {
           bot_token:     raw["bot_token"]
         }.compact
+      when :dingtalk
+        {
+          client_id:     raw["client_id"],
+          client_secret: raw["client_secret"],
+          allowed_users: raw["allowed_users"]
+        }.compact
       when :telegram
         {
           bot_token:     raw["bot_token"],

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1746,6 +1746,11 @@ module Clacky
             allowed_users: raw["allowed_users"] || [],
             has_token:     !raw["bot_token"].to_s.strip.empty?
           }
+        when :dingtalk
+          {
+            client_id:     raw["client_id"] || "",
+            allowed_users: raw["allowed_users"] || []
+          }
         else
           {}
         end

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -5782,6 +5782,11 @@ body.setup-mode[data-theme="dark"] {
   color: #fff;
 }
 
+.channel-logo-dingtalk {
+  background: linear-gradient(135deg, #3296fa, #1677ff);
+  color: #fff;
+}
+
 .channel-card-name {
   font-size: 15px;
   font-weight: 600;

--- a/lib/clacky/web/channels.js
+++ b/lib/clacky/web/channels.js
@@ -10,7 +10,8 @@ const Channels = (() => {
 
   // Platform display metadata (use accessor to pick up runtime language)
   // SVG sources: dashboard-icons (Lark, multi-color brand mark),
-  // TDesign icons (WeCom/WeChat, single-color), simpleicons (Discord/Telegram).
+  // TDesign icons (WeCom/WeChat, single-color), simpleicons (Discord/Telegram),
+  // ant-design/ant-design-icons outlined (DingTalk).
   function PLATFORM_META() {
     return {
       feishu: {
@@ -35,6 +36,14 @@ const Channels = (() => {
         name:      "Weixin",
         desc:      I18n.t("channels.weixin.desc"),
         setupCmd:  "/channel-setup setup weixin",
+        testCmd:   "/channel-setup doctor",
+      },
+      dingtalk: {
+        logo:      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" aria-hidden="true"><path fill="#fff" d="M573.7 252.5C422.5 197.4 201.3 96.7 201.3 96.7c-15.7-4.1-17.9 11.1-17.9 11.1c-5 61.1 33.6 160.5 53.6 182.8c19.9 22.3 319.1 113.7 319.1 113.7S326 357.9 270.5 341.9c-55.6-16-37.9 17.8-37.9 17.8c11.4 61.7 64.9 131.8 107.2 138.4c42.2 6.6 220.1 4 220.1 4s-35.5 4.1-93.2 11.9c-42.7 5.8-97 12.5-111.1 17.8c-33.1 12.5 24 62.6 24 62.6c84.7 76.8 129.7 50.5 129.7 50.5c33.3-10.7 61.4-18.5 85.2-24.2L565 743.1h84.6L603 928l205.3-271.9H700.8l22.3-38.7c.3.5.4.8.4.8S799.8 496.1 829 433.8l.6-1h-.1c5-10.8 8.6-19.7 10-25.8c17-71.3-114.5-99.4-265.8-154.5"/></svg>`,
+        logoClass: "channel-logo-dingtalk",
+        name:      "DingTalk",
+        desc:      I18n.t("channels.dingtalk.desc"),
+        setupCmd:  "/channel-setup setup dingtalk",
         testCmd:   "/channel-setup doctor",
       },
       discord: {

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -352,7 +352,7 @@ const I18n = (() => {
 
       // ── Channels panel ──
       "channels.title":           "Channels",
-      "channels.subtitle":        "Connect IM platforms so your users can chat with the assistant via Feishu, WeCom, Weixin, Discord or Telegram",
+      "channels.subtitle":        "Connect IM platforms so your users can chat with the assistant via Feishu, WeCom, Weixin, Discord, Telegram or DingTalk",
       "channels.loading":         "Loading…",
       "channels.badge.running":         "Running",
       "channels.badge.enabled":         "Enabled",
@@ -378,6 +378,7 @@ const I18n = (() => {
       "channels.weixin.desc":     "Connect via WeChat iLink bot (QR login, HTTP long-poll)",
       "channels.discord.desc":    "Connect via Discord bot, invite via OAuth2 authorization link",
       "channels.telegram.desc":   "Connect via Telegram Bot API (HTTPS long-poll, token from @BotFather)",
+      "channels.dingtalk.desc":   "Connect via DingTalk Stream Mode WebSocket",
 
       // ── Settings panel ──
       "settings.title":           "Settings",
@@ -863,7 +864,7 @@ const I18n = (() => {
 
       // ── Channels panel ──
       "channels.title":           "频道",
-      "channels.subtitle":        "连接即时通讯平台，让用户通过飞书、企业微信、微信、Discord 或 Telegram 与助手对话",
+      "channels.subtitle":        "连接即时通讯平台，让用户通过飞书、企业微信、微信、Discord、Telegram 或钉钉与助手对话",
       "channels.loading":         "加载中…",
       "channels.loadError":       "加载频道失败：{{msg}}",
       "channels.badge.running":         "运行中",
@@ -889,6 +890,7 @@ const I18n = (() => {
       "channels.weixin.desc":     "通过微信 iLink 机器人接入（扫码登录，HTTP 长轮询）",
       "channels.discord.desc":    "通过 Discord 机器人接入，授权链接邀请 Bot 加入服务器",
       "channels.telegram.desc":   "通过 Telegram Bot API 接入（HTTPS 长轮询，token 来自 @BotFather）",
+      "channels.dingtalk.desc":   "通过钉钉 Stream 模式 WebSocket 接入",
 
       // ── Settings panel ──
       "settings.title":           "设置",


### PR DESCRIPTION
- Add DingTalk adapter with Stream Mode WebSocket client
- Add DingTalk API client for sending messages (text/markdown)
- Add DingTalk Device Flow QR setup script (dingtalk_setup.rb)
- Register DingTalk in channel config, HTTP server routes, and Web UI
- Add DingTalk logo and background color in app.css
- Update i18n.js with DingTalk platform name and description
- Update channel-setup SKILL.md with DingTalk setup flow