### PR TITLE
fix(channel): scope local image url rewriting to web ui only, use file basename as attachment name (C-5590)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1514,7 +1514,7 @@ module Clacky
         inline = $1 == "!"
         # URL-decode percent-encoded characters (e.g. Chinese filenames encoded by AI)
         raw_path = CGI.unescape($3)
-        name   = $2.empty? ? File.basename(raw_path) : $2
+        name   = File.basename(raw_path)
         path   = File.expand_path(raw_path)
         Clacky::Logger.info("[parse_file_links] raw=#{$3.inspect} expanded=#{path.inspect} exist=#{File.exist?(path)}")
         files << { name: name, path: path, inline: inline }
@@ -1523,12 +1523,14 @@ module Clacky
     end
 
     # Emit assistant message to UI, parsing any embedded file:// links first.
+    #
+    # Local image URL rewriting (file:// → /api/local-image) is intentionally
+    # NOT done here. It is browser-specific (the Web UI runs on http://localhost
+    # and cannot load file:// directly) and must stay scoped to the Web UI
+    # controller. IM channel subscribers need the original file:// markdown so
+    # parse_file_links can extract paths and deliver images as native attachments.
     private def emit_assistant_message(content)
       return if content.nil? || content.empty?
-
-      # Rewrite local image paths (file:// and bare absolute) to /api/local-image proxy URLs
-      # so the browser can render them without file:// security blocks.
-      content = Clacky::Utils::FileProcessor.rewrite_local_image_urls(content)
 
       parsed = parse_file_links(content)
       @ui&.show_assistant_message(parsed[:text], files: parsed[:files])

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -87,7 +87,13 @@ module Clacky
       def show_assistant_message(content, files:)
         return if (content.nil? || content.to_s.strip.empty?) && files.empty?
 
-        emit("assistant_message", content: content.to_s, files: files)
+        # Rewrite local image paths (file:// and bare absolute) to /api/local-image
+        # proxy URLs only for the browser, which runs on http://localhost and is
+        # blocked by browser security policy from loading file:// directly.
+        # Channel subscribers receive the original content so they can deliver
+        # local images as native attachments via send_file().
+        web_content = Clacky::Utils::FileProcessor.rewrite_local_image_urls(content.to_s)
+        emit("assistant_message", content: web_content, files: files)
         forward_to_subscribers { |sub| sub.show_assistant_message(content, files: files) }
       end
 


### PR DESCRIPTION
## Problem

When AI replies contain local image markdown (`![alt](file:///path/to/image.jpg)`), the backend rewrites `file://` paths to `/api/local-image?path=...` URLs globally — including for IM channels (Discord, Feishu, etc.). This URL is only accessible by the local Web UI, so channel recipients receive broken image links that cannot be rendered.

Additionally, when channels deliver local images as file attachments, the filename was taken from the alt text instead of the actual file path, resulting in attachments with no extension that recipients cannot identify.

## Fix
- `agent.rb` (`emit_assistant_message`): remove `rewrite_local_image_urls` call; raw `file://` markdown preserved so `parse_file_links` can extract paths for channel attachment delivery
- `web_ui_controller.rb` (`show_assistant_message`): apply `rewrite_local_image_urls` here instead, scoped to Web UI only
- `agent.rb` (`parse_file_links`): always use `File.basename(raw_path)` as the attachment name; alt text discarded

## Test
- ✅ Channel receives local image as file attachment with correct filename and extension
- ✅ Web UI still renders local images via `/api/local-image` proxy
- ✅ No regression on text-only messages