### PR TITLE
fix(skill-loader): builtin skill i18n via cached metadata (C-5582)

### DIFF
--- a/lib/clacky/default_skills/onboard/scripts/install_builtin_skills.rb
+++ b/lib/clacky/default_skills/onboard/scripts/install_builtin_skills.rb
@@ -21,6 +21,11 @@ class BuiltinSkillsInstaller
     @skipped_existing = 0
     @attempted        = 0
     @errors           = []
+    # i18n metadata harvested from the platform response for skills that were
+    # actually installed on this run. Pushed back to the local clacky server
+    # at the end so SkillLoader can persist them to ~/.clacky/skills/builtin_skills.json
+    # for zh-locale display overlays — mirrors how brand_skills.json is fed.
+    @meta             = []
   end
 
   def run
@@ -31,6 +36,7 @@ class BuiltinSkillsInstaller
     end
 
     skills.each { |skill| install_one(skill) }
+    push_meta_to_server
   ensure
     emit_summary
   end
@@ -77,8 +83,48 @@ class BuiltinSkillsInstaller
     @installed        += result[:installed].size
     @skipped_existing += result[:skipped].size
     @errors.concat(result[:errors]) if result[:errors].any?
+
+    # Capture i18n metadata for every skill the platform listed (whether newly
+    # installed or skipped because the directory already existed). This keeps
+    # builtin_skills.json in sync with the on-disk skills/ directory across
+    # repeat onboard runs.
+    @meta << {
+      'name'           => name,
+      'description'    => skill['description'].to_s,
+      'name_zh'        => skill['name_zh'].to_s,
+      'description_zh' => skill['description_zh'].to_s,
+    }
   rescue StandardError => e
     @errors << "#{name}: #{e.class}: #{e.message}"
+  end
+
+  # POST harvested i18n meta to the local clacky HTTP server, which persists it
+  # via SkillLoader.record_installed_builtin_skill. Best-effort — failure here
+  # only means the zh display overlay is missing on this machine; the skills
+  # themselves are installed and functional.
+  private def push_meta_to_server
+    return if @meta.empty?
+
+    host = ENV['CLACKY_SERVER_HOST'].to_s
+    port = ENV['CLACKY_SERVER_PORT'].to_s
+    if host.empty? || port.empty?
+      @errors << 'push_meta: CLACKY_SERVER_HOST/CLACKY_SERVER_PORT not set, skipping'
+      return
+    end
+
+    uri = URI.parse("http://#{host}:#{port}/api/onboard/builtin-skills-meta")
+    Net::HTTP.start(uri.host, uri.port,
+                    open_timeout: API_OPEN_TIMEOUT,
+                    read_timeout: API_READ_TIMEOUT) do |http|
+      req = Net::HTTP::Post.new(uri.request_uri, 'Content-Type' => 'application/json')
+      req.body = JSON.generate(meta: @meta)
+      response = http.request(req)
+      unless response.code.to_i == 200
+        @errors << "push_meta: HTTP #{response.code}"
+      end
+    end
+  rescue StandardError => e
+    @errors << "push_meta: #{e.class}: #{e.message}"
   end
 
   private def emit_summary

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -390,6 +390,7 @@ module Clacky
         when ["POST",   "/api/browser/toggle"]    then api_browser_toggle(res)
         when ["POST",   "/api/onboard/complete"]  then api_onboard_complete(req, res)
         when ["POST",   "/api/onboard/skip-soul"] then api_onboard_skip_soul(req, res)
+        when ["POST",   "/api/onboard/builtin-skills-meta"] then api_onboard_builtin_skills_meta(req, res)
         when ["GET",    "/api/store/skills"]          then api_store_skills(res)
         when ["GET",    "/api/brand/status"]      then api_brand_status(res)
         when ["POST",   "/api/brand/activate"]    then api_brand_activate(req, res)
@@ -664,6 +665,37 @@ module Clacky
           File.write(soul_path, soul_content)
         end
         json_response(res, 200, { ok: true })
