### PR TITLE
fix: preserve user-set session name from being overwritten by auto-rename

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3372,9 +3372,8 @@ module Clacky
         return unless agent
 
         # Auto-name the session from the first user message (before agent starts running).
-        # Check messages.empty? only — agent.name may already hold a default placeholder
-        # like "Session 1" assigned at creation time, so it's not a reliable signal.
-        if agent.history.empty?
+        # Skip if the name looks like it was set by the user (not a system-generated "Session N").
+        if agent.history.empty? && agent.name.match?(/\ASession \d+\z/)
           auto_name = content.gsub(/\s+/, " ").strip[0, 30]
           auto_name += "…" if content.strip.length > 30
           agent.rename(auto_name)

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -905,7 +905,6 @@
   <div class="modal-box new-session-modal">
     <div class="modal-header">
       <h3 class="modal-title" data-i18n="sessions.modal.title">Create New Session</h3>
-      <button id="new-session-modal-close" class="modal-close-btn" title="Close">×</button>
     </div>
     <div class="modal-body">
       <div class="modal-field">

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -349,9 +349,7 @@ const Sessions = (() => {
     document.getElementById("btn-welcome-new")
       .addEventListener("click", () => Sessions.create("general"));
 
-    // Modal: close / cancel / create / overlay click
-    document.getElementById("new-session-modal-close")
-      .addEventListener("click", () => Sessions.closeNewSessionModal());
+    // Modal: cancel / create / overlay click
     document.getElementById("new-session-cancel")
       .addEventListener("click", () => Sessions.closeNewSessionModal());
     document.getElementById("new-session-create")


### PR DESCRIPTION
- Add name_user_set flag to Agent to track whether user explicitly named the session
- Auto-rename from first message only fires when name was system-generated
- Remove close button (×) from new session modal