### PR TITLE
fix: 将 reasoning_content 以 <think> 标签包裹后传递到 Web UI

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1536,15 +1536,16 @@ module Clacky
       # Prepend reasoning/thinking content (from thinking-mode providers like
       # DeepSeek V4, Kimi K2) wrapped in <think> tags so the Web UI renders it
       # as a collapsible thinking block (see sessions.js _renderMarkdown).
-      full_content = content
       if reasoning_content && !reasoning_content.to_s.strip.empty?
         full_content = "<think>\n#{reasoning_content}\n</think>\n#{content}"
+      else
+        full_content = content
       end
 
       return if full_content.nil? || full_content.to_s.strip.empty?
 
       parsed = parse_file_links(content)
-      @ui&.show_assistant_message(parsed[:text], files: parsed[:files])
+      @ui&.show_assistant_message(full_content, files: parsed[:files])
     end
 
     # Track modified files for Time Machine snapshots

--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -427,7 +427,7 @@ module Clacky
               tool_calls_count: (response[:tool_calls] || []).size
             )
             if response[:content] && !response[:content].empty?
-              emit_assistant_message(response[:content])
+              emit_assistant_message(response[:content], reasoning_content: response[:reasoning_content])
             end
 
             # Show token usage after the assistant message so WebUI renders it below the bubble
@@ -448,7 +448,7 @@ module Clacky
 
           # Show assistant message if there's content before tool calls
           if response[:content] && !response[:content].empty?
-            emit_assistant_message(response[:content])
+            emit_assistant_message(response[:content], reasoning_content: response[:reasoning_content])
           end
 
           # Show token usage after assistant message (or immediately if no message).
@@ -1532,8 +1532,16 @@ module Clacky
     # and cannot load file:// directly) and must stay scoped to the Web UI
     # controller. IM channel subscribers need the original file:// markdown so
     # parse_file_links can extract paths and deliver images as native attachments.
-    private def emit_assistant_message(content)
-      return if content.nil? || content.empty?
+    private def emit_assistant_message(content, reasoning_content: nil)
+      # Prepend reasoning/thinking content (from thinking-mode providers like
+      # DeepSeek V4, Kimi K2) wrapped in <think> tags so the Web UI renders it
+      # as a collapsible thinking block (see sessions.js _renderMarkdown).
+      full_content = content
+      if reasoning_content && !reasoning_content.to_s.strip.empty?
+        full_content = "<think>\n#{reasoning_content}\n</think>\n#{content}"
+      end
+
+      return if full_content.nil? || full_content.to_s.strip.empty?
 
       parsed = parse_file_links(content)
       @ui&.show_assistant_message(parsed[:text], files: parsed[:files])

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -471,8 +471,13 @@ module Clacky
 
         case msg[:role].to_s
         when "assistant"
-          # Text content
+          # Text content — prepend reasoning/thinking content wrapped in <think> tags
+          # so the Web UI renders it as a collapsible thinking block
           text = extract_text_from_content(msg[:content]).to_s.strip
