### PR TITLE
fix(ui): constrain markdown image width inside assistant message bubble (C-5585)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -1726,6 +1726,7 @@ body {
   border-top: 1px solid var(--color-border-primary);
   margin: 0.8em 0;
 }
+.msg-assistant img { max-width: 100%; height: auto; border-radius: 4px; }
 .msg-assistant strong { font-weight: 600; color: var(--color-text-primary); }
 .msg-assistant em { font-style: italic; color: var(--color-text-secondary); }
 .msg-tool      { background: var(--color-bg-primary); border: 1px solid var(--color-border-primary); font-family: monospace; font-size: 12px; color: var(--color-text-secondary); align-self: flex-start; }


### PR DESCRIPTION
## Problem
Large images inserted via Markdown syntax in AI replies overflow the message bubble, requiring horizontal scrolling to view fully.

## Fix
Add `img` style rule inside `.msg-assistant`:
- `max-width: 100%`: constrains image width within the bubble container
- `height: auto`: scales proportionally to prevent distortion
- `border-radius: 4px`: consistent with `.msg-image-thumb` style in the project

## Test
Insert a large Markdown image in an AI reply, confirm it scales proportionally to fit within the bubble with no horizontal overflow.