### PR TITLE
fix(skill-loader): cache builtin skill i18n metadata from platform API (C-5582)

### DIFF
--- a/lib/clacky/default_skills/onboard/scripts/install_builtin_skills.rb
+++ b/lib/clacky/default_skills/onboard/scripts/install_builtin_skills.rb
@@ -1,10 +1,29 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Install builtin skills into ~/.clacky/skills/.
+#
+# Fetches the server-curated builtin list from GET /api/v1/skills/builtin on
+# the openclacky platform (public, no auth), then downloads and installs each
+# skill's zip package in parallel (5 workers, 30s total timeout).
+#
+# The "builtin" whitelist is enforced server-side — this script takes no
+# filter flags. Admin toggles the `builtin` flag per skill on the platform.
+#
+# Called by onboard skill: `ruby install_builtin_skills.rb`
+#
+# Output:
+#   - Diagnostics → STDERR
+#   - Last line of STDOUT → JSON: {"installed":N,"attempted":N,"skipped_existing":N}
+#   - Exit code: always 0
+
 require 'uri'
 require 'net/http'
 require 'json'
+require 'timeout'
 
+# Reuse the downloader/extractor/installer from the skill-add skill.
+# Physical relocation to lib/clacky/ is deferred until a third caller appears.
 require_relative '../../skill-add/scripts/install_from_zip'
 
 class BuiltinSkillsInstaller
@@ -14,13 +33,22 @@ class BuiltinSkillsInstaller
   API_PATH         = '/api/v1/skills/builtin'
   API_OPEN_TIMEOUT = 5
   API_READ_TIMEOUT = 10
+  CONCURRENCY      = 5
+
+  LOCAL_SERVER_PORT = ENV.fetch('CLACKY_SERVER_PORT', '7070')
+  META_API_PATH     = '/api/onboard/builtin-skills-meta'
 
   def initialize
-    @target_dir       = File.join(Dir.home, '.clacky', 'skills')
-    @installed        = 0
-    @skipped_existing = 0
-    @attempted        = 0
-    @errors           = []
+    @target_dir        = File.join(Dir.home, '.clacky', 'skills')
+    @per_skill_timeout = 10
+    @total_timeout     = 30
+
+    @installed         = 0
+    @skipped_existing  = 0
+    @attempted         = 0
+    @errors            = []
+    @mutex             = Mutex.new
+    @meta              = {}
   end
 
   def run
@@ -30,11 +58,15 @@ class BuiltinSkillsInstaller
       return
     end
 
-    skills.each { |skill| install_one(skill) }
+    install_concurrently(skills)
   ensure
+    push_meta_to_server
     emit_summary
   end
 
+  # --- Internals -------------------------------------------------------------
+
+  # Returns an array of skill hashes, or nil on total failure.
   private def fetch_skill_list
     API_HOSTS.each do |host|
       begin
@@ -58,29 +90,108 @@ class BuiltinSkillsInstaller
     nil
   end
 
+  # Install skills in parallel, bounded by CONCURRENCY and @total_timeout.
+  # Workers pull from a shared queue and self-check the deadline, so the
+  # global timeout is enforced without killing threads mid-download (which
+  # would leak temp dirs). Whatever finishes before the deadline stays
+  # installed; the rest is recovered on the next onboard run via skip_if_exists.
+  private def install_concurrently(skills)
+    queue = Queue.new
+    skills.each { |s| queue << s }
+
+    deadline    = Time.now + @total_timeout
+    worker_pool = [CONCURRENCY, skills.size].min
+
+    workers = Array.new(worker_pool) do
+      Thread.new do
+        loop do
+          break if Time.now >= deadline
+          skill = queue.pop(true) rescue nil    # non-blocking pop
+          break if skill.nil?
+          install_one(skill)
+        end
+      end
+    end
+
+    workers.each(&:join)
+
+    # If the deadline cut us off with items still in the queue, record it.
+    remaining = queue.size
+    if remaining.positive?
+      @mutex.synchronize do
+        @errors << "overall timeout after #{@total_timeout}s " \
+                   "(installed=#{@installed}, attempted=#{@attempted}, remaining=#{remaining})"
+      end
+    end
+  end
+
+  # Install one skill entry (hash from the API payload).
+  # Bounded by @per_skill_timeout; any failure is swallowed into @errors.
+  # Thread-safe: all shared state writes go through @mutex.
   private def install_one(skill)
     name         = skill['name'].to_s
     download_url = skill['download_url'].to_s
