### PR TITLE
fix(dingtalk): markdown rendering, file/image delivery, inbound GC (C-5596, C-5597, C-5598)

### DIFF
--- a/lib/clacky/server/channel/adapters/dingtalk/adapter.rb
+++ b/lib/clacky/server/channel/adapters/dingtalk/adapter.rb
@@ -53,6 +53,10 @@ module Clacky
             # and expires (~2h). We cache it from inbound events and validate on send.
             @webhook_urls  = {}
             @webhook_mutex = Mutex.new
+            # chat_id => { robot_code:, conv_id:, user_id:, conv_type: } — needed
+            # to route OAPI calls (e.g. send_file) which can't go through webhook.
+            @routes        = {}
+            @routes_mutex  = Mutex.new
           end
 
           WEBHOOK_SAFETY_MARGIN_MS = 5 * 60 * 1000
@@ -74,13 +78,69 @@ module Clacky
           end
 
           # @param chat_id [String] — for DingTalk Stream Mode, chat_id == webhook URL
+          # Always sent as markdown so AI replies render rich text (headings,
+          # bold, lists, links). DingTalk's markdown msgtype renders plain text
+          # unchanged, so no detection branch is needed.
           def send_text(chat_id, text, reply_to: nil)
             webhook_url = resolve_webhook(chat_id)
             unless webhook_url
               Clacky::Logger.warn("[dingtalk] no valid sessionWebhook for chat #{chat_id} (expired or never received)")
               return { ok: false, error: "session_webhook_expired" }
             end
