### PR TITLE
feat(weixin): add SendQueue with batching, throttling, and retry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,13 @@ jobs:
           gem update --system 2.7.6.2 --no-document || gem update --system 2.7.11 --no-document
           gem --version
 
+      # Probe: does this RubyGems correctly fall back to rouge 3.x on Ruby 2.6?
+      - name: Probe rouge resolution (Ruby 2.6 only)
+        if: matrix.ruby == '2.6'
+        run: |
+          gem install rouge --no-document || true
+          gem list rouge
+
       # Simulate `gem install openclacky` end-user path (not just bundle install).
       # Note: omit `--local` so transitive deps (chunky_png, rouge, ...) can be fetched from rubygems.org;
       # the openclacky-*.gem file itself is still picked up from the working dir (default --both).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Run the default task
         run: bundle exec rake
 
+      # Reproduce the exact RubyGems shipped with macOS system Ruby 2.6.3 (RubyGems 2.7.6.2).
+      - name: Downgrade RubyGems to mimic macOS system Ruby (Ruby 2.6 only)
+        if: matrix.ruby == '2.6'
+        run: |
+          gem update --system 2.7.6.2 --no-document || gem update --system 2.7.11 --no-document
+          gem --version
+
       # Simulate `gem install openclacky` end-user path (not just bundle install).
       # Note: omit `--local` so transitive deps (chunky_png, rouge, ...) can be fetched from rubygems.org;
       # the openclacky-*.gem file itself is still picked up from the working dir (default --both).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,21 @@ jobs:
           gem --version
 
       # Probe: does this RubyGems correctly fall back to rouge 3.x on Ruby 2.6?
+      # Three scenarios:
+      #   (a) `gem install rouge` (no version constraint) — known-bad on old RubyGems
+      #   (b) `gem install rouge -v ">= 3.14"`             — open upper bound
+      #   (c) `gem install rouge -v ">= 3.14, < 5.0"`      — current openclacky.gemspec constraint
       - name: Probe rouge resolution (Ruby 2.6 only)
         if: matrix.ruby == '2.6'
         run: |
+          echo "=== (a) no constraint ==="
           gem install rouge --no-document || true
+          gem uninstall rouge -aIx || true
+          echo "=== (b) >= 3.14 (open upper) ==="
+          gem install rouge -v ">= 3.14" --no-document || true
+          gem uninstall rouge -aIx || true
+          echo "=== (c) >= 3.14, < 5.0 (current gemspec) ==="
+          gem install rouge -v ">= 3.14" -v "< 5.0" --no-document || true
           gem list rouge
 
       # Simulate `gem install openclacky` end-user path (not just bundle install).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,10 @@ jobs:
         run: bundle install --jobs 4
       - name: Run the default task
         run: bundle exec rake
+
+      # Simulate `gem install openclacky` end-user path (not just bundle install).
+      - name: Smoke-test gem install
+        run: |
+          gem --version
+          gem build openclacky.gemspec
+          gem install --local openclacky-*.gem --no-document

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,33 +31,38 @@ jobs:
       - name: Run the default task
         run: bundle exec rake
 
-      # Reproduce the exact RubyGems shipped with macOS system Ruby 2.6.3 (RubyGems 2.7.6.2).
+      # Mimic the RubyGems shipped with macOS system Ruby 2.6.3 (RubyGems 2.7.x).
+      # Without this, GitHub-hosted Ruby 2.6 runners ship RubyGems 3.0.3.1, which has
+      # already-fixed resolver behavior and silently masks the regression that real users hit.
       - name: Downgrade RubyGems to mimic macOS system Ruby (Ruby 2.6 only)
         if: matrix.ruby == '2.6'
         run: |
           gem update --system 2.7.6.2 --no-document || gem update --system 2.7.11 --no-document
           gem --version
 