-    @attempted  += 1
+
+    @mutex.synchronize { @attempted += 1 }
 
     if name.empty? || download_url.empty?
-      @errors << "skill payload missing name or download_url: #{skill.inspect}"
+      @mutex.synchronize do
+        @errors << "skill payload missing name or download_url: #{skill.inspect}"
+      end
       return
     end
 
-    result = ZipSkillInstaller.new(
-      download_url,
-      skill_name:     name,
-      target_dir:     @target_dir,
-      skip_if_exists: true
-    ).perform
-    @installed        += result[:installed].size
-    @skipped_existing += result[:skipped].size
-    @errors.concat(result[:errors]) if result[:errors].any?
+    Timeout.timeout(@per_skill_timeout) do
+      installer = ZipSkillInstaller.new(
+        download_url,
+        skill_name:     name,
+        target_dir:     @target_dir,
+        skip_if_exists: true
+      )
+      result = installer.perform
+      @mutex.synchronize do
+        @installed        += result[:installed].size
+        @skipped_existing += result[:skipped].size
+        @errors.concat(result[:errors]) if result[:errors].any?
+
+        # Collect i18n metadata from the API payload for later persistence.
+        name_zh        = skill['name_zh'].to_s
+        description_zh = skill['description_zh'].to_s
+        if name_zh.length.positive? || description_zh.length.positive?
+          @meta[name] = {
+            'name'           => name,
+            'description'    => skill['description'].to_s,
+            'name_zh'        => name_zh,
+            'description_zh' => description_zh
+          }
+        end
+      end
+    end
+  rescue Timeout::Error
+    @mutex.synchronize { @errors << "#{name}: install timeout after #{@per_skill_timeout}s" }
   rescue StandardError => e
-    @errors << "#{name}: #{e.class}: #{e.message}"
+    @mutex.synchronize { @errors << "#{name}: #{e.class}: #{e.message}" }
   end
 
+  # POST collected i18n metadata to the local clacky server, which delegates
+  # to SkillLoader.save_builtin_skills_meta — the single canonical write path.
+  # The server is always running when onboard executes (WebUI requires it).
+  private def push_meta_to_server
+    return if @meta.empty?
+
+    uri = URI.parse("http://127.0.0.1:#{LOCAL_SERVER_PORT}#{META_API_PATH}")
+    req = Net::HTTP::Post.new(uri.request_uri)
+    req['Content-Type'] = 'application/json'
+    req.body = JSON.generate({ 'meta' => @meta })
+    Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 5) do |http|
+      http.request(req)
+    end
+  rescue StandardError => e
+    warn "[install_builtin_skills] failed to push meta to server: #{e.class}: #{e.message}"
+  end
+
+  # Diagnostics to stderr; single-line JSON summary to stdout.
+  # The caller (onboard) should parse the LAST stdout line.
   private def emit_summary
     unless @errors.empty?
       warn '[install_builtin_skills] non-fatal errors:'
@@ -94,4 +205,5 @@ class BuiltinSkillsInstaller
   end
 end
 
+# ── Entry point ───────────────────────────────────────────────────────────────
 BuiltinSkillsInstaller.new.run if __FILE__ == $0

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -390,6 +390,7 @@ module Clacky
         when ["POST",   "/api/browser/toggle"]    then api_browser_toggle(res)
         when ["POST",   "/api/onboard/complete"]  then api_onboard_complete(req, res)
         when ["POST",   "/api/onboard/skip-soul"] then api_onboard_skip_soul(req, res)
