### PR TITLE
feat: channel-manager feishu skills setup & onboard improvements

### DIFF
--- a/lib/clacky/default_skills/channel-manager/SKILL.md
+++ b/lib/clacky/default_skills/channel-manager/SKILL.md
@@ -227,7 +227,7 @@ Call `request_user_feedback`:
 zh:
 ```json
 {
-  "question": "是否要安装「飞书 CLI」？装好之后 AI 可以帮你操作飞书云文档、电子表格、多维表格、知识库、日历、任务等几乎全部飞书能力，不只是聊天，而是能\"做事\"。不装也 OK。",
+  \"question\": \"是否要安装「飞书 CLI」？装好之后 AI 可以帮你操作飞书云文档等能力。不装也 OK。\",
   "options": ["启用", "跳过"]
 }
 ```
@@ -235,7 +235,7 @@ zh:
 en:
 ```json
 {
-  "question": "Install Feishu CLI? With it, the AI can operate Feishu Docs, Sheets, Bitable, Wiki, Calendar, Tasks and almost every Feishu capability — not just chat, but actually get things done. Skipping is fine.",
+  "question": "Install Feishu CLI? With it, the AI can help you work with Feishu Docs and more. Skipping is fine.",
   "options": ["Enable", "Skip"]
 }
 ```
@@ -247,8 +247,7 @@ If the user picks Enable, run:
 ```bash
 lark-cli --version > /dev/null 2>&1 || npm install -g @larksuite/cli
 echo -n "<APP_SECRET>" | lark-cli config init --app-id <APP_ID> --app-secret-stdin --brand feishu
-npx -y skills add larksuite/cli -y -g
-ruby "SKILL_DIR/import_lark_skills.rb"
+ruby "SKILL_DIR/install_feishu_skills.rb"
 lark-cli auth login --recommend
 ```
 

--- a/lib/clacky/default_skills/channel-manager/install_feishu_skills.rb
+++ b/lib/clacky/default_skills/channel-manager/install_feishu_skills.rb
@@ -1,26 +1,39 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'uri'
 require 'net/http'
 require 'json'
 
-require_relative '../../skill-add/scripts/install_from_zip'
+require_relative '../skill-add/scripts/install_from_zip'
 
-class BuiltinSkillsInstaller
+# Install Feishu-related skills from the openclacky platform.
+#
+# Calls GET /api/v1/skills/feishu — same payload shape as /api/v1/skills/builtin:
+#   { "skills": [{ "name": "lark-doc", "download_url": "https://..." }, ...] }
+#
+# Each skill is installed sequentially via ZipSkillInstaller into ~/.clacky/skills/<name>/.
+#
+# Usage:
+#   ruby install_feishu_skills.rb
+#
+# Output:
+#   Diagnostics  → STDERR
+#   Last line    → JSON: {"installed":N,"attempted":N}
+#   Exit code    → always 0
+
+class FeishuSkillsInstaller
   PRIMARY_HOST     = ENV.fetch('CLACKY_LICENSE_SERVER', 'https://www.openclacky.com')
   FALLBACK_HOST    = 'https://openclacky.up.railway.app'
   API_HOSTS        = ENV['CLACKY_LICENSE_SERVER'] ? [PRIMARY_HOST] : [PRIMARY_HOST, FALLBACK_HOST]
-  API_PATH         = '/api/v1/skills/builtin'
+  API_PATH         = '/api/v1/skills/feishu'
   API_OPEN_TIMEOUT = 5
   API_READ_TIMEOUT = 10
 
   def initialize
-    @target_dir       = File.join(Dir.home, '.clacky', 'skills')
-    @installed        = 0
-    @skipped_existing = 0
-    @attempted        = 0
-    @errors           = []
+    @target_dir = File.join(Dir.home, '.clacky', 'skills')
+    @installed  = 0
+    @attempted  = 0
+    @errors     = []
   end
 
   def run
@@ -72,10 +85,9 @@ class BuiltinSkillsInstaller
       download_url,
       skill_name:     name,
       target_dir:     @target_dir,
-      skip_if_exists: true
+      skip_if_exists: false
     ).perform