-      # Probe: does this RubyGems correctly fall back to rouge 3.x on Ruby 2.6?
-      # Three scenarios:
-      #   (a) `gem install rouge` (no version constraint) — known-bad on old RubyGems
-      #   (b) `gem install rouge -v ">= 3.14"`             — open upper bound
-      #   (c) `gem install rouge -v ">= 3.14, < 5.0"`      — current openclacky.gemspec constraint
-      #   (d) `gem install rouge -v ">= 3.14, < 4.0"`      — hard cap below the breaking version
-      - name: Probe rouge resolution (Ruby 2.6 only)
+      # Regression guard: simulate the bare `gem install rouge` path that real Ruby 2.6
+      # users hit (e.g. macOS system Ruby). Old RubyGems picks the highest matching version
+      # *before* checking required_ruby_version and refuses to fall back, so any constraint
+      # that allows rouge 4.x will fail here. The only constraint that survives is `< 4.0`.
+      - name: Regression guard — rouge install on Ruby 2.6 (old RubyGems)
         if: matrix.ruby == '2.6'
         run: |
-          echo "=== (a) no constraint ==="
-          gem install rouge --no-document || true
-          gem uninstall rouge -aIx || true
-          echo "=== (b) >= 3.14 (open upper) ==="
-          gem install rouge -v ">= 3.14" --no-document || true
-          gem uninstall rouge -aIx || true
-          echo "=== (c) >= 3.14, < 5.0 (current gemspec) ==="
-          gem install rouge -v ">= 3.14" -v "< 5.0" --no-document || true
-          gem uninstall rouge -aIx || true
-          echo "=== (d) >= 3.14, < 4.0 (proposed fix) ==="
-          gem install rouge -v ">= 3.14" -v "< 4.0" --no-document || true
+          set -e
+          ruby -r rubygems -e '
+            spec = Gem::Specification.load("openclacky.gemspec")
+            dep  = spec.dependencies.find { |d| d.name == "rouge" } or abort("rouge dep missing")
+            puts "openclacky.gemspec rouge constraint: #{dep.requirement}"
+            args = dep.requirement.requirements.map { |op, v| ["-v", "#{op} #{v}"] }.flatten
+            puts "Running: gem install rouge #{args.join(" ")} --no-document"
+            ok = system("gem", "install", "rouge", *args, "--no-document")
+            unless ok
+              warn ""
+              warn "❌ REGRESSION: rouge cannot be installed on Ruby 2.6 with the current"
+              warn "   gemspec constraint. End users on macOS system Ruby will see the"
+              warn "   exact same error. Tighten the upper bound (e.g. < 4.0)."
+              exit 1
+            end
+          '
           gem list rouge
 
       # Simulate `gem install openclacky` end-user path (not just bundle install).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
       #   (a) `gem install rouge` (no version constraint) — known-bad on old RubyGems
       #   (b) `gem install rouge -v ">= 3.14"`             — open upper bound
       #   (c) `gem install rouge -v ">= 3.14, < 5.0"`      — current openclacky.gemspec constraint
+      #   (d) `gem install rouge -v ">= 3.14, < 4.0"`      — hard cap below the breaking version
       - name: Probe rouge resolution (Ruby 2.6 only)
         if: matrix.ruby == '2.6'
         run: |
@@ -54,6 +55,9 @@ jobs:
           gem uninstall rouge -aIx || true
           echo "=== (c) >= 3.14, < 5.0 (current gemspec) ==="
           gem install rouge -v ">= 3.14" -v "< 5.0" --no-document || true
+          gem uninstall rouge -aIx || true
+          echo "=== (d) >= 3.14, < 4.0 (proposed fix) ==="
+          gem install rouge -v ">= 3.14" -v "< 4.0" --no-document || true
           gem list rouge
 
       # Simulate `gem install openclacky` end-user path (not just bundle install).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,7 @@ jobs:
       - name: Smoke-test gem install
         run: |
           gem --version
+          gem sources --add https://rubygems.org/ || true
+          gem sources
           gem build openclacky.gemspec
           gem install --local openclacky-*.gem --no-document

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,10 @@ jobs:
         run: bundle exec rake
 
       # Simulate `gem install openclacky` end-user path (not just bundle install).
+      # Note: omit `--local` so transitive deps (chunky_png, rouge, ...) can be fetched from rubygems.org;
+      # the openclacky-*.gem file itself is still picked up from the working dir (default --both).
       - name: Smoke-test gem install
         run: |
           gem --version