+          reasoning = msg[:reasoning_content]
+          if reasoning && !reasoning.to_s.strip.empty?
+            text = "<think>\n#{reasoning}\n</think>\n#{text}"
+          end
           ui.show_assistant_message(text, files: []) unless text.empty?
 
           # Tool calls embedded in assistant message

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -112,7 +112,7 @@ const Sessions = (() => {
     return `<details class="thinking-block">` +
       `<summary class="thinking-summary">` +
         `<span class="thinking-chevron">›</span>` +
-        `<span class="thinking-label">Thought for a moment</span>` +
+        `<span class="thinking-label">Thinking…</span>` +
       `</summary>` +
       `<div class="thinking-body">${renderedHtml}</div>` +
     `</details>`;

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -112,7 +112,7 @@ const Sessions = (() => {
     return `<details class="thinking-block">` +
       `<summary class="thinking-summary">` +
         `<span class="thinking-chevron">›</span>` +
-        `<span class="thinking-label">Thinking…</span>` +
+        `<span class="thinking-label">Thoughts</span>` +
       `</summary>` +
       `<div class="thinking-body">${renderedHtml}</div>` +
     `</details>`;

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -1594,4 +1594,50 @@ RSpec.describe Clacky::Agent do
       end
     end
   end
+
+  describe "#emit_assistant_message" do
+    let(:ui_collector) do
+      Class.new do
+        attr_reader :messages
+        def initialize; @messages = []; end
+        def show_assistant_message(content, files:)
+          @messages << { content: content, files: files }
+        end
+      end.new
+    end
+
+    before do
+      agent.instance_variable_set(:@ui, ui_collector)
+    end
+
+    it "sends content as-is when no reasoning_content is provided" do
+      agent.send(:emit_assistant_message, "Hello, world!")
+      expect(ui_collector.messages.first[:content]).to eq("Hello, world!")
+    end
+
+    it "prepends think-wrapped reasoning when reasoning_content is present" do
+      agent.send(:emit_assistant_message, "Final answer.", reasoning_content: "Let me think...")
+      msg = ui_collector.messages.first[:content]
+      expect(msg).to start_with("<think>\nLet me think...\n</think>\n")
+      expect(msg).to end_with("Final answer.")
+    end
+
+    it "treats whitespace-only reasoning_content the same as absent" do
+      agent.send(:emit_assistant_message, "Clean output.", reasoning_content: "   ")
+      expect(ui_collector.messages.first[:content]).to eq("Clean output.")
+    end
+
+    it "does NOT emit message when both content and reasoning are empty" do
+      agent.send(:emit_assistant_message, "", reasoning_content: nil)
+      expect(ui_collector.messages).to be_empty
+    end
+
+    it "preserves file links extracted from original content" do
+      agent.send(:emit_assistant_message, "See ![img](file:///tmp/photo.png).",
+                 reasoning_content: "Checking the file...")
+      msg = ui_collector.messages.first
+      expect(msg[:files]).not_to be_empty
+      expect(msg[:files].first[:name]).to eq("photo.png")
+    end
+  end
 end


### PR DESCRIPTION
## 问题

DeepSeek V4、Kimi K2 等 thinking-mode provider 会在 API 响应中返回 `reasoning_content`（模型的思考过程）。项目在两方面已有前置准备：

- **后端**（2026年3月底，`607d727`）：已能接收并保留 `reasoning_content`
- **前端**（2026年3月9日，`18a16f8`）：`sessions.js` 已实现 `<think>` 标签的解析和折叠渲染

但两者之间从未接上线——`reasoning_content` 被后端丢弃，从未包装成 `<think>` 标签送往前端。用户的思考过程在整个对话中完全看不到。

## 修改

### `lib/clacky/agent.rb` — `emit_assistant_message`

- 方法签名扩展，新增 `reasoning_content:` 关键字参数
- 当 `reasoning_content` 非空时，将其包装为 `<think>\n{reasoning}\n</think>\n{content}` 格式
- 两处调用点（有/无 tool_calls 分支）均传递 `reasoning_content`
- `show_assistant_message` 传入 `full_content`（含 think 标签），而非原始 `parsed[:text]`

### `lib/clacky/agent/session_serializer.rb` — `_replay_single_message`

- Session 回放时对 assistant 消息做同样的 `<think>` 包裹处理

### `spec/clacky/agent_spec.rb` — 单元测试

5 个测试覆盖以下场景：

| 场景 | 断言 |
|---|---|
| 无 reasoning_content | 内容原样传递 |
| 有 reasoning_content | `<think>` 标签正确包裹在前 |
| reasoning_content 纯空白 | 视为不存在，原样传递 |
| content + reasoning 都为空 | 不发送任何消息 |
| 有 file:// 链接 + reasoning | 文件链接正常提取，think 包裹生效 |

## 效果

使用 thinking-mode provider 时，Web UI 中将出现可折叠的 "Thoughts" 区块，展示模型的思考过程。