+      end
+
+      # POST /api/onboard/builtin-skills-meta
+      # Called by the install_builtin_skills.rb child process after each batch
+      # of builtin skills is installed to ~/.clacky/skills/. The child posts the
+      # list of skills it just installed (with EN/ZH name+description harvested
+      # from the platform response); this handler persists each entry to
+      # ~/.clacky/skills/builtin_skills.json via SkillLoader.record_installed_builtin_skill.
+      #
+      # Mirrors the brand_skills.json registry shape so SkillLoader#load_global_clacky_skills
+      # can later overlay zh display fields without re-parsing every SKILL.md.
+      def api_onboard_builtin_skills_meta(req, res)
+        body = parse_json_body(req)
+        meta = body["meta"]
+        unless meta.is_a?(Array)
+          json_response(res, 400, { ok: false, error: "meta must be an array" })
+          return
+        end
+
+        meta.each do |entry|
+          next unless entry.is_a?(Hash)
+          name = entry["name"].to_s
+          next if name.empty?
+          SkillLoader.record_installed_builtin_skill(
+            name,
+            description:    entry["description"].to_s,
+            name_zh:        entry["name_zh"].to_s,
+            description_zh: entry["description_zh"].to_s,
+          )
+        end
+        json_response(res, 200, { ok: true, count: meta.size })
       end
 
       # ── Brand API ─────────────────────────────────────────────────────────────

--- a/lib/clacky/skill.rb
+++ b/lib/clacky/skill.rb
@@ -406,6 +406,21 @@ module Clacky
 
       content = skill_file.read
       parse_frontmatter(content)
+
+      # Overlay display fields from the cached builtin_skills.json registry.
+      # The registry holds platform-authoritative name / description /
+      # name_zh / description_zh collected during onboard, so it is treated as
+      # the source of truth for what the user sees — SKILL.md frontmatter may
+      # be unnormalized (mixed zh/en, user-authored variants) and only acts as
+      # a fallback when the registry has no entry. Behavior fields parsed from
+      # frontmatter (user_invocable / agent / fork_agent / model / etc.) are
+      # left untouched.
+      if @cached_metadata
+        @name           = @cached_metadata["name"]           if @cached_metadata["name"].to_s.length.positive?
+        @name_zh        = @cached_metadata["name_zh"]        if @cached_metadata["name_zh"].to_s.length.positive?
+        @description    = @cached_metadata["description"]    if @cached_metadata["description"].to_s.length.positive?
+        @description_zh = @cached_metadata["description_zh"] if @cached_metadata["description_zh"].to_s.length.positive?
+      end
     end
 
     # Load a brand (encrypted) skill from SKILL.md.enc.

--- a/lib/clacky/skill_loader.rb
+++ b/lib/clacky/skill_loader.rb
@@ -2,6 +2,7 @@
 
 require "pathname"
 require "fileutils"
+require "json"
 require "clacky"
 
 module Clacky
@@ -50,6 +51,7 @@ module Clacky
       clear
 
       load_default_skills
+      load_builtin_skills
       load_global_clacky_skills
       
       # Only load project-level skills when working_dir is explicitly provided.
@@ -121,11 +123,113 @@ module Clacky
       @shadowed_by_local || {}
     end
 
-    # Load skills from ~/.clacky/skills/ (user global)
+    # Load skills from ~/.clacky/skills/ — user-installed plain skills only.
+    # Builtin skills (installed by the onboard flow and tracked in
+    # builtin_skills.json) are loaded earlier by #load_builtin_skills, so
+    # we skip directories that are already registered to keep the loader
+    # idempotent and avoid duplicate-skill warnings.
     # @return [Array<Skill>]
     def load_global_clacky_skills
       global_clacky_dir = Pathname.new(ENV.fetch("HOME", "~")).join(".clacky", "skills")