-    @installed        += result[:installed].size
-    @skipped_existing += result[:skipped].size
+    @installed += result[:installed].size
     @errors.concat(result[:errors]) if result[:errors].any?
   rescue StandardError => e
     @errors << "#{name}: #{e.class}: #{e.message}"
@@ -83,15 +95,11 @@ class BuiltinSkillsInstaller
 
   private def emit_summary
     unless @errors.empty?
-      warn '[install_builtin_skills] non-fatal errors:'
+      warn '[install-feishu-skills] non-fatal errors:'
       @errors.each { |e| warn "  - #{e}" }
     end
-    puts JSON.generate(
-      installed:        @installed,
-      attempted:        @attempted,
-      skipped_existing: @skipped_existing
-    )
+    puts JSON.generate(installed: @installed, attempted: @attempted)
   end
 end
 
-BuiltinSkillsInstaller.new.run if __FILE__ == $0
+FeishuSkillsInstaller.new.run if __FILE__ == $0

--- a/lib/clacky/default_skills/onboard/SKILL.md
+++ b/lib/clacky/default_skills/onboard/SKILL.md
@@ -226,8 +226,8 @@ If `yes`:
 1. `ruby "SKILL_DIR/scripts/import_external_skills.rb" --source openclaw --dry-run`
 2. Parse the skill count N.
 3. Ask via `request_user_feedback`:
-   - zh: `{ "question": "检测到你安装过 OpenClaw，找到 N 个 Skills，导入到 Clacky 直接使用？", "options": ["导入", "跳过"] }`
-   - en: `{ "question": "OpenClaw detected. Found N skills. Import them into Clacky?", "options": ["Import", "Skip"] }`
+   - zh: `{ "question": "检测到你安装过 OpenClaw，找到 N 个 Skills。现在建议跳过，后续使用 /skill-add 按需安装。", "options": ["全部导入", "跳过"] }`
+   - en: `{ "question": "OpenClaw detected. Found N skills. We recommend skipping for now and installing only what you need later with /skill-add.", "options": ["Import all", "Skip"] }`
 4. If confirmed: `ruby "SKILL_DIR/scripts/import_external_skills.rb" --source openclaw --yes`
 
 ### A.11. Celebrate soul setup & offer browser

--- a/lib/clacky/default_skills/onboard/scripts/import_external_skills.rb
+++ b/lib/clacky/default_skills/onboard/scripts/import_external_skills.rb
@@ -8,7 +8,7 @@ require 'pathname'
 #
 # Supported sources:
 #   - OpenClaw: ~/.openclaw/skills/, ~/.openclaw/workspace/skills/,
-#               ~/.agents/skills/, ~/.openclaw/workspace/.agents/skills/
+#               ~/.openclaw/workspace/.agents/skills/
 #
 # Each source is imported into a dedicated category subdirectory under ~/.clacky/skills/,
 # e.g. ~/.clacky/skills/openclaw-imports/<skill-name>/. This keeps imported skills
@@ -178,16 +178,14 @@ class OpenClawImporter < ExternalSkillsImporter
   # Returns all directories that may contain OpenClaw skills.
   # Each entry is a hash: { root: Pathname, layout: :flat }
   #
-  # Mirrors the four sources from hermes openclaw_to_hermes.py:
+  # Mirrors the sources from hermes openclaw_to_hermes.py:
   #   - ~/.openclaw/workspace/skills/             (workspace skills)
   #   - ~/.openclaw/skills/                        (managed/shared skills)
-  #   - ~/.agents/skills/                          (personal cross-project skills)
   #   - ~/.openclaw/workspace/.agents/skills/      (project-level shared skills)
   private def source_dirs
     [
       @openclaw_dir.join('workspace', 'skills'),
       @openclaw_dir.join('skills'),
-      Pathname.new(Dir.home).join('.agents', 'skills'),
       @openclaw_dir.join('workspace', '.agents', 'skills')
     ].select(&:exist?)
   end


### PR DESCRIPTION
- Add install_feishu_skills.rb for feishu skill installation in channel-manager
- Update channel-manager SKILL.md with feishu setup flow
- Serialize install_builtin_skills.rb (remove concurrency logic)
- Remove ~/.agents/skills/ from import_external_skills.rb source dirs
- Update onboard SKILL.md OpenClaw migration prompt copy