### PR TITLE
feat: add Dockerfile and fix CLACKY_ACCESS_KEY check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:3.4.4-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN gem install openclacky --no-document
+
+FROM ruby:3.4.4-slim
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+
+RUN curl https://mise.run | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+VOLUME ["/root/.clacky"]
+
+EXPOSE 7070
+
+ENTRYPOINT ["openclacky"]
+CMD ["server", "--host", "0.0.0.0"]

--- a/lib/clacky/cli.rb
+++ b/lib/clacky/cli.rb
@@ -965,7 +965,7 @@ module Clacky
       # ── Security gate ──────────────────────────────────────────────────────
       # Binding to 0.0.0.0 exposes the server to the public network.
       # Refuse to start unless CLACKY_ACCESS_KEY env var is set.
-      if options[:host] == "0.0.0.0" && ENV.fetch("CLACKY_ACCESS_KEY", "").strip.empty?
+      if options[:host] == "0.0.0.0" && !ENV.key?("CLACKY_ACCESS_KEY")
         puts <<~MSG
           ╔══════════════════════════════════════════════════════════════╗
           ║  ⚠️  Security Warning: Refusing to start                      ║


### PR DESCRIPTION
- Add multi-stage Dockerfile for openclacky server
- Fix access key check: use ENV.key? instead of strip.empty?