-      load_skills_from_directory(global_clacky_dir, :global_clacky)
+      load_skills_from_directory(global_clacky_dir, :global_clacky, skip_existing: true)
+    end
+
+    # Load builtin skills installed by the onboard flow.
+    #
+    # Mirrors #load_default_skills in style: system-managed skills get their
+    # own dedicated loader, separate from user-installed global skills. The
+    # canonical source of truth is builtin_skills.json (the registry written
+    # by install_builtin_skills.rb) — we iterate the registry instead of
+    # globbing the directory so user-installed skills under the same
+    # ~/.clacky/skills/ root are never mistaken for builtins.
+    #
+    # i18n display fields (name_zh / description_zh) come from the registry
+    # and are overlaid onto the Skill via cached_metadata.
+    # @return [Array<Skill>]
+    private def load_builtin_skills
+      skills_dir = Pathname.new(Dir.home).join(".clacky", "skills")
+      return [] unless skills_dir.exist?
+
+      installed_metadata = self.class.cached_builtin_skills_metadata
+      return [] if installed_metadata.empty?
+
+      source_path = Pathname.new(Dir.home).join(".clacky")
+
+      installed_metadata.each_key do |skill_name|
+        skill_dir = skills_dir.join(skill_name)
+        next unless skill_dir.join("SKILL.md").exist?
+
+        cached_metadata = installed_metadata[skill_name]
+        load_single_skill(skill_dir, source_path, skill_name, :global_clacky, cached_metadata: cached_metadata)
+      end
+    end
+
+    # Read the local builtin_skills.json registry, cross-validated against the
+    # actual file system. A skill is only considered installed when:
+    #   1. It has an entry in builtin_skills.json, AND
+    #   2. Its skill directory exists under ~/.clacky/skills/, AND
+    #   3. That directory contains a SKILL.md.
+    #
+    # If the JSON record exists but the directory is missing or empty the entry
+    # is silently dropped from the result and the JSON file is cleaned up so
+    # subsequent loads start from a clean state.
+    #
+    # Returns a hash keyed by name: { "name" => ..., "name_zh" => ..., ... }
+    def self.cached_builtin_skills_metadata
+      skills_dir = File.join(Dir.home, ".clacky", "skills")
+      path = File.join(skills_dir, "builtin_skills.json")
+      return {} unless File.exist?(path)
+
+      raw = JSON.parse(File.read(path))
+
+      valid   = {}
+      changed = false
+
+      raw.each do |name, meta|
+        skill_dir = File.join(skills_dir, name)
+        has_files = Dir.exist?(skill_dir) && File.exist?(File.join(skill_dir, "SKILL.md"))
+
+        if has_files
+          valid[name] = meta
+        else
+          # JSON record exists but files are missing — mark for cleanup.
+          changed = true
+        end
+      end
+
+      if changed
+        File.write(path, JSON.generate(valid))
+      end
+
+      valid
+    rescue StandardError
+      {}
+    end
+
+    # Record a single installed builtin skill into builtin_skills.json — the
+    # canonical write path for builtin skill metadata. Mirrors
+    # BrandConfig#record_installed_skill so future callers (e.g. a cloud skill
+    # platform) can persist metadata uniformly.
+    # @param name [String] Skill slug (must match the on-disk directory name)
+    # @param description [String, nil] English description from the platform
+    # @param name_zh [String, nil] Chinese display name
+    # @param description_zh [String, nil] Chinese description
+    def self.record_installed_builtin_skill(name, description: nil, name_zh: nil, description_zh: nil)
+      slug = name.to_s.strip
+      return if slug.empty?
+
+      skills_dir = File.join(Dir.home, ".clacky", "skills")
+      FileUtils.mkdir_p(skills_dir)
+      path = File.join(skills_dir, "builtin_skills.json")
+      installed = cached_builtin_skills_metadata
+      installed[slug] = {
+        "name"           => slug,
+        "name_zh"        => name_zh.to_s,
+        "description"    => description.to_s,
+        "description_zh" => description_zh.to_s,
+        "installed_at"   => Time.now.utc.iso8601
+      }
+      File.write(path, JSON.generate(installed))
     end
 
     # Load skills from .clacky/skills/ (project-level, highest priority)