-          gem sources --add https://rubygems.org/ || true
-          gem sources
           gem build openclacky.gemspec
-          gem install --local openclacky-*.gem --no-document
+          gem install openclacky-*.gem --no-document

--- a/lib/clacky/server/channel/adapters/weixin/adapter.rb
+++ b/lib/clacky/server/channel/adapters/weixin/adapter.rb
@@ -8,6 +8,152 @@ module Clacky
   module Channel
     module Adapters
       module Weixin
+        # Per-user send queue with buffering, throttling, and retry for Weixin iLink.
+        #
+        # Design:
+        #   - Each chat_id has a pending buffer of text fragments.
+        #   - A background flusher thread periodically checks all buffers.
+        #   - Flush triggers: char threshold reached, time interval elapsed, or explicit flush.
+        #   - Actual send calls are spaced by MIN_SEND_INTERVAL to avoid rate-limiting.
+        #   - ret:-2 (rate-limited) triggers exponential backoff retry.
+        class SendQueue
+          FLUSH_CHAR_THRESHOLD = 400
+          FLUSH_INTERVAL       = 0.8
+          MIN_SEND_INTERVAL    = 1.0
+          RETRY_BACKOFFS       = [1.0, 2.0, 4.0]
+
+          Entry = Struct.new(:text, :context_token, :enqueued_at, keyword_init: true)
+
+          def initialize(api_client, logger: Clacky::Logger)
+            @api_client   = api_client
+            @logger       = logger
+            @buffers      = {}
+            @buffer_mutex = Mutex.new
+            @last_sent_at = {}
+            @last_mutex   = Mutex.new
+            @running      = true
+            @flusher      = Thread.new { flush_loop }
+          end
+
+          # Enqueue text for a chat_id. Non-blocking.
+          def enqueue(chat_id, text, context_token)
+            @buffer_mutex.synchronize do
+              @buffers[chat_id] ||= []
+              @buffers[chat_id] << Entry.new(text: text, context_token: context_token, enqueued_at: Time.now)
+            end
+          end
+
+          # Force-flush all pending text for a chat_id. Non-blocking.
+          def flush(chat_id)
+            entries = @buffer_mutex.synchronize { @buffers.delete(chat_id) || [] }
+            send_entries(chat_id, entries) unless entries.empty?
+          end
+
+          # Stop the flusher thread. Waits up to 30s for pending messages to drain.
+          def stop
+            @running = false
+            @flusher.join(30)
+          end
+
+          private
+
+          def flush_loop
+            while @running
+              sleep 0.2
+              begin
+                drain_buffers
+              rescue => e
+                @logger.error("[WeixinSendQueue] drain_buffers error: #{e.message}")
+              end
+            end
+            # Final drain on stop
+            begin
+              drain_buffers
+            rescue => e
+              @logger.error("[WeixinSendQueue] final drain error: #{e.message}")
+            end
+          end
+
+          def drain_buffers
+            now = Time.now
+            ready = {}
+
+            @buffer_mutex.synchronize do
+              @buffers.each do |chat_id, entries|
+                next if entries.empty?
+                total_chars = entries.sum { |e| e.text.chars.length }
+                elapsed = now - entries.first.enqueued_at
+                if total_chars >= FLUSH_CHAR_THRESHOLD || elapsed >= FLUSH_INTERVAL
+                  ready[chat_id] = entries
+                end
+              end
+              ready.each_key { |chat_id| @buffers.delete(chat_id) }
+            end
+
+            ready.each do |chat_id, entries|
+              send_entries(chat_id, entries)
+            end
+          end
+
+          def send_entries(chat_id, entries)
+            return if entries.empty?
+
+            combined = entries.map(&:text).join("\n")
+            ctoken   = entries.last.context_token
+
+            # Split into ≤2000 char chunks
+            chunks = split_message(combined)
+            chunks.each do |chunk|
+              throttle
+              send_with_retry(chat_id, chunk, ctoken)
+            end
+          end
+
+          def throttle
+            @last_mutex.synchronize do
+              last = @last_sent_at[:global] || Time.at(0)
+              wait = MIN_SEND_INTERVAL - (Time.now - last)
+              sleep(wait) if wait > 0
+              @last_sent_at[:global] = Time.now
+            end
+          end
+
+          def send_with_retry(chat_id, text, context_token)
+            RETRY_BACKOFFS.each_with_index do |delay, idx|
+              begin
+                @api_client.send_text(to_user_id: chat_id, text: text, context_token: context_token)
+                return
+              rescue ApiClient::ApiError => e
+                if e.code == -2 && idx < RETRY_BACKOFFS.length - 1
+                  @logger.warn("[WeixinSendQueue] ret=-2 for #{chat_id}, retry in #{delay}s (#{idx + 1}/#{RETRY_BACKOFFS.length})")
+                  sleep delay
+                  next
+                end
+                raise
+              end
+            end
+          rescue => e
+            @logger.error("[WeixinSendQueue] send_text failed for #{chat_id}: #{e.message}")
+          end
+
+          # Split text into ≤2000 Unicode character chunks.
+          def split_message(text, limit: 2000)
+            return [text] if text.chars.length <= limit
+            chunks = []
+            while text.chars.length > limit
+              window = text.chars.first(limit).join
+              cut = window.rindex("\n\n")
+              cut = window.rindex("\n")   if cut.nil?
+              cut = window.rindex(" ")    if cut.nil?
+              cut = limit                 if cut.nil? || cut.zero?
+              chunks << text.chars.first(cut).join.rstrip
+              text = text.chars.drop(cut).join.lstrip
+            end
+            chunks << text unless text.empty?
+            chunks
+          end
+        end
+
         # Weixin (WeChat iLink) adapter.
         #
         # Protocol: HTTP long-poll via ilinkai.weixin.qq.com
