### PR TITLE
fix: clean up BrowserManager MCP process on agent exit in CLI mode

### DIFF
--- a/lib/clacky/cli.rb
+++ b/lib/clacky/cli.rb
@@ -163,6 +163,7 @@ module Clacky
         end
       ensure
         Dir.chdir(original_dir)
+        Clacky::BrowserManager.instance.stop rescue nil
       end
     end
 


### PR DESCRIPTION
## 问题

`BrowserManager#stop` 只在 Server 模式的 shutdown 路径 (`HttpServer#shutdown_proc`) 中被调用，CLI 模式下 (`clacky agent`) 退出时未清理 `chrome-devtools-mcp` 守护进程，导致每次 CLI session 结束后残留一个孤儿进程。

## 修复

在 `cli.rb` 的 `agent` 命令 `ensure` 块中增加一行：

```ruby
Clacky::BrowserManager.instance.stop rescue nil
```

`ensure` 覆盖了三种 CLI 模式（交互、非交互、JSON）的所有退出路径（正常退出、`/exit`、Ctrl+C）。`rescue nil` 处理 `BrowserManager` 从未初始化的情况。

## 改动

- `lib/clacky/cli.rb` — +1 行