@@ -284,7 +388,16 @@ module Clacky
     end
 
 
-    def load_skills_from_directory(dir, source_type)
+    # Load skills from a directory tree.
+    #
+    # @param dir [Pathname] Root directory to scan
+    # @param source_type [Symbol] :global_clacky / :project_clacky / etc.
+    # @param skip_existing [Boolean] When true, skip skill names that are
+    #   already registered in @skills. Used by #load_global_clacky_skills to
+    #   avoid re-loading builtin skills that were already loaded by
+    #   #load_builtin_skills (and to avoid the duplicate-skill warning that
+    #   #register_skill would otherwise emit).
+    def load_skills_from_directory(dir, source_type, skip_existing: false)
       return [] unless dir.exist?
 
       source_path = case source_type
@@ -300,7 +413,10 @@ module Clacky
       dir.children.select(&:directory?).each do |entry|
         if entry.join("SKILL.md").exist?
           # Direct skill directory
-          skill = load_single_skill(entry, source_path, entry.basename.to_s, source_type)
+          skill_name = entry.basename.to_s
+          next if skip_existing && @skills.key?(skill_name)
+
+          skill = load_single_skill(entry, source_path, skill_name, source_type)
           skills << skill if skill
         else
           # Treat as a category directory — scan one level deeper for skills.
@@ -309,7 +425,10 @@ module Clacky
           entry.children.select(&:directory?).each do |skill_dir|
             next unless skill_dir.join("SKILL.md").exist?
 
-            skill = load_single_skill(skill_dir, source_path, skill_dir.basename.to_s, source_type)
+            skill_name = skill_dir.basename.to_s
+            next if skip_existing && @skills.key?(skill_name)
+
+            skill = load_single_skill(skill_dir, source_path, skill_name, source_type)
             skills << skill if skill
           end
         end
@@ -344,8 +463,8 @@ module Clacky
       nil
     end
 
-    private def load_single_skill(skill_dir, source_path, skill_name, source_type)
-      skill = Skill.new(skill_dir, source_path: source_path)
+    private def load_single_skill(skill_dir, source_path, skill_name, source_type, cached_metadata: nil)
+      skill = Skill.new(skill_dir, source_path: source_path, cached_metadata: cached_metadata)
       register_skill(skill, source: source_type)
       skill
     rescue Clacky::AgentError => e


### PR DESCRIPTION
## Problem

Under the zh locale, builtin skills show English name/description in the WebUI, inconsistent with brand skills. Root cause: builtin skills are loaded through the generic `load_global_clacky_skills` path with no i18n metadata injection.

## Fix

- `SkillLoader`: add a dedicated `load_builtin_skills` loader, symmetrical to `load_default_skills`; rename `installed_builtin_skills` → `cached_builtin_skills_metadata`; slim `load_global_clacky_skills` down to user-installed skills only; add `skip_existing` to `load_skills_from_directory` to suppress duplicate-load warnings
- `install_builtin_skills.rb`: `push_meta_to_server` now reads `CLACKY_SERVER_HOST` + `CLACKY_SERVER_PORT` from env, gracefully skips when unset
- `http_server.rb`: new `POST /skills/builtin_meta` endpoint to receive the i18n payload
- `Skill`: apply `name_zh` / `description_zh` from cached metadata as a display overlay

Scope: builtin skill loading path + i18n metadata persistence only.

## Test

- ✅ `spec/clacky/skill_loader_spec.rb`: 21 examples, 0 failures
- ✅ `spec/clacky/`: 1668 examples, 0 failures
- ✅ onboard run produces `~/.clacky/skills/builtin_skills.json` with `name_zh` / `description_zh`
- ✅ WebUI under zh locale: builtin shows Chinese, default stays English (no zh field)