### PR TITLE
fix: persist sessions on shutdown and restart without race conditions

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -240,6 +240,17 @@ module Clacky
         shutdown_proc = proc do
           next if shutdown_once
           shutdown_once = true
+          # Save all agent sessions synchronously BEFORE starting the
+          # forced-exit timer. The timer runs in a separate thread; if
+          # session save is slow (many sessions / slow disk), we must
+          # not let the timer kill the process mid-write.
+          @registry.each_agent do |session_id, s|
+            begin
+              @session_manager.save(s[:agent].to_session_data(status: :interrupted))
+            rescue => e
+              Clacky::Logger.warn("[HttpServer] Failed to save session #{session_id} during shutdown: #{e.message}")
+            end
+          end
           Thread.new do
             sleep 2
             Clacky::Logger.warn("[HttpServer] Forced exit after graceful shutdown timeout.")
@@ -1304,7 +1315,17 @@ module Clacky
           sleep 0.5  # Let WEBrick flush the HTTP response
 
           if @master_pid
-            # Worker mode: tell master to hot-restart, then exit cleanly.
+            # Worker mode: save all sessions, then tell master to hot-restart.
+            # Worker is self-sufficient — it persists its own state instead of
+            # relying on master's TERM to trigger shutdown_proc (which risks
+            # zombie workers if master crashes or never sends TERM).
+            @registry.each_agent do |session_id, s|
+              begin
+                @session_manager.save(s[:agent].to_session_data(status: :interrupted))
+              rescue => e
+                Clacky::Logger.warn("[HttpServer] Failed to save session #{session_id} during restart: #{e.message}")
+              end
+            end
             Clacky::Logger.info("[Restart] Sending USR1 to master (PID=#{@master_pid})")
             begin
               Process.kill("USR1", @master_pid)

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -122,6 +122,16 @@ module Clacky
         @mutex.synchronize { @sessions[session_id]&.dup }
       end
 
+      # Yield [session_id, session_hash] for every registered session that has an agent.
+      def each_agent
+        @mutex.synchronize do
+          @sessions.each do |id, s|
+            next unless s[:agent]
+            yield id, s
+          end
+        end
+      end
+
       # Update arbitrary runtime fields of a session (status, error, pending_*, etc.).
       def update(session_id, **fields)
         @mutex.synchronize do


### PR DESCRIPTION
## 问题背景

OpenClacky 的 Master/Worker 架构中，**所有 session 都在 Worker 进程里**（Master 只持有 socket、管理子进程，不跑 HttpServer）。有两个场景导致 session 丢失：

### 场景一：进程收到 SIGTERM/SIGINT

Worker 的 `shutdown_proc` 被触发时，原来的流程只做了资源清理（停 channel、停 browser、关 WEBrick），**没有保存 session**。多轮对话的上下文、工具调用历史全部丢失。

### 场景二：热重启（`/api/restart`）

Worker 发 USR1 通知 Master 后立即 `exit(0)`，但 session 还没存盘。原来的逻辑是 Worker 等 Master 收到 USR1 后发 TERM 回来触发 `shutdown_proc` 来保存——但 Worker 已经退出了，TERM 追不上。

## 修复方案

所有改动在 `http_server.rb`（Worker 侧），Master 无需改动。

### shutdown_proc：先存盘再清理

```
  💾 同步保存所有 session → status: :interrupted
  ⚡ 启动 2s 定时器（安全网，兜底后续清理步骤）
  清理 channel / browser / WEBrick
```

session 保存放在定时器**之前**同步执行，杜绝竞态——慢磁盘或多 session 时也不会写到一半被炸。

### restart：Worker 自己管自己的 session

```
  💾 Worker 保存自己所有 session
  📤 发 USR1 给 Master 触发热重启
  🚪 exit(0)
```

Worker 不再依赖 Master 的 TERM 来兜底保存。自己的 session 自己管，管完干净退出。Master 收到 USR1 后正常 spawn 新 Worker。

## 改动文件

- `lib/clacky/server/http_server.rb` — shutdown_proc 顺序调整 + restart 路径自保存
- `lib/clacky/server/session_registry.rb` — 新增 `each_agent` 遍历方法