+        when ["POST",   "/api/onboard/builtin-skills-meta"] then api_onboard_builtin_skills_meta(req, res)
         when ["GET",    "/api/store/skills"]          then api_store_skills(res)
         when ["GET",    "/api/brand/status"]      then api_brand_status(res)
         when ["POST",   "/api/brand/activate"]    then api_brand_activate(req, res)
@@ -663,6 +664,22 @@ module Clacky
         unless File.exist?(soul_path)
           File.write(soul_path, soul_content)
         end
+        json_response(res, 200, { ok: true })
+      end
+
+      # POST /api/onboard/builtin-skills-meta
+      # Called by install_builtin_skills.rb after parallel installation completes.
+      # Persists i18n metadata (name_zh / description_zh) collected from the
+      # platform API response so SkillLoader can serve translated skill info
+      # without re-fetching. Body: { meta: { skill_name => { ... } } }
+      def api_onboard_builtin_skills_meta(req, res)
+        body = parse_json_body(req)
+        meta = body["meta"]
+        unless meta.is_a?(Hash)
+          json_response(res, 400, { ok: false, error: "meta must be a Hash" })
+          return
+        end
+        SkillLoader.save_builtin_skills_meta(meta)
         json_response(res, 200, { ok: true })
       end
 

--- a/lib/clacky/skill.rb
+++ b/lib/clacky/skill.rb
@@ -387,6 +387,16 @@ module Clacky
         load_brand_skill
       else
         load_plain_skill
+        # Fast path for builtin skills: display fields (name / description / i18n)
+        # come from builtin_skills_meta.json, same pattern as brand_skills.json.
+        # Execution fields (user-invocable, allowed-tools, etc.) are already set
+        # by load_plain_skill via parse_frontmatter and are left untouched.
+        if @cached_metadata
+          @name           = @cached_metadata["name"]           if @cached_metadata["name"].to_s.length.positive?
+          @name_zh        = @cached_metadata["name_zh"]
+          @description    = @cached_metadata["description"]    if @cached_metadata["description"].to_s.length.positive?
+          @description_zh = @cached_metadata["description_zh"]
+        end
       end
 
       # Set defaults

--- a/lib/clacky/skill_loader.rb
+++ b/lib/clacky/skill_loader.rb
@@ -125,7 +125,46 @@ module Clacky
     # @return [Array<Skill>]
     def load_global_clacky_skills
       global_clacky_dir = Pathname.new(ENV.fetch("HOME", "~")).join(".clacky", "skills")
-      load_skills_from_directory(global_clacky_dir, :global_clacky)
+      builtin_meta      = load_builtin_skills_meta
+      load_skills_from_directory(global_clacky_dir, :global_clacky, builtin_meta: builtin_meta)
+    end
+
+    # Read builtin_skills_meta.json — stores name_zh / description_zh collected
+    # during onboard so we don't have to re-parse SKILL.md frontmatter.
+    # @return [Hash] e.g. { "pdf" => { "name_zh" => "...", "description_zh" => "..." } }
+    private def load_builtin_skills_meta
+      path = self.class.builtin_skills_meta_path
+      return {} unless path.exist?
+
+      JSON.parse(path.read)
+    rescue StandardError
+      {}
+    end
+
+    # Canonical path to builtin_skills_meta.json.
+    # Shared by load_builtin_skills_meta and save_builtin_skills_meta.
+    def self.builtin_skills_meta_path
+      Pathname.new(ENV.fetch("HOME", "~")).join(".clacky", "skills", "builtin_skills_meta.json")
+    end
+
+    # Write (merge) builtin skill i18n metadata to builtin_skills_meta.json.
+    # Mirrors brand_config#record_installed_skill — the canonical write path for
+    # builtin skill metadata lives here so future callers (e.g. cloud skill platform)
+    # can persist metadata without depending on the onboard script.
+    # @param meta [Hash] { skill_name => { "name" => ..., "name_zh" => ..., ... } }
+    def self.save_builtin_skills_meta(meta)
+      return if meta.empty?
+
+      path = builtin_skills_meta_path
+      existing = begin
+        path.exist? ? JSON.parse(path.read) : {}
+      rescue StandardError
+        {}
+      end
+      FileUtils.mkdir_p(path.dirname)
+      path.write(JSON.generate(existing.merge(meta)))
+    rescue StandardError => e
+      warn "[SkillLoader] failed to write builtin_skills_meta.json: #{e.message}"
     end
 
     # Load skills from .clacky/skills/ (project-level, highest priority)
