### PR TITLE
feat: add Debian apt mirror support and refactor CN mirror config

### DIFF
--- a/scripts/build/lib/apt.sh
+++ b/scripts/build/lib/apt.sh
@@ -1,6 +1,6 @@
 # apt.sh — apt package manager helpers (Ubuntu/Debian)
-# Depends-On: colors.sh
-# Requires-Vars: $DISTRO $USE_CN_MIRRORS
+# Depends-On: colors.sh network.sh
+# Requires-Vars: $DISTRO $USE_CN_MIRRORS $CN_ALIYUN_MIRROR
 # Sets-Vars: (none)
 # Include via: @include lib/apt.sh
 
@@ -12,20 +12,40 @@ setup_apt_mirror() {
 
     if [ "$USE_CN_MIRRORS" = true ]; then
         print_info "Region: China — configuring Aliyun apt mirror"
-        local codename="${VERSION_CODENAME:-jammy}"
-        local components="main restricted universe multiverse"
-        local arch; arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
-        if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
-            local mirror="https://mirrors.aliyun.com/ubuntu-ports/"
-        else
-            local mirror="https://mirrors.aliyun.com/ubuntu/"
+
+        if [ -f /etc/apt/sources.list ]; then
+            sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
+            print_info "Backed up /etc/apt/sources.list to sources.list.bak"
         fi
-        sudo tee /etc/apt/sources.list > /dev/null <<EOF
+
+        if [ "$DISTRO" = "debian" ]; then
+            local codename="${VERSION_CODENAME:-bookworm}"
+            local components="main contrib non-free non-free-firmware"
+            local mirror="${CN_ALIYUN_MIRROR}/debian/"
+            local security_mirror="${CN_ALIYUN_MIRROR}/debian-security/"
+            sudo tee /etc/apt/sources.list > /dev/null <<EOF
+deb ${mirror} ${codename} ${components}
+deb ${mirror} ${codename}-updates ${components}
+deb ${mirror} ${codename}-backports ${components}
+deb ${security_mirror} ${codename}-security ${components}
+EOF
+        else
+            local codename="${VERSION_CODENAME:-jammy}"
+            local components="main restricted universe multiverse"
+            local arch; arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
+            if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
+                local mirror="${CN_ALIYUN_MIRROR}/ubuntu-ports/"
+            else
+                local mirror="${CN_ALIYUN_MIRROR}/ubuntu/"
+            fi
+            sudo tee /etc/apt/sources.list > /dev/null <<EOF
 deb ${mirror} ${codename} ${components}
 deb ${mirror} ${codename}-updates ${components}
 deb ${mirror} ${codename}-backports ${components}
 deb ${mirror} ${codename}-security ${components}
 EOF
+        fi
+
         print_success "apt mirror set to Aliyun"
     else
         print_info "Region: global — using default apt sources"

--- a/scripts/build/lib/network.sh
+++ b/scripts/build/lib/network.sh
@@ -1,7 +1,7 @@
 # network.sh — network region detection, mirror variables, URL probing
 # Depends-On: colors.sh
 # Requires-Vars: (none)
-# Sets-Vars: $USE_CN_MIRRORS $NETWORK_REGION $CN_CDN_BASE_URL $CN_RUBYGEMS_URL $CN_NODE_MIRROR_URL $CN_NPM_REGISTRY $CN_MISE_INSTALL_URL $CN_RUBY_PRECOMPILED_URL $MISE_INSTALL_URL $NODE_MIRROR_URL $NPM_REGISTRY_URL $RUBY_VERSION_SPEC $DEFAULT_RUBYGEMS_URL $DEFAULT_MISE_INSTALL_URL $DEFAULT_NPM_REGISTRY
+# Sets-Vars: $USE_CN_MIRRORS $NETWORK_REGION $CN_CDN_BASE_URL $CN_ALIYUN_MIRROR $CN_RUBYGEMS_URL $CN_NODE_MIRROR_URL $CN_NPM_REGISTRY $CN_MISE_INSTALL_URL $CN_RUBY_PRECOMPILED_URL $MISE_INSTALL_URL $NODE_MIRROR_URL $NPM_REGISTRY_URL $RUBY_VERSION_SPEC $DEFAULT_RUBYGEMS_URL $DEFAULT_MISE_INSTALL_URL $DEFAULT_NPM_REGISTRY
 # Include via: @include lib/network.sh
 
 # --------------------------------------------------------------------------
@@ -17,9 +17,10 @@ DEFAULT_NPM_REGISTRY="https://registry.npmjs.org"
 DEFAULT_MISE_INSTALL_URL="https://mise.run"
 
 CN_CDN_BASE_URL="https://oss.1024code.com"
+CN_ALIYUN_MIRROR="https://mirrors.aliyun.com"
 CN_MISE_INSTALL_URL="${CN_CDN_BASE_URL}/mise.sh"
 CN_RUBY_PRECOMPILED_URL="${CN_CDN_BASE_URL}/ruby/ruby-{version}.{platform}.tar.gz"
-CN_RUBYGEMS_URL="https://mirrors.aliyun.com/rubygems/"
+CN_RUBYGEMS_URL="${CN_ALIYUN_MIRROR}/rubygems/"
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
 CN_NODE_MIRROR_URL="https://cdn.npmmirror.com/binaries/node/"
 CN_GEM_BASE_URL="${CN_CDN_BASE_URL}/openclacky"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -129,9 +129,10 @@ DEFAULT_NPM_REGISTRY="https://registry.npmjs.org"
 DEFAULT_MISE_INSTALL_URL="https://mise.run"
 
 CN_CDN_BASE_URL="https://oss.1024code.com"
+CN_ALIYUN_MIRROR="https://mirrors.aliyun.com"
 CN_MISE_INSTALL_URL="${CN_CDN_BASE_URL}/mise.sh"
 CN_RUBY_PRECOMPILED_URL="${CN_CDN_BASE_URL}/ruby/ruby-{version}.{platform}.tar.gz"
-CN_RUBYGEMS_URL="https://mirrors.aliyun.com/rubygems/"
+CN_RUBYGEMS_URL="${CN_ALIYUN_MIRROR}/rubygems/"
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
 CN_NODE_MIRROR_URL="https://cdn.npmmirror.com/binaries/node/"
 CN_GEM_BASE_URL="${CN_CDN_BASE_URL}/openclacky"
@@ -278,20 +279,40 @@ setup_apt_mirror() {
 
     if [ "$USE_CN_MIRRORS" = true ]; then
         print_info "Region: China — configuring Aliyun apt mirror"
-        local codename="${VERSION_CODENAME:-jammy}"
-        local components="main restricted universe multiverse"
-        local arch; arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
-        if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
-            local mirror="https://mirrors.aliyun.com/ubuntu-ports/"
-        else
-            local mirror="https://mirrors.aliyun.com/ubuntu/"
+
+        if [ -f /etc/apt/sources.list ]; then
+            sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
+            print_info "Backed up /etc/apt/sources.list to sources.list.bak"
         fi
-        sudo tee /etc/apt/sources.list > /dev/null <<EOF
+
+        if [ "$DISTRO" = "debian" ]; then
+            local codename="${VERSION_CODENAME:-bookworm}"
+            local components="main contrib non-free non-free-firmware"
+            local mirror="${CN_ALIYUN_MIRROR}/debian/"
+            local security_mirror="${CN_ALIYUN_MIRROR}/debian-security/"
+            sudo tee /etc/apt/sources.list > /dev/null <<EOF
+deb ${mirror} ${codename} ${components}
+deb ${mirror} ${codename}-updates ${components}
+deb ${mirror} ${codename}-backports ${components}
+deb ${security_mirror} ${codename}-security ${components}
+EOF
+        else
+            local codename="${VERSION_CODENAME:-jammy}"
+            local components="main restricted universe multiverse"
+            local arch; arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
+            if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
+                local mirror="${CN_ALIYUN_MIRROR}/ubuntu-ports/"
+            else
+                local mirror="${CN_ALIYUN_MIRROR}/ubuntu/"
+            fi
+            sudo tee /etc/apt/sources.list > /dev/null <<EOF
 deb ${mirror} ${codename} ${components}
 deb ${mirror} ${codename}-updates ${components}
 deb ${mirror} ${codename}-backports ${components}
 deb ${mirror} ${codename}-security ${components}
 EOF
+        fi
+
         print_success "apt mirror set to Aliyun"
     else
         print_info "Region: global — using default apt sources"


### PR DESCRIPTION
- Add Debian branch in setup_apt_mirror with bookworm defaults
- Refactor CN mirror URLs into CN_ALIYUN_MIRROR variable (network.sh)
- Fix arch detection position under components declaration
- Rebuild install.sh