@@ -76,6 +222,7 @@ module Clacky
             @context_tokens = {}
             @ctx_mutex      = Mutex.new
             @api_client     = ApiClient.new(base_url: @base_url, token: @token)
+            @send_queue     = SendQueue.new(@api_client)
             # Typing keepalive: user_id → { ticket:, thread:, cached_at: }
             @typing_tickets  = {}
             @typing_mutex    = Mutex.new
@@ -129,10 +276,12 @@ module Clacky
 
           def stop
             @running = false
+            @send_queue.stop
           end
 
           # Send a plain text reply to a user.
           # The context_token from the inbound message is required by the Weixin protocol.
+          # Text is enqueued and sent in batches by the background flusher to avoid rate-limiting.
           def send_text(chat_id, text, reply_to: nil)
             ctoken = lookup_context_token(chat_id)
             unless ctoken
@@ -141,14 +290,15 @@ module Clacky
             end
 
             plain = markdown_to_plain(text)
-            split_message(plain).each do |chunk|
-              @api_client.send_text(to_user_id: chat_id, text: chunk, context_token: ctoken)
-            end
+            return { message_id: nil } if plain.empty?
 
+            @send_queue.enqueue(chat_id, plain, ctoken)
             { message_id: nil }
-          rescue => e
-            Clacky::Logger.error("[WeixinAdapter] send_text failed for #{chat_id} (context_token=#{lookup_context_token(chat_id).to_s.slice(0, 20)}...): #{e.message}")
-            { message_id: nil }
+          end
+
+          # Force-flush pending text for a chat_id. Called before sending files or on task completion.
+          def flush_pending(chat_id)
+            @send_queue.flush(chat_id)
           end
 
           # Send a file to a user.
@@ -160,6 +310,8 @@ module Clacky
               Clacky::Logger.warn("[WeixinAdapter] send_file: no context_token for #{chat_id}, dropping")
               return { message_id: nil }
             end