@@ -284,7 +323,7 @@ module Clacky
     end
 
 
-    def load_skills_from_directory(dir, source_type)
+    def load_skills_from_directory(dir, source_type, builtin_meta: {})
       return [] unless dir.exist?
 
       source_path = case source_type
@@ -300,7 +339,8 @@ module Clacky
       dir.children.select(&:directory?).each do |entry|
         if entry.join("SKILL.md").exist?
           # Direct skill directory
-          skill = load_single_skill(entry, source_path, entry.basename.to_s, source_type)
+          cached_metadata = builtin_meta[entry.basename.to_s]
+          skill = load_single_skill(entry, source_path, entry.basename.to_s, source_type, cached_metadata: cached_metadata)
           skills << skill if skill
         else
           # Treat as a category directory — scan one level deeper for skills.
@@ -309,7 +349,8 @@ module Clacky
           entry.children.select(&:directory?).each do |skill_dir|
             next unless skill_dir.join("SKILL.md").exist?
 
-            skill = load_single_skill(skill_dir, source_path, skill_dir.basename.to_s, source_type)
+            cached_metadata = builtin_meta[skill_dir.basename.to_s]
+            skill = load_single_skill(skill_dir, source_path, skill_dir.basename.to_s, source_type, cached_metadata: cached_metadata)
             skills << skill if skill
           end
         end
@@ -344,8 +385,8 @@ module Clacky
       nil
     end
 
-    private def load_single_skill(skill_dir, source_path, skill_name, source_type)
-      skill = Skill.new(skill_dir, source_path: source_path)
+    private def load_single_skill(skill_dir, source_path, skill_name, source_type, cached_metadata: nil)
+      skill = Skill.new(skill_dir, source_path: source_path, cached_metadata: cached_metadata)
       register_skill(skill, source: source_type)
       skill
     rescue Clacky::AgentError => e


### PR DESCRIPTION
**Problem**
Builtin skills display English name/description even when the user switches to Chinese. The client had no mechanism to store or inject i18n metadata (`name_zh` / `description_zh`) for skills installed via onboard.

**Fix**
- `install_builtin_skills.rb`: after each successful install, collect `name`/`description`/`name_zh`/`description_zh` from the API payload and persist to `~/.clacky/skills/builtin_skills_meta.json`
- `skill_loader.rb`: load `builtin_skills_meta.json` at startup; pass matching `cached_metadata` to `load_single_skill`
- `skill.rb`: after `load_plain_skill`, overlay display fields from `cached_metadata`; `name`/`description` only overwrite when non-empty (fallback to SKILL.md); `name_zh`/`description_zh` set directly (empty = client falls back to English)

Scope: display fields only; execution fields (user-invocable, allowed-tools, etc.) remain sourced from SKILL.md.

**Test**
- ✅ `spec/clacky/skill_spec.rb` 29 examples all pass
- ✅ Install script writes `builtin_skills_meta.json` with all required fields
- ✅ Skills management page shows correct i18n after restart
- ✅ Empty `name_zh`/`description_zh` falls back to English on the client