-            @api_client.send_via_webhook(webhook_url, text)
+            @api_client.send_via_webhook(webhook_url, text, msg_type: :markdown)
+          end
+
+          # Send a local file (image or generic file) as a native attachment.
+          # Webhook can't deliver attachments — use OAPI sendMessage with mediaId.
+          # @param chat_id [String]
+          # @param path [String] local file path
+          # @param name [String, nil] display filename (not used by image msg)
+          def send_file(chat_id, path, name: nil, reply_to: nil)
+            unless File.exist?(path)
+              Clacky::Logger.warn("[dingtalk] send_file: file not found #{path}")
+              return { ok: false, error: "file_not_found" }
+            end
+
+            route = resolve_route(chat_id)
+            unless route
+              Clacky::Logger.warn("[dingtalk] send_file: no routing info for chat #{chat_id}")
+              return { ok: false, error: "no_route" }
+            end
+
+            kind = image_file?(path) ? :image : :file
+
+            # Non-image files outside DingTalk's accepted extension list
+            # (sampleFile rejects anything not in SUPPORTED_FILE_EXTS).
+            # Surface the failure directly to the user in the chat,
+            # disguised as a DingTalk system message so it's clear the
+            # restriction comes from the IM platform, not us.
+            if kind == :file && !supported_file?(path)
+              ext = File.extname(path).delete_prefix(".").downcase
+              display_name = name || File.basename(path)
+              Clacky::Logger.info("[dingtalk] send_file: unsupported extension .#{ext} (#{display_name})")
+              supported_list = ApiClient::SUPPORTED_FILE_EXTS.map { |e| ".#{e}" }.join(", ")
+              send_text(
+                chat_id,
+                %([DingTalk System] ⚠️ Failed to deliver file "#{display_name}": file type ".#{ext}" is not supported. Supported types: #{supported_list}.)
+              )
+              return { ok: false, error: :unsupported_extension }
+            end
+
+            media_id = @api_client.upload_media(path, kind: kind)
+            unless media_id
+              Clacky::Logger.warn("[dingtalk] send_file: upload failed for #{path}")
+              return { ok: false, error: "upload_failed" }
+            end
+
+            @api_client.send_media(
+              robot_code: route[:robot_code],
+              conv_type:  route[:conv_type],
+              conv_id:    route[:conv_id],
+              user_id:    route[:user_id],
+              media_id:   media_id,
+              kind:       kind,
+              file_name:  name || File.basename(path)
+            )
           end
 
           def validate_config(config)
@@ -106,16 +166,18 @@ module Clacky
             chat_id      = data.dig("conversationId") || sender_id
             webhook_url  = data.dig("sessionWebhook") || ""
             expired_ms   = (data.dig("sessionWebhookExpiredTime") || 0).to_i
-            text         = extract_text(data)
             conv_type    = data.dig("conversationType").to_s  # "1"=DM, "2"=group
+            robot_code   = data["robotCode"].to_s
 
             cache_webhook(chat_id, webhook_url, expired_ms) unless webhook_url.empty?
+            cache_route(chat_id, robot_code: robot_code, conv_id: data["conversationId"].to_s,
+                        user_id: sender_id, conv_type: conv_type)
 
             return if sender_id.empty?
 
             # Group chats: only respond when @-mentioned
             if conv_type == "2"
-              content = data.dig("text", "content").to_s
+              content  = data.dig("text", "content").to_s
               at_users = Array(data.dig("atUsers")).map { |u| u.dig("dingtalkId") || u.dig("staffId") || "" }
               bot_id   = data.dig("chatbotUserId").to_s
               unless at_users.include?(bot_id) || content.include?("@")
@@ -126,20 +188,70 @@ module Clacky
             allowed = @config[:allowed_users]
             return if allowed && !allowed.empty? && !allowed.include?(sender_id)
 
+            text, files = extract_payload(data, robot_code)
+            return if text.strip.empty? && files.empty?
+
             event = {
               platform:   :dingtalk,
               user_id:    sender_id,
               chat_id:    chat_id,
               message_id: data.dig("msgId") || "",
               text:       text,
-              files:      [],
+              files:      files,
               chat_type:  conv_type == "2" ? :group : :direct
             }
 
-            Clacky::Logger.info("[dingtalk] message from #{sender_id}: #{text.to_s[0, 80]}")
+            log_parts = []
+            log_parts << text.slice(0, 80) unless text.strip.empty?
+            log_parts << "#{files.size} file(s)" unless files.empty?
+            Clacky::Logger.info("[dingtalk] message from #{sender_id}: #{log_parts.join(' | ')}")
             @on_message&.call(event)
           rescue => e
             Clacky::Logger.warn("[dingtalk] handle_frame error: #{e.message}")
+          end
+
+          # Parse text + attachments from inbound event by msgtype.
+          # Returns [text, files] where files is an array of { path:, mime:, name: }.
+          private def extract_payload(data, robot_code)
+            msgtype = data["msgtype"].to_s
+            text    = ""
+            files   = []
+
+            case msgtype
+            when "text"
+              text = extract_text(data)
+            when "picture"
+              code = data.dig("content", "downloadCode")
+              file = download_one(code, robot_code)
+              files << file if file
+            when "file"
+              # Inbound file message — DingTalk's downloadCode → downloadUrl path
+              # works for any file type (no whitelist on the inbound side).
+              code = data.dig("content", "downloadCode")
+              name = data.dig("content", "fileName")
+              file = download_one(code, robot_code, prefer_name: name)
+              files << file if file
+            when "richText"
+              Array(data.dig("content", "richText")).each do |part|
+                if part["text"]
+                  text += part["text"].to_s
+                elsif part["downloadCode"] && part["type"] == "picture"
+                  file = download_one(part["downloadCode"], robot_code)
+                  files << file if file
+                end
+              end
+            else
+              Clacky::Logger.info("[dingtalk] unsupported msgtype=#{msgtype}, ignoring")
+            end
+
+            [text, files]
+          end
+
+          private def download_one(download_code, robot_code, prefer_name: nil)
+            res = @api_client.download_message_file(download_code, robot_code, prefer_name: prefer_name)
+            return nil unless res
+            name = (prefer_name && !prefer_name.to_s.empty?) ? prefer_name.to_s : File.basename(res[:path])
+            { path: res[:path], mime: res[:mime], name: name }
           end
 
           private def extract_text(data)
@@ -167,6 +279,31 @@ module Clacky
               end
             end
             entry[:url]
+          end
+
+          private def cache_route(chat_id, robot_code:, conv_id:, user_id:, conv_type:)
+            return if robot_code.empty?
+            @routes_mutex.synchronize do
+              @routes[chat_id] = {
+                robot_code: robot_code,
+                conv_id:    conv_id,
+                user_id:    user_id,
+                conv_type:  conv_type
+              }
+            end
+          end
+
+          private def resolve_route(chat_id)
+            @routes_mutex.synchronize { @routes[chat_id] }
+          end
+
+          private def image_file?(path)
+            %w[.jpg .jpeg .png .gif .webp].include?(File.extname(path).downcase)
+          end
+
+          private def supported_file?(path)
+            ext = File.extname(path).delete_prefix(".").downcase
+            ApiClient::SUPPORTED_FILE_EXTS.include?(ext)
           end
         end
 

--- a/lib/clacky/server/channel/adapters/dingtalk/api_client.rb
+++ b/lib/clacky/server/channel/adapters/dingtalk/api_client.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "uri"
 require "json"
+require "securerandom"
 
 module Clacky
   module Channel
@@ -11,12 +12,31 @@ module Clacky
         # DingTalk Bot API client — sends messages via session webhook (Stream Mode).
         class ApiClient
           OPENAPI_BASE = "https://api.dingtalk.com"
+          OAPI_BASE    = "https://oapi.dingtalk.com"
+
+          # File extensions accepted by DingTalk sampleFile message (fileType field).
+          # Anything outside this list is rejected by DingTalk's API — we surface
+          # a friendly text notice to the user instead of attempting upload.
+          #
+          # Why 9 entries instead of the 6 the public doc lists? The official
+          # doc (open.dingtalk.com / sampleFile) explicitly names only:
+          #   xlsx, pdf, zip, rar, doc, docx
+          # However old-format Office types (xls / ppt / pptx) are accepted in
+          # practice and were verified by hand during the C-5597 rollout.
+          # We deliberately keep the empirical 9-entry list because
+          # downgrading to the doc's 6 would silently reject files users
+          # routinely send. If DingTalk ever tightens enforcement and the
+          # extra 3 start failing, prefer adding a converter (e.g. xls→xlsx)
+          # over shrinking the list — the goal is "things users send arrive".
+          SUPPORTED_FILE_EXTS = %w[doc docx xls xlsx ppt pptx pdf zip rar].freeze
 
           def initialize(client_id:, client_secret:)
             @client_id     = client_id
             @client_secret = client_secret
             @token         = nil
             @token_expires_at = 0
+            @oapi_token    = nil
+            @oapi_token_expires_at = 0
           end
 
           # Send a text (or Markdown) message via the session webhook URL.
@@ -67,6 +87,26 @@ module Clacky
             @token
           end
 
+          # OAPI access token — required by legacy /media/upload endpoint.
+          # Independent token system from /v1.0/oauth2/accessToken.
+          def oapi_access_token
+            return @oapi_token if @oapi_token && Time.now.to_i < @oapi_token_expires_at - 60
+
+            uri = URI.parse("#{OAPI_BASE}/gettoken?appkey=#{@client_id}&appsecret=#{@client_secret}")
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            resp = http.request(Net::HTTP::Get.new(uri.request_uri))
+            data = JSON.parse(resp.body)
+
+            unless resp.code.to_i == 200 && data["errcode"].to_i.zero? && data["access_token"]
+              raise "DingTalk OAPI token error (#{resp.code}): #{data["errmsg"] || resp.body}"
+            end
+
+            @oapi_token = data["access_token"]
+            @oapi_token_expires_at = Time.now.to_i + (data["expires_in"] || 7200).to_i
+            @oapi_token
+          end
+
           # Validate credentials by fetching a token.
           # @return [Hash] { ok: Boolean, error: String? }
           def test_connection
@@ -74,6 +114,275 @@ module Clacky
             { ok: true, message: "DingTalk access token obtained" }
           rescue => e
             { ok: false, error: e.message }
+          end
+
+          # Download a file the bot received, given its downloadCode + robotCode
+          # from the inbound event. Two-step: exchange downloadCode for a temporary
+          # downloadUrl, then persist bytes to UPLOAD_DIR via FileProcessor.save.
+          # @param download_code [String]
+          # @param robot_code [String]
+          # @param prefer_name [String, nil] original filename from inbound event
+          #   (DingTalk's content.fileName) — used to pick the file extension so
+          #   downstream consumers (parsers, vision models) route by suffix correctly.
+          # @return [Hash, nil] { name:, path:, mime: } or nil on failure
+          def download_message_file(download_code, robot_code, prefer_name: nil)
+            return nil if download_code.to_s.empty? || robot_code.to_s.empty?
+
+            url = fetch_download_url(download_code, robot_code)
+            return nil unless url
+
+            download_to_disk(url, prefer_name: prefer_name)
+          rescue => e
+            Clacky::Logger.warn("[dingtalk] download_message_file failed: #{e.message}")
+            nil
+          end
+
+          private def fetch_download_url(download_code, robot_code)
+            uri  = URI.parse("#{OPENAPI_BASE}/v1.0/robot/messageFiles/download")
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            req = Net::HTTP::Post.new(uri.path,
+              "Content-Type"                => "application/json",
+              "x-acs-dingtalk-access-token" => access_token)
+            req.body = JSON.generate(downloadCode: download_code, robotCode: robot_code)
+            resp = http.request(req)
+            data = JSON.parse(resp.body) rescue {}
+            unless resp.code.to_i == 200 && data["downloadUrl"]
+              Clacky::Logger.warn("[dingtalk] fetch_download_url rejected (#{resp.code}): #{resp.body}")
+              return nil
+            end
+            data["downloadUrl"]
+          end
+
+          private def download_to_disk(url, prefer_name: nil)
+            uri  = URI.parse(url)
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = uri.scheme == "https"
+            resp = http.get(uri.request_uri)
+            return nil unless resp.code.to_i == 200
+
+            mime = resp["content-type"].to_s
+            # Prefer extension from the original fileName supplied by DingTalk
+            # (e.g. report.pdf, notes.txt). Fall back to MIME mapping, then .bin.
+            ext  = ext_from_name(prefer_name) || guess_ext(mime) || ".bin"
+
+            base     = prefer_name && !prefer_name.to_s.empty? ?
+                         File.basename(prefer_name.to_s, ".*") : "dingtalk"
+            base     = sanitize_basename(base)
+            filename = "#{base}-#{Time.now.strftime('%Y%m%d-%H%M%S')}-#{SecureRandom.hex(3)}#{ext}"
+            saved    = Clacky::Utils::FileProcessor.save(body: resp.body, filename: filename)
+            saved.merge(mime: mime)
+          end
+
+          private def ext_from_name(name)
+            return nil if name.to_s.empty?
+            ext = File.extname(name.to_s).downcase
+            ext.empty? ? nil : ext
+          end
+
+          private def sanitize_basename(name)
+            # Keep ASCII letters/digits/dash/underscore; drop everything else
+            # (CJK, spaces, slashes) so the final filename stays filesystem-safe.
+            cleaned = name.to_s.gsub(/[^A-Za-z0-9_\-]/, "_").gsub(/_+/, "_").gsub(/^_+|_+$/, "")
+            cleaned.empty? ? "dingtalk" : cleaned
+          end
+
+          private def guess_ext(mime)
+            case mime.to_s.split(";").first.to_s.strip.downcase
+            # Images
+            when "image/jpeg", "image/jpg" then ".jpg"
+            when "image/png"               then ".png"
+            when "image/gif"               then ".gif"
+            when "image/webp"              then ".webp"
+            when "image/bmp"               then ".bmp"
+            when "image/svg+xml"           then ".svg"
+            # Documents
+            when "application/pdf"         then ".pdf"
+            when "application/msword"      then ".doc"
+            when "application/vnd.openxmlformats-officedocument.wordprocessingml.document" then ".docx"
+            when "application/vnd.ms-excel" then ".xls"
+            when "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" then ".xlsx"
+            when "application/vnd.ms-powerpoint" then ".ppt"
+            when "application/vnd.openxmlformats-officedocument.presentationml.presentation" then ".pptx"
+            # Archives
+            when "application/zip"         then ".zip"
+            when "application/x-rar-compressed", "application/vnd.rar" then ".rar"
+            when "application/x-7z-compressed" then ".7z"
+            when "application/x-tar"       then ".tar"
+            when "application/gzip"        then ".gz"
+            # Text
+            when "text/plain"              then ".txt"
+            when "text/markdown"           then ".md"
+            when "text/csv"                then ".csv"
+            when "text/html"               then ".html"
+            when "application/json"        then ".json"
+            when "application/xml", "text/xml" then ".xml"
+            when "application/x-yaml", "text/yaml" then ".yml"
+            # Audio / video
+            when "audio/mpeg"              then ".mp3"
+            when "audio/wav", "audio/x-wav" then ".wav"
+            when "audio/aac"               then ".aac"
+            when "audio/ogg"               then ".ogg"
+            when "video/mp4"               then ".mp4"
+            when "video/quicktime"         then ".mov"
+            end
+          end
+
+          # Upload a local file to DingTalk and return its media_id.
+          # Webhook delivery doesn't support image/file attachments — uploaded
+          # mediaId is used by the OAPI sendMessage path below.
+          # @param path [String]
+          # @param kind [Symbol] :image | :file
+          # @return [String, nil] media_id
+          def upload_media(path, kind:)
+            type_str = kind == :image ? "image" : "file"
+            # NB: legacy OAPI /media/upload — the new /v1.0/robot/messageFiles/*
+            # path returns 404, this is the only working endpoint as of 2026-05.
+            token    = oapi_access_token
+            uri      = URI.parse("#{OAPI_BASE}/media/upload?access_token=#{token}&type=#{type_str}")
+            boundary = "----DingTalkBoundary#{rand(1 << 64).to_s(16)}"
+            body     = build_multipart(path, boundary, type_str)
+
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            req = Net::HTTP::Post.new(uri.request_uri,
+              "Content-Type" => "multipart/form-data; boundary=#{boundary}")
+            req.body = body
+            resp = http.request(req)
+            data = JSON.parse(resp.body) rescue {}
+            unless resp.code.to_i == 200 && data["errcode"].to_i.zero? && data["media_id"]
+              Clacky::Logger.warn("[dingtalk] upload_media rejected (#{resp.code}): #{resp.body}")
+              return nil
+            end
+            # Operational log: confirm upload succeeded and surface the
+            # media_id shape (length + first 4 chars). We keep this at info
+            # level because outbound failures correlate strongly with
+            # media_id format drift (e.g. DingTalk silently changing the
+            # `@` prefix policy). Avoid logging the full body to keep the
+            # token / id from leaking into shared log channels.
+            mid = data["media_id"].to_s
+            Clacky::Logger.info("[dingtalk] upload_media ok type=#{type_str} media_id_len=#{mid.length} media_id_prefix=#{mid[0, 4].inspect}")
+            mid
+          rescue => e
+            Clacky::Logger.warn("[dingtalk] upload_media failed: #{e.message}")
+            nil
+          end
+
+          # Send a media message via OAPI (not webhook).
+          # DM    → /v1.0/robot/oToMessages/batchSend (needs userIds)
+          # Group → /v1.0/robot/groupMessages/send   (needs openConversationId)
+          # @param conv_type [String] "1"=DM, "2"=group
+          # @param kind [Symbol] :image | :file
+          def send_media(robot_code:, conv_type:, conv_id:, user_id:, media_id:, kind:, file_name: nil)
+            msg_key, msg_param = build_media_message(media_id, kind, file_name)
+
+            if conv_type == "2"
+              path = "/v1.0/robot/groupMessages/send"
+              body = {
+                msgKey:             msg_key,
+                msgParam:           JSON.generate(msg_param),
+                openConversationId: conv_id,
+                robotCode:          robot_code
+              }
+            else
+              path = "/v1.0/robot/oToMessages/batchSend"
+              body = {
+                msgKey:    msg_key,
+                msgParam:  JSON.generate(msg_param),
+                userIds:   [user_id],
+                robotCode: robot_code
+              }
+            end
+
+            uri  = URI.parse("#{OPENAPI_BASE}#{path}")
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            req = Net::HTTP::Post.new(uri.request_uri,
+              "Content-Type"                => "application/json",
+              "x-acs-dingtalk-access-token" => access_token)
+            req.body = JSON.generate(body)
+            resp = http.request(req)
+            data = JSON.parse(resp.body) rescue {}
+            if resp.code.to_i != 200
+              Clacky::Logger.warn("[dingtalk] send_media rejected (#{resp.code}): #{resp.body}")
+              return { ok: false, error: data["message"] || resp.body }
+            end
+            # Operational log: success path. We log msgKey (image vs file)
+            # so the operator can correlate "sampleImageMsg" with image
+            # delivery and "sampleFile" with file delivery without parsing
+            # the full request body.
+            Clacky::Logger.info("[dingtalk] send_media ok kind=#{kind} msgKey=#{msg_key}")
+            { ok: true, data: data }
+          rescue => e
+            Clacky::Logger.warn("[dingtalk] send_media failed: #{e.message}")
+            { ok: false, error: e.message }
+          end
+
+          private def build_media_message(media_id, kind, file_name)
+            # Images: `sampleImageMsg` with the OAPI-uploaded mediaId (type=image)
+            # renders an inline original-resolution image in the chat. The doc
+            # field is named `photoURL`, but DingTalk explicitly documents that
+            # photoURL accepts either a public URL OR a mediaId — and the
+            # mediaId form is what we use (the only way to send local files
+            # without standing up a public file server).
+            #
+            # NOTE — implementation pitfalls hard-won (2026-05-19):
+            #   1. Pass the raw mediaId returned by /media/upload AS-IS.
+            #      Despite the sampleLink doc example showing `picUrl: "@lADO..."`
+            #      with an `@` prefix, sampleImageMsg.photoURL must NOT be
+            #      prefixed — the upload response already includes whatever
+            #      shape DingTalk wants. Adding `@` produces "原图加载失败".
+            #   2. msgKey is `sampleImageMsg`, NOT `msgtype: "image"`.
+            #      `msgtype:image` belongs to the corpconversation/asyncsend_v2
+            #      work-notification protocol and does NOT work on the group
+            #      robot endpoint we use here.
+            #   3. msgParam must be a JSON-stringified object (handled by the
+            #      caller), not a nested hash.
+            return ["sampleImageMsg", { photoURL: media_id }] if kind == :image
+
+            # Generic files: sampleFile. fileType must be one of
+            # SUPPORTED_FILE_EXTS (see top of file for why we keep the
+            # empirically-verified 9-entry list rather than the 6-entry
+            # doc list). Upstream `Adapter#send_file` already screens out
+            # unsupported extensions before we reach here, so we just pass
+            # `ext` through.
+            ext = File.extname(file_name.to_s).delete(".")
+            ["sampleFile", { mediaId: media_id, fileName: file_name.to_s, fileType: ext }]
+          end
+
+          private def build_multipart(path, boundary, type_str)
+            filename = File.basename(path)
+            mime     = mime_for(filename)
+            content  = File.binread(path)
+
+            # All parts must be ASCII-8BIT before joining; mixing UTF-8 (e.g. a
+            # filename with CJK chars) with binary file content raises
+            # "incompatible character encodings: UTF-8 and BINARY".
+            parts = []
+            parts << "--#{boundary}\r\n".b
+            parts << "Content-Disposition: form-data; name=\"type\"\r\n\r\n#{type_str}\r\n".b
+            parts << "--#{boundary}\r\n".b
+            parts << "Content-Disposition: form-data; name=\"media\"; filename=\"#{filename}\"\r\n".b
+            parts << "Content-Type: #{mime}\r\n\r\n".b
+            parts << content.b
+            parts << "\r\n--#{boundary}--\r\n".b
+            parts.join
+          end
+
+          private def mime_for(filename)
+            case File.extname(filename).downcase
+            when ".jpg", ".jpeg" then "image/jpeg"
+            when ".png"          then "image/png"
+            when ".gif"          then "image/gif"
+            when ".webp"         then "image/webp"
+            when ".txt", ".log"  then "text/plain"
+            when ".md"           then "text/markdown"
+            when ".pdf"          then "application/pdf"
+            when ".json"         then "application/json"
+            when ".csv"          then "text/csv"
+            when ".zip"          then "application/zip"
+            else                       "application/octet-stream"
+            end
           end
         end
       end

--- a/spec/clacky/server/channel/adapters/dingtalk/adapter_spec.rb
+++ b/spec/clacky/server/channel/adapters/dingtalk/adapter_spec.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/channel/adapters/dingtalk/adapter"
+require "clacky/server/channel/adapters/dingtalk/api_client"
+
+RSpec.describe Clacky::Channel::Adapters::DingTalk::Adapter do
+  let(:config) do
+    {
+      client_id:     "cid",
+      client_secret: "secret",
+      allowed_users: []
+    }
+  end
+
+  let(:adapter)    { described_class.new(config) }
+  let(:api_client) { adapter.instance_variable_get(:@api_client) }
+
+  describe ".platform_id" do
+    it { expect(described_class.platform_id).to eq(:dingtalk) }
+  end
+
+  describe "#send_text" do
+    let(:webhook) { "https://oapi.dingtalk.com/robot/send?access_token=xxx" }
+
+    before do
+      adapter.send(:cache_webhook, "chat-1", webhook,
+                   ((Time.now.to_f + 7200) * 1000).to_i)
+    end
+
+    it "always sends as markdown msgtype (C-5596)" do
+      expect(api_client).to receive(:send_via_webhook)
+        .with(webhook, "# Hello\n**bold**", msg_type: :markdown)
+        .and_return({ "errcode" => 0 })
+
+      adapter.send_text("chat-1", "# Hello\n**bold**")
+    end
+
+    it "sends plain text as markdown too (no detection branch)" do
+      expect(api_client).to receive(:send_via_webhook)
+        .with(webhook, "just text", msg_type: :markdown)
+        .and_return({ "errcode" => 0 })
+
+      adapter.send_text("chat-1", "just text")
+    end
+
+    it "returns error hash when webhook expired" do
+      adapter.instance_variable_set(:@webhook_urls, {})
+      result = adapter.send_text("chat-1", "hi")
+      expect(result[:ok]).to eq(false)
+      expect(result[:error]).to eq("session_webhook_expired")
+    end
+  end
+
+  describe "#handle_frame inbound parsing (C-5598)" do
+    let(:on_message) { ->(_evt) {} }
+    let(:webhook)    { "https://oapi.dingtalk.com/robot/send?access_token=xxx" }
+    let(:expires)    { ((Time.now.to_f + 7200) * 1000).to_i }
+
+    before { adapter.instance_variable_set(:@on_message, on_message) }
+
+    def base_data(extra = {})
+      {
+        "senderStaffId"             => "user-1",
+        "conversationId"            => "conv-1",
+        "sessionWebhook"            => webhook,
+        "sessionWebhookExpiredTime" => expires,
+        "conversationType"          => "1",
+        "robotCode"                 => "robot-1",
+        "msgId"                     => "m-1"
+      }.merge(extra)
+    end
+
+    def frame(data)
+      {
+        "headers" => { "topic" => "/v1.0/im/bot/messages/get" },
+        "data"    => JSON.generate(data)
+      }
+    end
+
+    it "parses text msgtype" do
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "text",
+        "text"    => { "content" => "hello bot" }
+      )))
+
+      expect(captured[:text]).to eq("hello bot")
+      expect(captured[:files]).to eq([])
+    end
+
+    it "parses picture msgtype and downloads file" do
+      tempfile = Tempfile.new(["dl-", ".png"])
+      tempfile.close
+      allow(api_client).to receive(:download_message_file)
+        .with("DL-CODE-1", "robot-1", prefer_name: nil)
+        .and_return({ path: tempfile.path, mime: "image/png" })
+
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "picture",
+        "content" => { "downloadCode" => "DL-CODE-1" }
+      )))
+
+      expect(captured[:files].size).to eq(1)
+      expect(captured[:files].first[:mime]).to eq("image/png")
+    end
+
+    it "parses file msgtype, downloads it, and preserves original fileName" do
+      tempfile = Tempfile.new(["dl-", ".bin"])
+      tempfile.close
+      allow(api_client).to receive(:download_message_file)
+        .with("DL-FILE-1", "robot-1", prefer_name: "report.pdf")
+        .and_return({ path: tempfile.path, mime: "application/pdf" })
+
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "file",
+        "content" => { "downloadCode" => "DL-FILE-1", "fileName" => "report.pdf" }
+      )))
+
+      expect(captured[:files].size).to eq(1)
+      expect(captured[:files].first[:name]).to eq("report.pdf")
+      expect(captured[:files].first[:mime]).to eq("application/pdf")
+    end
+
+    it "parses file msgtype for non-whitelist extensions (e.g. .txt) — inbound has no whitelist" do
+      tempfile = Tempfile.new(["dl-", ".bin"])
+      tempfile.close
+      allow(api_client).to receive(:download_message_file)
+        .with("DL-FILE-2", "robot-1", prefer_name: "notes.txt")
+        .and_return({ path: tempfile.path, mime: "text/plain" })
+
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "file",
+        "content" => { "downloadCode" => "DL-FILE-2", "fileName" => "notes.txt" }
+      )))
+
+      expect(captured[:files].size).to eq(1)
+      expect(captured[:files].first[:name]).to eq("notes.txt")
+    end
+
+    it "parses richText msgtype: text + picture mixed" do
+      tempfile = Tempfile.new(["dl-", ".jpg"])
+      tempfile.close
+      allow(api_client).to receive(:download_message_file)
+        .with("DL-CODE-2", "robot-1", prefer_name: nil)
+        .and_return({ path: tempfile.path, mime: "image/jpeg" })
+
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "richText",
+        "content" => {
+          "richText" => [
+            { "text" => "look at this " },
+            { "downloadCode" => "DL-CODE-2", "type" => "picture" }
+          ]
+        }
+      )))
+
+      expect(captured[:text]).to eq("look at this ")
+      expect(captured[:files].size).to eq(1)
+    end
+
+    it "skips download when downloadCode resolution fails" do
+      allow(api_client).to receive(:download_message_file).and_return(nil)
+
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "picture",
+        "content" => { "downloadCode" => "BAD" }
+      )))
+
+      expect(captured).to be_nil  # text empty + files empty → no event
+    end
+
+    it "ignores unsupported msgtype" do
+      captured = nil
+      adapter.instance_variable_set(:@on_message, ->(evt) { captured = evt })
+
+      adapter.send(:handle_frame, frame(base_data(
+        "msgtype" => "audio",
+        "content" => { "downloadCode" => "X" }
+      )))
+
+      expect(captured).to be_nil
+    end
+  end
+
+  describe "#send_file (C-5597)" do
+    let(:tempfile) do
+      f = Tempfile.new(["pic-", ".png"])
+      f.write("\x89PNG fake")
+      f.close
+      f
+    end
+
+    before do
+      adapter.send(:cache_route, "chat-1",
+                   robot_code: "robot-1",
+                   conv_id:    "conv-1",
+                   user_id:    "user-1",
+                   conv_type:  "1")
+    end
+
+    it "uploads media then sends image via OAPI for DM" do
+      expect(api_client).to receive(:upload_media)
+        .with(tempfile.path, kind: :image)
+        .and_return("media-xyz")
+      expect(api_client).to receive(:send_media)
+        .with(hash_including(
+          robot_code: "robot-1",
+          conv_type:  "1",
+          user_id:    "user-1",
+          media_id:   "media-xyz",
+          kind:       :image
+        ))
+        .and_return({ ok: true })
+
+      result = adapter.send_file("chat-1", tempfile.path)
+      expect(result[:ok]).to eq(true)
+    end
+
+    it "uses :file kind for non-image extensions" do
+      pdf = Tempfile.new(["doc-", ".pdf"])
+      pdf.write("hi"); pdf.close
+
+      expect(api_client).to receive(:upload_media)
+        .with(pdf.path, kind: :file)
+        .and_return("media-doc")
+      expect(api_client).to receive(:send_media)
+        .with(hash_including(kind: :file, file_name: File.basename(pdf.path)))
+        .and_return({ ok: true })
+
+      adapter.send_file("chat-1", pdf.path)
+    end
+
+    it "sends [DingTalk System] error text and returns ok:false for non-whitelist files" do
+      txt = Tempfile.new(["unsupported-", ".txt"])
+      txt.write("hi"); txt.close
+
+      # send_text routes via webhook, so the spec needs a valid sessionWebhook
+      # cached for chat-1 (the parent describe only seeds cache_route).
+      adapter.send(:cache_webhook, "chat-1",
+                   "https://oapi.dingtalk.com/robot/send?access_token=xxx",
+                   ((Time.now.to_f + 7200) * 1000).to_i)
+
+      # Adapter must NOT upload or call send_media for unsupported extensions.
+      # Instead it sends a chat message disguised as a DingTalk system error,
+      # so the user sees the failure inline without any LLM round-trip.
+      expect(api_client).not_to receive(:upload_media)
+      expect(api_client).not_to receive(:send_media)
+
+      sent_text = nil
+      expect(api_client).to receive(:send_via_webhook) do |_url, text, **_kwargs|
+        sent_text = text
+        { "errcode" => 0 }
+      end
+
+      result = adapter.send_file("chat-1", txt.path, name: "report.txt")
+      expect(result[:ok]).to eq(false)
+      expect(result[:error]).to eq(:unsupported_extension)
+
+      expect(sent_text).to start_with("[DingTalk System] ⚠️")
+      expect(sent_text).to include('"report.txt"')
+      expect(sent_text).to include('".txt"')
+      # Lists the supported extensions so the LLM/user knows what to convert to.
+      Clacky::Channel::Adapters::DingTalk::ApiClient::SUPPORTED_FILE_EXTS.each do |ext|
+        expect(sent_text).to include(".#{ext}")
+      end
+    end
+
+    it "returns file_not_found when path doesn't exist" do
+      result = adapter.send_file("chat-1", "/nonexistent/path.png")
+      expect(result[:ok]).to eq(false)
+      expect(result[:error]).to eq("file_not_found")
+    end
+
+    it "returns no_route when chat has no cached routing" do
+      adapter.instance_variable_set(:@routes, {})
+      result = adapter.send_file("chat-1", tempfile.path)
+      expect(result[:ok]).to eq(false)
+      expect(result[:error]).to eq("no_route")
+    end
+
+    it "returns upload_failed when media upload returns nil" do
+      allow(api_client).to receive(:upload_media).and_return(nil)
+      result = adapter.send_file("chat-1", tempfile.path)
+      expect(result[:ok]).to eq(false)
+      expect(result[:error]).to eq("upload_failed")
+    end
+  end
+end