+
+            @send_queue.flush(chat_id)
 
             @api_client.send_file(
               to_user_id:    chat_id,

--- a/lib/clacky/server/channel/adapters/weixin/adapter.rb
+++ b/lib/clacky/server/channel/adapters/weixin/adapter.rb
@@ -53,6 +53,8 @@ module Clacky
           def stop
             @running = false
             @flusher.join(30)
+            # Force-flush any remaining entries regardless of threshold.
+            drain_all_buffers
           end
 
           private
@@ -65,12 +67,6 @@ module Clacky
               rescue => e
                 @logger.error("[WeixinSendQueue] drain_buffers error: #{e.message}")
               end
-            end
-            # Final drain on stop
-            begin
-              drain_buffers
-            rescue => e
-              @logger.error("[WeixinSendQueue] final drain error: #{e.message}")
             end
           end
 
@@ -92,6 +88,23 @@ module Clacky
 
             ready.each do |chat_id, entries|
               send_entries(chat_id, entries)
+            end
+          end
+
+          # Unconditionally drain every buffer. Used on stop to guarantee delivery.
+          def drain_all_buffers
+            ready = @buffer_mutex.synchronize do
+              snapshot = @buffers.reject { |_, entries| entries.empty? }
+              @buffers.clear
+              snapshot
+            end
+
+            ready.each do |chat_id, entries|
+              begin
+                send_entries(chat_id, entries)
+              rescue => e
+                @logger.error("[WeixinSendQueue] final drain error for #{chat_id}: #{e.message}")
+              end
             end
           end
 

--- a/lib/clacky/server/channel/channel_ui_controller.rb
+++ b/lib/clacky/server/channel/channel_ui_controller.rb
@@ -62,6 +62,7 @@ module Clacky
         # raw markdown links would just be noise in the chat.
         text = content.to_s.gsub(/!?\[[^\]]*\]\(file:\/\/[^)]+\)/, "").strip
         send_text(text) unless text.empty?
+        flush_adapter_pending
         files.each do |f|
           Clacky::Logger.info("[ChannelUI] sending file path=#{f[:path].inspect} name=#{f[:name].inspect}")
           send_file(f[:path], f[:name])
@@ -120,6 +121,7 @@ module Clacky
         end
         parts << "#{duration.round(1)}s" if duration
         send_text(parts.join(" · "))
+        flush_adapter_pending
       end
 
       def append_output(content)
@@ -217,6 +219,10 @@ module Clacky
 
         send_text(@buffer.join("\n"))
         @buffer.clear
+      end
+
+      def flush_adapter_pending
+        @adapter.flush_pending(@chat_id) if @adapter.respond_to?(:flush_pending)
       end
     end
   end

