### PR TITLE
feat(onboard,settings): focus provider select on model config open

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -3289,6 +3289,14 @@ body {
 .custom-select-trigger:hover {
   border-color: var(--color-text-muted);
 }
+/* Focus: same accent border as `.open` so users see "this is where to start"
+   without the dropdown auto-expanding. Used by onboard step 2 and the
+   settings "add model" flow to nudge users to pick a provider first. */
+.custom-select-trigger:focus,
+.custom-select-trigger:focus-visible {
+  outline: none;
+  border-color: var(--color-accent-primary);
+}
 .custom-select-trigger.open {
   border-color: var(--color-accent-primary);
 }

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -834,7 +834,7 @@
       <div class="setup-field">
         <label class="setup-label" data-i18n="onboard.key.provider">Provider</label>
         <div class="custom-select-wrapper" id="setup-provider-wrapper">
-          <div class="custom-select-trigger">
+          <div class="custom-select-trigger" tabindex="0">
             <span class="custom-select-value placeholder" data-i18n="onboard.key.provider.placeholder">— Choose provider —</span>
             <svg class="custom-select-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>

--- a/lib/clacky/web/onboard.js
+++ b/lib/clacky/web/onboard.js
@@ -86,6 +86,12 @@ const Onboard = (() => {
       _showSetupStep("key");
       await _loadProviders();
       _bindKeyStep();
+      // Nudge: focus the provider trigger so the user knows step 1 is "pick
+      // a provider". `tabindex="0"` on the trigger makes it focusable; the
+      // .open class is NOT toggled, so the dropdown stays closed — we just
+      // get the accent-color border via `.custom-select-trigger:focus`.
+      const trigger = $("setup-provider-wrapper")?.querySelector(".custom-select-trigger");
+      if (trigger) trigger.focus({ preventScroll: true });
     });
   }
 

--- a/lib/clacky/web/settings.js
+++ b/lib/clacky/web/settings.js
@@ -81,7 +81,7 @@ const Settings = (() => {
         <label class="model-field quick-setup-field" ${(model.model || model.base_url) ? 'style="display:none"' : ''}>
           <span class="field-label">${I18n.t("settings.models.field.quicksetup")}</span>
           <div class="custom-select-wrapper" data-index="${index}">
-            <div class="custom-select-trigger">
+            <div class="custom-select-trigger" tabindex="0">
               <span class="custom-select-value placeholder">${I18n.t("settings.models.placeholder.provider")}</span>
               <svg class="custom-select-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
@@ -709,10 +709,22 @@ const Settings = (() => {
           behavior: "smooth"
         });
 
-        // Put focus on the new card's first input so the user can start
-        // typing immediately.
-        const firstInput = last.querySelector("input, select, textarea");
-        if (firstInput) firstInput.focus({ preventScroll: true });
+        // Put focus on the new card so the user can start configuring.
+        // Priority order:
+        //   1. The provider `.custom-select-trigger` — nudges the user to
+        //      pick a provider first (step 1 of the 3-field form). It's a
+        //      div with tabindex="0", so it gets the accent border via
+        //      `:focus` without expanding the dropdown.
+        //   2. Fall back to the first form input (used when the quick-setup
+        //      field is hidden, e.g. on a model card that already has values).
+        const providerTrigger = last.querySelector(".custom-select-wrapper .custom-select-trigger");
+        const isVisible = el => el && el.offsetParent !== null;
+        if (isVisible(providerTrigger)) {
+          providerTrigger.focus({ preventScroll: true });
+        } else {
+          const firstInput = last.querySelector("input, select, textarea");
+          if (firstInput) firstInput.focus({ preventScroll: true });
+        }
       });
     });
   }


### PR DESCRIPTION
## Problem
Onboard step 2 and Settings "Add model" landed with no focus cue. Users typed into the wrong field or didn't know where to start. Picking a provider must come first.

## Fix
Focus the **Provider** trigger on entry, with a purple border matching the existing Model-input focus style. Dropdown stays closed (focus on a `<div>` does not fire its click handler).

- `app.css`: `.custom-select-trigger:focus` reuses `--color-accent-primary`
- `index.html` + `settings.js` template: `tabindex="0"` on trigger (also a11y win)
- `onboard.js`: focus provider trigger after `_bindKeyStep()`
- `settings.js _addModel`: focus provider trigger; fallback to first input when quick-setup is hidden (existing cards unchanged)

## Test
- ✅ `bundle exec rspec` 1933/1933
- ✅ Onboard step 2 — provider trigger highlighted, dropdown closed
- ✅ Settings → Add model — same
- ✅ Click still expands dropdown normally
- ✅ Editing existing models — no regression