--- a/spec/clacky/server/channel/adapters/dingtalk/api_client_spec.rb
+++ b/spec/clacky/server/channel/adapters/dingtalk/api_client_spec.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/channel/adapters/dingtalk/api_client"
+
+RSpec.describe Clacky::Channel::Adapters::DingTalk::ApiClient do
+  let(:client) { described_class.new(client_id: "cid", client_secret: "secret") }
+
+  before do
+    # Stub access_token to avoid hitting real network
+    allow(client).to receive(:access_token).and_return("AT-stub")
+    allow(client).to receive(:oapi_access_token).and_return("OAPI-stub")
+  end
+
+  # Build a Net::HTTPResponse-like double whose body / code can be controlled.
+  def fake_response(code:, body:, headers: {})
+    resp = instance_double(Net::HTTPResponse)
+    allow(resp).to receive(:code).and_return(code.to_s)
+    allow(resp).to receive(:body).and_return(body)
+    headers.each { |k, v| allow(resp).to receive(:[]).with(k).and_return(v) }
+    allow(resp).to receive(:[]).and_return(nil) unless headers.any?
+    resp
+  end
+
+  describe "#send_via_webhook (C-5596)" do
+    let(:webhook) { "https://oapi.dingtalk.com/robot/send?access_token=xxx" }
+
+    it "builds markdown body with title + text when msg_type is :markdown" do
+      captured = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured = JSON.parse(req.body)
+        fake_response(code: 200, body: '{"errcode":0}')
+      end
+
+      client.send_via_webhook(webhook, "# Hi\n**bold**", msg_type: :markdown)
+      expect(captured["msgtype"]).to eq("markdown")
+      expect(captured["markdown"]["title"]).to eq("Reply")
+      expect(captured["markdown"]["text"]).to eq("# Hi\n**bold**")
+    end
+
+    it "builds text body when msg_type is :text" do
+      captured = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured = JSON.parse(req.body)
+        fake_response(code: 200, body: '{"errcode":0}')
+      end
+
+      client.send_via_webhook(webhook, "plain", msg_type: :text)
+      expect(captured["msgtype"]).to eq("text")
+      expect(captured["text"]["content"]).to eq("plain")
+    end
+  end
+
+  describe "#download_message_file (C-5598)" do
+    it "exchanges downloadCode for downloadUrl then persists bytes to UPLOAD_DIR" do
+      call_count = 0
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, _req|
+        call_count += 1
+        fake_response(code: 200, body: JSON.generate(downloadUrl: "https://cdn.example/x.png"))
+      end
+      allow_any_instance_of(Net::HTTP).to receive(:get) do |_http, _path|
+        fake_response(code: 200, body: "PNGDATA", headers: { "content-type" => "image/png" })
+      end
+
+      result = client.download_message_file("DC-1", "robot-1")
+      expect(result).not_to be_nil
+      expect(result[:mime]).to eq("image/png")
+      expect(result[:name]).to match(/\Adingtalk-\d{8}-\d{6}-[0-9a-f]{6}\.png\z/)
+      expect(File.exist?(result[:path])).to be(true)
+      expect(File.read(result[:path])).to eq("PNGDATA")
+    end
+
+    it "preserves the original filename's extension when prefer_name is supplied" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 200, body: JSON.generate(downloadUrl: "https://cdn.example/x")))
+      allow_any_instance_of(Net::HTTP).to receive(:get)
+        .and_return(fake_response(code: 200, body: "PDFDATA",
+                                  headers: { "content-type" => "application/pdf" }))
+
+      result = client.download_message_file("DC-2", "robot-1", prefer_name: "report.pdf")
+      expect(result[:name]).to end_with(".pdf")
+      expect(result[:name]).to start_with("report-")
+    end
+
+    it "preserves the .txt extension for non-whitelist files (no .bin downgrade)" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 200, body: JSON.generate(downloadUrl: "https://cdn.example/x")))
+      allow_any_instance_of(Net::HTTP).to receive(:get)
+        .and_return(fake_response(code: 200, body: "hello",
+                                  headers: { "content-type" => "text/plain" }))
+
+      result = client.download_message_file("DC-3", "robot-1", prefer_name: "notes.txt")
+      expect(result[:name]).to end_with(".txt")
+    end
+
+    it "falls back to MIME-based extension when prefer_name is nil" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 200, body: JSON.generate(downloadUrl: "https://cdn.example/x")))
+      allow_any_instance_of(Net::HTTP).to receive(:get)
+        .and_return(fake_response(code: 200, body: "PDFDATA",
+                                  headers: { "content-type" => "application/pdf" }))
+
+      result = client.download_message_file("DC-4", "robot-1")
+      expect(result[:name]).to end_with(".pdf")
+    end
+
+    it "sanitizes CJK / spaces in basename to keep filesystem-safe filenames" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 200, body: JSON.generate(downloadUrl: "https://cdn.example/x")))
+      allow_any_instance_of(Net::HTTP).to receive(:get)
+        .and_return(fake_response(code: 200, body: "x",
+                                  headers: { "content-type" => "application/pdf" }))
+
+      result = client.download_message_file("DC-5", "robot-1", prefer_name: "我的 报告.pdf")
+      expect(result[:name]).to end_with(".pdf")
+      # basename portion should not contain CJK / spaces
+      expect(result[:name]).not_to match(/[\u4e00-\u9fff ]/)
+    end
+
+    it "returns nil on missing downloadUrl" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 200, body: '{"errcode":40000}'))
+      expect(client.download_message_file("DC-X", "robot-1")).to be_nil
+    end
+
+    it "returns nil on empty downloadCode" do
+      expect(client.download_message_file("", "robot-1")).to be_nil
+    end
+
+    it "returns nil on empty robotCode" do
+      expect(client.download_message_file("DC-X", "")).to be_nil
+    end
+  end
+
+  describe "#guess_ext (private)" do
+    it "maps common image mime types" do
+      expect(client.send(:guess_ext, "image/jpeg")).to eq(".jpg")
+      expect(client.send(:guess_ext, "image/png")).to  eq(".png")
+      expect(client.send(:guess_ext, "image/gif")).to  eq(".gif")
+      expect(client.send(:guess_ext, "image/webp")).to eq(".webp")
+    end
+
+    it "maps document mime types" do
+      expect(client.send(:guess_ext, "application/pdf")).to eq(".pdf")
+      expect(client.send(:guess_ext, "application/vnd.openxmlformats-officedocument.wordprocessingml.document")).to eq(".docx")
+      expect(client.send(:guess_ext, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).to eq(".xlsx")
+    end
+
+    it "maps text and archive mime types" do
+      expect(client.send(:guess_ext, "text/plain")).to eq(".txt")
+      expect(client.send(:guess_ext, "application/json")).to eq(".json")
+      expect(client.send(:guess_ext, "application/zip")).to eq(".zip")
+    end
+
+    it "tolerates charset suffix in Content-Type header" do
+      expect(client.send(:guess_ext, "text/plain; charset=utf-8")).to eq(".txt")
+    end
+
+    it "returns nil for unknown mime" do
+      expect(client.send(:guess_ext, "application/x-something-novel")).to be_nil
+    end
+  end
+
+  describe "#mime_for (private)" do
+    it "maps image extensions" do
+      expect(client.send(:mime_for, "a.png")).to  eq("image/png")
+      expect(client.send(:mime_for, "a.jpg")).to  eq("image/jpeg")
+      expect(client.send(:mime_for, "a.jpeg")).to eq("image/jpeg")
+      expect(client.send(:mime_for, "a.gif")).to  eq("image/gif")
+      expect(client.send(:mime_for, "a.webp")).to eq("image/webp")
+    end
+
+    it "falls back to octet-stream for unknown" do
+      expect(client.send(:mime_for, "a.bin")).to eq("application/octet-stream")
+    end
+  end
+
+  describe "#build_media_message (private)" do
+    it "produces sampleImageMsg with photoURL=mediaId for :image (renders inline thumbnail)" do
+      key, param = client.send(:build_media_message, "media-1", :image, "x.png")
+      expect(key).to eq("sampleImageMsg")
+      expect(param).to eq(photoURL: "media-1")
+    end
+
+    it "produces sampleFile with mediaId/fileName/fileType for :file" do
+      key, param = client.send(:build_media_message, "media-2", :file, "report.pdf")
+      expect(key).to eq("sampleFile")
+      expect(param).to eq(mediaId: "media-2", fileName: "report.pdf", fileType: "pdf")
+    end
+  end
+
+  describe "#build_multipart (private)" do
+    let(:tempfile) do
+      f = Tempfile.new(["up-", ".png"])
+      f.write("\x89PNG fake")
+      f.close
+      f
+    end
+
+    it "includes the type field, media field, and file content" do
+      body = client.send(:build_multipart, tempfile.path, "BOUND", "image")
+      expect(body).to include('name="type"')
+      expect(body).to include('image')
+      expect(body).to include('name="media"')
+      expect(body.b).to include("\x89PNG fake".b)
+      expect(body).to include("--BOUND--")
+    end
+
+    # Regression: filenames with non-ASCII chars (e.g. CJK) used to crash
+    # build_multipart with "incompatible character encodings: UTF-8 and BINARY"
+    # because UTF-8 string parts were joined with a binary file body.
+    it "handles UTF-8 filenames with binary content (no encoding crash)" do
+      utf8_file = Tempfile.new(["一些api key-", ".txt"])
+      utf8_file.binmode
+      utf8_file.write("\x00\x01binary\xFF\xFE".b)
+      utf8_file.close
+      expect {
+        client.send(:build_multipart, utf8_file.path, "BOUND", "file")
+      }.not_to raise_error
+    end
+  end
+
+  describe "#upload_media (C-5597)" do
+    let(:tempfile) do
+      f = Tempfile.new(["up-", ".png"])
+      f.write("\x89PNG fake")
+      f.close
+      f
+    end
+
+    it "POSTs multipart to OAPI /media/upload and returns media_id on success" do
+      captured_uri = nil
+      captured     = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured_uri = req.path
+        captured     = req
+        fake_response(code: 200, body: '{"errcode":0,"media_id":"media-abc","type":"image"}')
+      end
+
+      expect(client.upload_media(tempfile.path, kind: :image)).to eq("media-abc")
+      expect(captured_uri).to start_with("/media/upload")
+      expect(captured_uri).to include("access_token=OAPI-stub")
+      expect(captured_uri).to include("type=image")
+      expect(captured["Content-Type"]).to start_with("multipart/form-data")
+      expect(captured["x-acs-dingtalk-access-token"]).to be_nil
+      expect(captured.body).to include('name="media"')
+    end
+
+    it "returns nil on rejection" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 200, body: '{"errcode":40078,"errmsg":"invalid type"}'))
+      expect(client.upload_media(tempfile.path, kind: :image)).to be_nil
+    end
+  end
+
+  describe "#send_media (C-5597)" do
+    it "uses oToMessages/batchSend for DM (conv_type=1)" do
+      captured_uri  = nil
+      captured_body = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured_uri  = req.path
+        captured_body = JSON.parse(req.body)
+        fake_response(code: 200, body: '{"processQueryKey":"q"}')
+      end
+
+      result = client.send_media(
+        robot_code: "robot-1", conv_type: "1",
+        conv_id:    "conv-1",  user_id:   "user-1",
+        media_id:   "media-xyz", kind: :file, file_name: "report.pdf"
+      )
+      expect(result[:ok]).to eq(true)
+      expect(captured_uri).to eq("/v1.0/robot/oToMessages/batchSend")
+      expect(captured_body["msgKey"]).to eq("sampleFile")
+      expect(captured_body["userIds"]).to eq(["user-1"])
+      expect(captured_body["robotCode"]).to eq("robot-1")
+      expect(JSON.parse(captured_body["msgParam"])["mediaId"]).to eq("media-xyz")
+    end
+
+    it "uses groupMessages/send for group (conv_type=2)" do
+      captured_uri  = nil
+      captured_body = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured_uri  = req.path
+        captured_body = JSON.parse(req.body)
+        fake_response(code: 200, body: '{}')
+      end
+
+      client.send_media(
+        robot_code: "robot-1", conv_type: "2",
+        conv_id:    "conv-1",  user_id:   "user-1",
+        media_id:   "media-xyz", kind: :file, file_name: "report.pdf"
+      )
+      expect(captured_uri).to eq("/v1.0/robot/groupMessages/send")
+      expect(captured_body["openConversationId"]).to eq("conv-1")
+      expect(captured_body["msgKey"]).to eq("sampleFile")
+    end
+
+    it "uses sampleFile msgKey for non-image kind" do
+      captured_body = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured_body = JSON.parse(req.body)
+        fake_response(code: 200, body: '{}')
+      end
+
+      client.send_media(
+        robot_code: "robot-1", conv_type: "1",
+        conv_id:    "conv-1",  user_id:   "user-1",
+        media_id:   "media-doc", kind: :file, file_name: "report.pdf"
+      )
+      msg_param = JSON.parse(captured_body["msgParam"])
+      expect(captured_body["msgKey"]).to eq("sampleFile")
+      expect(msg_param["mediaId"]).to eq("media-doc")
+      expect(msg_param["fileName"]).to eq("report.pdf")
+      expect(msg_param["fileType"]).to eq("pdf")
+    end
+
+    it "uses sampleImageMsg msgKey for :image kind (renders inline preview)" do
+      captured_body = nil
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, req|
+        captured_body = JSON.parse(req.body)
+        fake_response(code: 200, body: '{}')
+      end
+
+      client.send_media(
+        robot_code: "robot-1", conv_type: "1",
+        conv_id:    "conv-1",  user_id:   "user-1",
+        media_id:   "media-img", kind: :image, file_name: "shot.png"
+      )
+      msg_param = JSON.parse(captured_body["msgParam"])
+      expect(captured_body["msgKey"]).to eq("sampleImageMsg")
+      expect(msg_param["photoURL"]).to eq("media-img")
+    end
+
+    it "returns ok=false on non-200 response" do
+      allow_any_instance_of(Net::HTTP).to receive(:request)
+        .and_return(fake_response(code: 500, body: '{"message":"server err"}'))
+
+      result = client.send_media(
+        robot_code: "robot-1", conv_type: "1",
+        conv_id:    "conv-1",  user_id:   "user-1",
+        media_id:   "media-xyz", kind: :image
+      )
+      expect(result[:ok]).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