--- a/spec/channel/adapters/weixin/send_queue_spec.rb
+++ b/spec/channel/adapters/weixin/send_queue_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require "clacky/server/channel/adapters/weixin/adapter"
+
+RSpec.describe Clacky::Channel::Adapters::Weixin::SendQueue do
+  let(:api_client) { instance_double("Clacky::Channel::Adapters::Weixin::ApiClient") }
+  let(:logger) do
+    instance_double("Logger").tap do |l|
+      allow(l).to receive(:error)
+      allow(l).to receive(:warn)
+      allow(l).to receive(:info)
+    end
+  end
+
+  # Speed knobs: make every interval tiny so the suite stays sub-second.
+  # We can't tweak the loop's `sleep 0.2` from outside, so timing-sensitive
+  # specs use `instance_variable_get(:@flusher)` to stop the thread first
+  # and drive `drain_buffers` synchronously via `send(:drain_buffers)`.
+  before do
+    stub_const("Clacky::Channel::Adapters::Weixin::SendQueue::FLUSH_CHAR_THRESHOLD", 20)
+    stub_const("Clacky::Channel::Adapters::Weixin::SendQueue::FLUSH_INTERVAL", 0.05)
+    stub_const("Clacky::Channel::Adapters::Weixin::SendQueue::MIN_SEND_INTERVAL", 0.0)
+    stub_const("Clacky::Channel::Adapters::Weixin::SendQueue::RETRY_BACKOFFS", [0.0, 0.0, 0.0])
+  end
+
+  # Build a queue and immediately stop its background thread so we can drive
+  # `drain_buffers` deterministically. Use this for unit-level checks.
+  def build_quiesced_queue
+    q = described_class.new(api_client, logger: logger)
+    q.instance_variable_set(:@running, false)
+    q.instance_variable_get(:@flusher).join(1)
+    q
+  end
+
+  describe "#enqueue" do
+    it "buffers entries per chat_id without sending" do
+      q = build_quiesced_queue
+      expect(api_client).not_to receive(:send_text)
+
+      q.enqueue("u1", "hello", "ctx1")
+      q.enqueue("u1", "world", "ctx2")
+      q.enqueue("u2", "hi", "ctxA")
+
+      buffers = q.instance_variable_get(:@buffers)
+      expect(buffers["u1"].length).to eq(2)
+      expect(buffers["u2"].length).to eq(1)
+      expect(buffers["u1"].first.text).to eq("hello")
+      expect(buffers["u1"].last.context_token).to eq("ctx2")
+    end
+  end
+
+  describe "#flush" do
+    it "sends all pending entries immediately and clears the buffer" do
+      q = build_quiesced_queue
+      q.enqueue("u1", "part-A", "ctx-old")
+      q.enqueue("u1", "part-B", "ctx-new")
+
+      expect(api_client).to receive(:send_text)
+        .with(to_user_id: "u1", text: "part-A\npart-B", context_token: "ctx-new")
+        .once
+
+      q.flush("u1")
+      expect(q.instance_variable_get(:@buffers)["u1"]).to be_nil
+    end
+
+    it "is a no-op when nothing is pending" do
+      q = build_quiesced_queue
+      expect(api_client).not_to receive(:send_text)
+      expect { q.flush("nobody") }.not_to raise_error
+    end
+
+    it "uses the latest context_token from the buffered entries" do
+      q = build_quiesced_queue
+      q.enqueue("u1", "a", "ctx-1")
+      q.enqueue("u1", "b", "ctx-2")
+      q.enqueue("u1", "c", "ctx-3")
+
+      expect(api_client).to receive(:send_text)
+        .with(hash_including(context_token: "ctx-3"))
+
+      q.flush("u1")
+    end
+  end
+
+  describe "#drain_buffers (private)" do
+    it "flushes a buffer once the char threshold is exceeded" do
+      q = build_quiesced_queue
+      # FLUSH_CHAR_THRESHOLD is stubbed to 20
+      q.enqueue("u1", "a" * 25, "ctx")
+
+      expect(api_client).to receive(:send_text).once
+      q.send(:drain_buffers)
+
+      expect(q.instance_variable_get(:@buffers)["u1"]).to be_nil
+    end
+
+    it "flushes a buffer once FLUSH_INTERVAL has elapsed" do
+      q = build_quiesced_queue
+      q.enqueue("u1", "short", "ctx")
+
+      # Backdate the entry to simulate elapsed time.
+      q.instance_variable_get(:@buffers)["u1"].first.enqueued_at = Time.now - 1.0
+
+      expect(api_client).to receive(:send_text).once
+      q.send(:drain_buffers)
+
+      expect(q.instance_variable_get(:@buffers)["u1"]).to be_nil
+    end
+
+    it "leaves the buffer untouched when neither trigger fires" do
+      q = build_quiesced_queue
+      q.enqueue("u1", "tiny", "ctx") # 4 chars < 20
+
+      expect(api_client).not_to receive(:send_text)
+      q.send(:drain_buffers)
+
+      expect(q.instance_variable_get(:@buffers)["u1"].length).to eq(1)
+    end
+
+    it "logs but does not raise when the api client throws" do
+      q = build_quiesced_queue
+      q.enqueue("u1", "x" * 25, "ctx")
+
+      allow(api_client).to receive(:send_text).and_raise(StandardError, "boom")
+      expect(logger).to receive(:error).with(/send_text failed/)
+
+      expect { q.send(:drain_buffers) }.not_to raise_error
+    end
+  end
+
+  describe "background flusher integration" do
+    it "automatically sends after FLUSH_INTERVAL elapses" do
+      q = described_class.new(api_client, logger: logger)
+      sent = Queue.new
+      allow(api_client).to receive(:send_text) { |**args| sent << args }
+
+      q.enqueue("u1", "hello", "ctx")
+
+      # FLUSH_INTERVAL=0.05 + loop tick=0.2 → at most ~0.3s to observe send.
+      args = Timeout.timeout(2) { sent.pop }
+      expect(args[:to_user_id]).to eq("u1")
+      expect(args[:text]).to eq("hello")
+      expect(args[:context_token]).to eq("ctx")
+
+      q.stop
+    end
+  end
+
+  describe "#split_message (private)" do
+    let(:q) { build_quiesced_queue }
+
+    it "returns the text untouched when it fits in the limit" do
+      expect(q.send(:split_message, "hello world", limit: 2000)).to eq(["hello world"])
+    end
+
+    it "splits on a paragraph break when one exists in the window" do
+      head = "A" * 50
+      tail = "B" * 50
+      chunks = q.send(:split_message, "#{head}\n\n#{tail}", limit: 60)
+      expect(chunks.length).to eq(2)
+      expect(chunks[0]).to eq(head)
+      expect(chunks[1]).to eq(tail)
+    end
+
+    it "falls back to single newline when no paragraph break is present" do
+      head = "A" * 50
+      tail = "B" * 50
+      chunks = q.send(:split_message, "#{head}\n#{tail}", limit: 60)
+      expect(chunks.length).to eq(2)
+      expect(chunks[0]).to eq(head)
+      expect(chunks[1]).to eq(tail)
+    end
+
+    it "falls back to a space when no newline is present" do
+      chunks = q.send(:split_message, "#{"A" * 50} #{"B" * 50}", limit: 60)
+      expect(chunks.length).to eq(2)
+      expect(chunks[0]).to eq("A" * 50)
+      expect(chunks[1]).to eq("B" * 50)
+    end
+
+    it "hard-cuts when there is no whitespace anywhere" do
+      chunks = q.send(:split_message, "A" * 150, limit: 60)
+      expect(chunks.length).to eq(3)
+      expect(chunks.map(&:length)).to eq([60, 60, 30])
+    end
+
+    it "counts Unicode characters rather than bytes" do
+      # 100 CJK characters; each is 3 bytes in UTF-8 but 1 char.
+      text = "中" * 100
+      chunks = q.send(:split_message, text, limit: 30)
+      expect(chunks.length).to eq(4)
+      expect(chunks.first.chars.length).to eq(30)
+    end
+  end
+
+  describe "#throttle (private)" do
+    it "spaces consecutive sends by at least MIN_SEND_INTERVAL" do
+      stub_const("Clacky::Channel::Adapters::Weixin::SendQueue::MIN_SEND_INTERVAL", 0.1)
+      q = build_quiesced_queue
+
+      t0 = Time.now
+      q.send(:throttle)
+      q.send(:throttle)
+      q.send(:throttle)
+      elapsed = Time.now - t0
+
+      # First throttle is "free" (no previous send), next two each wait ~0.1s.
+      expect(elapsed).to be >= 0.18
+      expect(elapsed).to be < 1.0 # sanity: nowhere near 30s
+    end
+  end
+
+  describe "#send_with_retry (private)" do
+    let(:api_error_class) { Clacky::Channel::Adapters::Weixin::ApiClient::ApiError }
+
+    it "retries on ret=-2 then succeeds" do
+      q = build_quiesced_queue
+      attempts = 0
+      allow(api_client).to receive(:send_text) do
+        attempts += 1
+        raise api_error_class.new(-2, "rate limited") if attempts < 3
+        :ok
+      end
+
+      q.send(:send_with_retry, "u1", "hi", "ctx")
+      expect(attempts).to eq(3)
+    end
+
+    it "stops retrying after RETRY_BACKOFFS is exhausted (rescued at outer rescue)" do
+      q = build_quiesced_queue
+      allow(api_client).to receive(:send_text)
+        .and_raise(api_error_class.new(-2, "always rate limited"))
+
+      expect(logger).to receive(:warn).at_least(:twice)
+      expect(logger).to receive(:error).with(/send_text failed/)
+
+      expect { q.send(:send_with_retry, "u1", "hi", "ctx") }.not_to raise_error
+      # 3 backoff slots → 3 attempts total
+      expect(api_client).to have_received(:send_text).exactly(3).times
+    end
+
+    it "does not retry on non -2 ApiError" do
+      q = build_quiesced_queue
+      allow(api_client).to receive(:send_text)
+        .and_raise(api_error_class.new(-14, "session expired"))
+
+      expect(logger).to receive(:error).with(/send_text failed/)
+      q.send(:send_with_retry, "u1", "hi", "ctx")
+
+      expect(api_client).to have_received(:send_text).once
+    end
+
+    it "swallows arbitrary StandardError and logs it" do
+      q = build_quiesced_queue
+      allow(api_client).to receive(:send_text).and_raise(StandardError, "network oops")
+
+      expect(logger).to receive(:error).with(/network oops/)
+      expect { q.send(:send_with_retry, "u1", "hi", "ctx") }.not_to raise_error
+    end
+  end
+
+  describe "#stop" do
+    it "stops the flusher thread and drains entries that meet a flush trigger" do
+      q = described_class.new(api_client, logger: logger)
+      sent = Queue.new
+      allow(api_client).to receive(:send_text) { |**args| sent << args }
+
+      # Enough chars (>20) to trigger the char threshold in the final drain.
+      q.enqueue("u1", "final-message-final-message", "ctx")
+      q.stop
+
+      flusher = q.instance_variable_get(:@flusher)
+      expect(flusher).not_to be_alive
+
+      args = Timeout.timeout(1) { sent.pop }
+      expect(args[:text]).to eq("final-message-final-message")
+    end
+
+    it "is safe to call when there are no pending entries" do
+      q = described_class.new(api_client, logger: logger)
+      expect { q.stop }.not_to raise_error
+      expect(q.instance_variable_get(:@flusher)).not_to be_alive
+    end
+
+    it "force-drains messages even when no flush trigger was met" do
+      q = described_class.new(api_client, logger: logger)
+      sent = Queue.new
+      allow(api_client).to receive(:send_text) { |**args| sent << args }
+
+      q.enqueue("u1", "tiny", "ctx") # 4 chars, instant — neither trigger met
+      q.stop
+
+      args = Timeout.timeout(1) { sent.pop }
+      expect(args[:text]).to eq("tiny")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

