### PR TITLE
fix(discord): add multipart middleware to Faraday connection for file upload (C-5589)

### DIFF
--- a/lib/clacky/server/channel/adapters/discord/api_client.rb
+++ b/lib/clacky/server/channel/adapters/discord/api_client.rb
@@ -18,6 +18,7 @@ module Clacky
             @conn = Faraday.new(url: BASE_URL) do |f|
               f.headers["Authorization"] = "Bot #{@bot_token}"
               f.headers["User-Agent"]    = self.class.user_agent
+              f.request :multipart
               f.response :raise_error
               f.adapter Faraday.default_adapter
             end


### PR DESCRIPTION
## Problem

When AI replies contain local file links (`[filename](file:///path/to/file)`), the Discord adapter attempts to send the file as an attachment via `send_file`. However, `ApiClient#send_file` sets `req.body` to a Hash containing a `Faraday::UploadIO` object — but the Faraday connection was initialized without `f.request :multipart`, so Faraday does not know to encode the body as multipart/form-data. The Hash is passed raw to the underlying adapter, which calls `bytesize` on it, resulting in:
undefined method `bytesize` for #hash:0x...

This error fires once per file link, every time.

## Fix
Add `f.request :multipart` to the Faraday connection initializer in `ApiClient`. This enables the multipart middleware so file uploads are correctly encoded, consistent with how other adapters (Feishu, Telegram) handle file sending.

## Test
- ✅ Discord channel successfully receives local files as attachments
- ✅ No regression on text-only messages or `send_message` / `edit_message`