### PR TITLE
fix(onboard): detect Windows-native OpenClaw config on WSL (C-5580)

### DIFF
--- a/lib/clacky/default_skills/onboard/SKILL.md
+++ b/lib/clacky/default_skills/onboard/SKILL.md
@@ -221,8 +221,12 @@ then parse the last stdout line as JSON and read `installed` as N.
 
 ### A.10. Import external skills (optional)
 
-Run `test -d ~/.openclaw && echo yes || echo no`. If `no`, skip silently.
-If `yes`:
+Check if OpenClaw is installed:
+- Run `test -d ~/.openclaw && echo yes || echo no`
+- If `no` and on WSL (i.e. `/proc/version` contains `microsoft`), also run:
+  `powershell.exe -NoProfile -Command '$env:USERPROFILE' 2>/dev/null | tr -d '\r'` to get the Windows home, then check `test -d "$(wslpath '<win_home>')/.openclaw" && echo yes || echo no`
+- If all checks return `no`, skip silently.
+If any check returns `yes`:
 1. `ruby "SKILL_DIR/scripts/import_external_skills.rb" --source openclaw --dry-run`
 2. Parse the skill count N.
 3. Ask via `request_user_feedback`:

--- a/lib/clacky/default_skills/onboard/scripts/import_external_skills.rb
+++ b/lib/clacky/default_skills/onboard/scripts/import_external_skills.rb
@@ -172,7 +172,7 @@ class OpenClawImporter < ExternalSkillsImporter
   end
 
   private def source_available?
-    @openclaw_dir.exist?
+    openclaw_dirs.any?(&:exist?)
   end
 
   # Returns all directories that may contain OpenClaw skills.
@@ -182,12 +182,56 @@ class OpenClawImporter < ExternalSkillsImporter
   #   - ~/.openclaw/workspace/skills/             (workspace skills)
   #   - ~/.openclaw/skills/                        (managed/shared skills)
   #   - ~/.openclaw/workspace/.agents/skills/      (project-level shared skills)
+  #
+  # On WSL, also scans the Windows-native %USERPROFILE%\.openclaw directory.
   private def source_dirs
-    [
-      @openclaw_dir.join('workspace', 'skills'),
-      @openclaw_dir.join('skills'),
-      @openclaw_dir.join('workspace', '.agents', 'skills')
-    ].select(&:exist?)
+    openclaw_dirs.flat_map do |root|
+      [
+        root.join('workspace', 'skills'),
+        root.join('skills'),
+        root.join('workspace', '.agents', 'skills')
+      ]
+    end.select(&:exist?)
+  end
+
+  # All candidate OpenClaw root directories.
+  # On WSL, includes both ~/.openclaw and the Windows-native path.
+  private def openclaw_dirs
+    dirs = [@openclaw_dir]
+    win_home = windows_home
+    dirs << win_home.join('.openclaw') if win_home && win_home.join('.openclaw') != @openclaw_dir
+    dirs
+  end
+
+  # True when running inside WSL.
+  # Mirrors EnvironmentDetector#wsl? — reads /proc/version for "microsoft".
+  private def wsl?
+    return @wsl if defined?(@wsl)
+
+    @wsl = File.exist?('/proc/version') &&
+           File.read('/proc/version').downcase.include?('microsoft')
+  rescue StandardError
+    @wsl = false
+  end
+
+  # Resolve the Windows %USERPROFILE% as a WSL-accessible Pathname.
+  # Uses powershell.exe (standard in WSL) then wslpath for conversion,
+  # mirroring the approach in EnvironmentDetector#wsl_desktop_path.
+  # Returns nil when not on WSL or when the path cannot be resolved.
+  private def windows_home
+    return nil unless wsl?
+    return nil if `which powershell.exe 2>/dev/null`.strip.empty?
+
+    win_path = `powershell.exe -NoProfile -Command '$env:USERPROFILE' 2>/dev/null`.strip.tr("\r\n", '')
+    return nil if win_path.empty?
+
+    linux_path = `wslpath '#{win_path}' 2>/dev/null`.strip
+    return nil if linux_path.empty?
+
+    path = Pathname.new(linux_path)
+    path.exist? ? path : nil
+  rescue StandardError
+    nil
   end
 
   private def discover_skills


### PR DESCRIPTION
**Problem**

On WSL, the onboard flow silently skipped OpenClaw migration even when OpenClaw was installed on the Windows side. There were two root causes:

1. `SKILL.md` pre-check only ran `test -d ~/.openclaw` (WSL Linux path) — if absent, it bailed out before ever invoking the importer
2. `OpenClawImporter#source_available?` also only checked `~/.openclaw`, never scanning the Windows-native path

**Changes**

- `SKILL.md`: added WSL branch to the pre-check — when running under WSL, additionally checks `%USERPROFILE%\.openclaw` via `powershell.exe` + `wslpath`
- `import_external_skills.rb`: added `openclaw_dirs`, `wsl?`, and `windows_home` helpers — the importer now scans both the WSL-internal and Windows-native `.openclaw` directories

**Behavior**

- Non-WSL: no change
- WSL: checks both `~/.openclaw` and `/mnt/c/Users/<username>/.openclaw`; either existing triggers the import flow