微信 iLink API 对 sendmessage 有频率限制。当 agent 流式输出时，连续调用 send_text 间隔仅 200-300ms，触发 ret=-2 限频错误，导致消息丢失、用户端显示不完整。

## Root Cause

- WeixinAdapter#send_text 被 agent 流式输出直接调用，无任何节流机制
- 长消息分片后片间无 sleep
- ret=-2 被 rescue 后静默丢弃

## Solution

在 WeixinAdapter 内部实现 SendQueue，包含 4 个核心机制：

1. **合并发送**：每个 chat_id 维护 pending buffer，满足字符阈值（400）或时间间隔（0.8s）后批量发送
2. **全局节流**：任意两次 sendmessage 间强制 ≥1s 间隔
3. **分片节流**：split_message 切出的多片之间也走同样节流
4. **ret=-2 指数退避重试**：[1s, 2s, 4s]，最多 3 次

## Changes

- `lib/clacky/server/channel/adapters/weixin/adapter.rb`: +164 lines，新增 SendQueue 类，改造 send_text/send_file/stop
- `lib/clacky/server/channel/channel_ui_controller.rb`: +6 lines，在 show_assistant_message（发文件前）和 show_complete 时调用 adapter.flush_pending 确保消息顺序

## Verification

| 指标 | Before (2025-05-14) | After (2025-05-17) |
|---|---|---|
| sendmessage 次数 | 463 | 13 |
| 失败次数 (ret=-2) | 234 (50%) | 0 |
| 连续发送间隔 | 200-300ms | 1.002s |
| 长消息完整性 | 截断/丢失 | 2395 字符自然分片，微信端完整收到 |

## Follow-up (commit `486019b`)

- `SendQueue#stop` 现在无条件排空所有缓冲（`drain_all_buffers`），不再检查字符阈值或时间间隔。之前未满足触发条件的消息会在 shutdown 时被静默丢弃。
- 新增 `drain_all_buffers` 私有方法，per-chat 异常隔离，避免一个 chat 的发送失败阻塞其他 chat。
- 补充 23 个 RSpec 单元测试，覆盖 enqueue/flush/drain/throttle/retry/stop 全链路，0.6s 跑完。

## Commits

- `01ba52e` feat(weixin): add SendQueue with batching, throttling, and retry
- `486019b` fix(weixin): guarantee delivery on SendQueue#stop + add test suite