DingTalk adapter has three interlocking bugs plus one missing inbound handler:

- **C-5596**: Outbound text sent as raw markdown string — DingTalk does not render it, user sees unformatted text.
- **C-5597**: Outbound file/image delivery silently drops for non-whitelisted extensions; images also fail because the per-turn capability reminder (injected in session context) is ignored by weak instruction-following models.
- **C-5598**: Inbound picture downloads lose the tempfile to Ruby GC before the agent can read it.

## Fix

- **C-5596** — Send outbound text as `msgtype=markdown` via webhook instead of raw markdown string.
- **C-5597** — Add `Adapter#send_file` with two-stage flow (`upload_media` → `send_media`). Files → `sampleFile`, images → `sampleImageMsg`. Move the per-turn capability reminder from session context to after the user's current turn (vision-Note pattern) so weak models actually honor it. Explicitly carve out `![alt](src)` from the file extension whitelist — images travel on a separate IM channel and have nothing to do with file restrictions. ✅
- **C-5598** — Use `Clacky::Utils::FileProcessor.save` instead of bare `Tempfile` for inbound picture downloads, so the file lives through the agent turn. ✅
- **New** — Inbound `file` msgtype now parsed; `fileName` passed to LLM with original extension instead of `.bin`. ✅

## Test

- `spec/clacky/agent/channel_capability_reminder_spec.rb` — verifies reminder injection point and `IMAGES` carve-out content.
- `spec/clacky/server/channel/adapters/capability_invariants_spec.rb` — only DingTalk declares non-empty capabilities.
- `spec/clacky/server/channel/adapters/dingtalk/capability_reminder_no_regression_spec.rb` — 4 explicit invariants: inbound file parsing, inbound image parsing, other IM adapters isolation, non-whitelist outbound blocking.

1976 examples, 0 failures. ✅