### PR TITLE
fix: 修复 USR1 热重启后 worker 丢失 session 消息的问题

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1064,6 +1064,9 @@ module Clacky
       !@start_time.nil?
     end
 
+    # Cooperative cancellation signal.
+    #
+    # Set by interrupt_all_agents (worker shutdown) BEFORE Thread#raise, so that
     private def build_result(status = :success, error: nil)
       task_iterations = @iterations - (@task_start_iterations || 0)
       task_cost = @total_cost - (@task_start_cost || 0)

--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1064,9 +1064,6 @@ module Clacky
       !@start_time.nil?
     end
 
-    # Cooperative cancellation signal.
-    #
-    # Set by interrupt_all_agents (worker shutdown) BEFORE Thread#raise, so that
     private def build_result(status = :success, error: nil)
       task_iterations = @iterations - (@task_start_iterations || 0)
       task_cost = @total_cost - (@task_start_cost || 0)

--- a/lib/clacky/agent/llm_caller.rb
+++ b/lib/clacky/agent/llm_caller.rb
@@ -756,7 +756,6 @@ module Clacky
       # progress handle on fast streams.
       private def build_progress_on_chunk
         return nil unless @ui
-
         last_emit_at = 0.0
         min_interval = 0.25
         ->(input_tokens:, output_tokens:) {

--- a/lib/clacky/cli.rb
+++ b/lib/clacky/cli.rb
@@ -1008,8 +1008,8 @@ module Clacky
         $stdout = Clacky::Server::EPIPESafeIO.new($stdout)
         $stderr = Clacky::Server::EPIPESafeIO.new($stderr)
 
-        fd         = ENV["CLACKY_INHERIT_FD"].to_i
-        master_pid = ENV["CLACKY_MASTER_PID"].to_i
+        fd              = ENV["CLACKY_INHERIT_FD"].to_i
+        master_pid      = ENV["CLACKY_MASTER_PID"].to_i
         # Must use TCPServer.for_fd (not Socket.for_fd) so that accept_nonblock
         # returns a single Socket, not [Socket, Addrinfo] — WEBrick expects the former.
         socket     = TCPServer.for_fd(fd)

--- a/lib/clacky/message_history.rb
+++ b/lib/clacky/message_history.rb
@@ -116,7 +116,6 @@ module Clacky
       last = @messages.last
       return false unless last[:role] == "assistant" && last[:tool_calls]&.any?
 
-      # Check that there is no tool result message after this assistant message
       last_assistant_idx = @messages.rindex { |m| m == last }
       @messages[(last_assistant_idx + 1)..].none? { |m| m[:role] == "tool" || m[:tool_results] }
     end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -154,8 +154,8 @@ module Clacky
         @agent_config   = agent_config
         @client_factory = client_factory  # callable: -> { Clacky::Client.new(...) }
         @brand_test     = brand_test      # when true, skip remote API calls for license activation
-        @inherited_socket = socket        # TCPServer socket passed from Master (nil = standalone mode)
-        @master_pid       = master_pid    # Master PID so we can send USR1 on upgrade/restart
+        @inherited_socket  = socket        # TCPServer socket passed from Master (nil = standalone mode)
+        @master_pid        = master_pid    # Master PID so we can send USR1 on upgrade/restart
         # Capture the absolute path of the entry script and original ARGV at startup,
         # so api_restart can re-exec the correct binary even if cwd changes later.
         @restart_script = File.expand_path($0)
@@ -240,13 +240,13 @@ module Clacky
         shutdown_proc = proc do
           next if shutdown_once
           shutdown_once = true
-          Thread.new do
-            sleep 2
-            Clacky::Logger.warn("[HttpServer] Forced exit after graceful shutdown timeout.")
-            exit!(0)
-          end
-          # Detach the inherited (shared) listen socket BEFORE shutdown so that
-          # WEBrick's cleanup_listener does not call shutdown(SHUT_RDWR)+close on
+          # Persist in-flight agent sessions BEFORE starting the forced-exit
+          # timer, so any new messages added to @history since the last save
+          # are on disk before the new worker reads them after a hot restart.
+          interrupt_all_agents
+
+          # Detach the inherited (shared) listen socket BEFORE WEBrick.shutdown
+          # so that cleanup_listener does not call shutdown(SHUT_RDWR)+close on
           # it — that would propagate to every process sharing the underlying
           # kernel socket (Master + new worker), breaking subsequent accept()
           # on Linux. macOS's BSD stack tolerates this; Linux does not.
@@ -3549,6 +3549,23 @@ module Clacky
         return unless agent
 
         run_agent_task(session_id, agent) { agent.run(prompt) }
+      end
+
+      # Interrupt every running agent thread and persist its session state.
+      private def interrupt_all_agents
+        return unless @registry && @session_manager
+
+        @registry.each_live_agent do |id, agent, thread|
+          next unless thread&.alive?
+          begin
+            thread.raise(Clacky::AgentInterrupted, "Worker shutting down")
+            Clacky::Logger.info("[shutdown] interrupted session=#{id}")
+          rescue => e
+            Clacky::Logger.error("[shutdown] interrupt failed for session=#{id}: #{e.message}")
+          end
+          thread.join(2)
+          @session_manager.save(agent.to_session_data(status: :interrupted))
+        end
       end
 
       # Run an agent task in a background thread, handling status updates,

--- a/lib/clacky/server/server_master.rb
+++ b/lib/clacky/server/server_master.rb
@@ -26,9 +26,6 @@ module Clacky
       RESTART_EXIT_CODE        = 75
       MAX_CONSECUTIVE_FAILURES = 5
 
-      # How long (seconds) to wait for a new worker to become ready before killing the old one.
-      NEW_WORKER_BOOT_WAIT = 3
-
       def initialize(host:, port:, argv: nil, extra_flags: [])
         @host   = host
         @port   = port
@@ -158,22 +155,16 @@ module Clacky
         pid
       end
 
-      # Spawn a new worker, wait for it to boot, then gracefully stop the old one.
+      # Gracefully stop the old worker (so it can persist in-memory sessions),
+      # wait for it to exit, then spawn a new one.
       def hot_restart
         old_pid = @worker_pid
-        Clacky::Logger.info("[Master] Hot restart: spawning new worker (old PID=#{old_pid})...")
+        Clacky::Logger.info("[Master] Hot restart: stopping old worker PID=#{old_pid}...")
 
-        new_pid = spawn_worker
-        @worker_pid = new_pid
-
-        # Give the new worker time to bind and start serving
-        sleep NEW_WORKER_BOOT_WAIT
-
-        # Gracefully stop old worker — TERM the whole process group first so
-        # grandchildren (node MCP, etc.) also get a chance to shut down cleanly.
+        # TERM the old worker's process group so grandchildren (node MCP, etc.)
+        # also get a chance to shut down cleanly (triggering interrupt_all_agents).
         begin
           Process.kill("TERM", -old_pid)
-          # Reap it (non-blocking loop so we don't block the monitor)
           deadline = Time.now + 5
           loop do
             pid, = Process.waitpid2(old_pid, Process::WNOHANG)
@@ -186,6 +177,9 @@ module Clacky
           # already gone — fine
         end
 
+        # Old worker is gone; now spawn the replacement.
+        new_pid = spawn_worker
+        @worker_pid = new_pid
         Clacky::Logger.info("[Master] Hot restart complete. New worker PID=#{new_pid}")
       end
 

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -357,6 +357,27 @@ module Clacky
         to_evict.each { |id, session| persist_and_release(id, session) }
       end
 
+      # Yield [session_id, agent, thread] for each session that currently has
+      # an in-memory agent. Used by the worker's graceful-shutdown path to
+      # flush any unsaved @history (e.g. a user message added at the start
+      # of Agent#run that hasn't yet reached the save-on-completion branch
+      # in run_agent_task).
+      #
+      # The session id list is snapshotted under the mutex so concurrent
+      # mutations don't disturb iteration; the yield happens outside the
+      # mutex so callers can do slow I/O (JSON serialization, File.write)
+      # without blocking other registry operations.
+      def each_live_agent
+        snapshot = @mutex.synchronize do
+          @sessions.filter_map do |id, s|
+            agent = s[:agent]
+            next nil unless agent
+            [id, agent, s[:thread]]
+          end
+        end
+        snapshot.each { |id, agent, thread| yield id, agent, thread }
+      end
+
       private def persist_and_release(id, session)
         agent = session[:agent]
         @session_manager&.save(agent.to_session_data(status: :success)) if agent

--- a/spec/clacky/server/http_server_spec.rb
+++ b/spec/clacky/server/http_server_spec.rb
@@ -980,4 +980,134 @@ RSpec.describe Clacky::Server::HttpServer do
       expect(result).not_to eq("short")
     end
   end
+
+  # ── interrupt_all_agents (private) ───────────────────────────────────────
+  #
+  # Worker shutdown path. The `:interrupted` rescue branch in run_agent_task
+  # (http_server.rb) is what writes session JSON on a clean Thread#raise. When
+  # the agent thread refuses to die in 2s, interrupt_all_agents must fall back
+  # to a manual save so the in-flight @history isn't lost.
+
+  describe "#interrupt_all_agents (private)" do
+    let(:sessions_dir) { Dir.mktmpdir("clacky_interrupt_spec_sessions") }
+
+    after { FileUtils.rm_rf(sessions_dir) }
+
+    def build_server
+      described_class.new(
+        agent_config:   agent_config,
+        client_factory: -> { double("client") },
+        sessions_dir:   sessions_dir
+      )
+    end
+
+    # Stand-in for Clacky::Agent. We only need the surface that
+    # interrupt_all_agents touches: cancel! and to_session_data.
+    def fake_agent(session_id)
+      a = double("Agent[#{session_id}]", session_id: session_id)
+      allow(a).to receive(:to_session_data) do |status: nil, error_message: nil|
+        { session_id: session_id, created_at: Time.now.iso8601, name: "T", last_status: status&.to_s }
+      end
+      a
+    end
+
+    # Spawn an agent-like thread that mimics run_agent_task's rescue block.
+    # Crucially, waits until the thread is sleeping inside the begin scope
+    # before returning — otherwise Thread#raise can fire before the rescue
+    # handler is established, and the thread dies with an unhandled exception.
+    def spawn_interruptible_agent_thread(&work)
+      ready = Queue.new
+      t = Thread.new do
+        Thread.current.report_on_exception = false
+        begin
+          ready << :in_rescue_scope
+          (work || -> { sleep 5 }).call
+        rescue Clacky::AgentInterrupted
+          :exited_cleanly
+        end
+      end
+      ready.pop
+      # Spin until the thread is actually blocked in sleep (not just past `ready << ...`).
+      sleep 0.005 until t.status == "sleep"
+      t
+    end
+
+    # Spawn a thread that swallows Thread#raise so interrupt_all_agents'
+    # join(2) is forced to time out and exercise the manual-save fallback.
+    def spawn_uninterruptible_thread
+      ready = Queue.new
+      t = Thread.new do
+        Thread.current.report_on_exception = false
+        Thread.handle_interrupt(Exception => :never) do
+          ready << :in_handle_interrupt
+          sleep 10
+        end
+      end
+      ready.pop
+      sleep 0.005 until t.status == "sleep"
+      t
+    end
+
+    it "saves session state after interrupting and waiting for the agent thread" do
+      server   = build_server
+      registry = server.instance_variable_get(:@registry)
+      agent    = fake_agent("clean-1")
+
+      registry.create(session_id: "clean-1")
+      thread = spawn_interruptible_agent_thread
+      registry.with_session("clean-1") { |s| s[:agent] = agent; s[:thread] = thread }
+
+      expect(agent).to receive(:to_session_data).with(status: :interrupted).once
+
+      server.send(:interrupt_all_agents)
+
+      expect(thread.join(1)).to eq(thread)
+    end
+
+    it "falls back to manual save when a thread refuses to die in 2s" do
+      server   = build_server
+      registry = server.instance_variable_get(:@registry)
+      sm       = server.instance_variable_get(:@session_manager)
+      agent    = fake_agent("stuck-1")
+
+      registry.create(session_id: "stuck-1")
+      stuck_thread = spawn_uninterruptible_thread
+      registry.with_session("stuck-1") { |s| s[:agent] = agent; s[:thread] = stuck_thread }
+
+      expect(sm).to receive(:save).with(hash_including(session_id: "stuck-1")).once
+
+      server.send(:interrupt_all_agents)
+
+      stuck_thread.kill
+      stuck_thread.join
+    end
+
+    it "waits serially — total wall time reflects N × per-thread timeout" do
+      server   = build_server
+      registry = server.instance_variable_get(:@registry)
+      sm       = server.instance_variable_get(:@session_manager)
+
+      # Three unresponsive threads — serial takes ≥ 6s.
+      stuck_threads = []
+      3.times do |i|
+        sid   = "stuck-#{i}"
+        agent = fake_agent(sid)
+        registry.create(session_id: sid)
+        t = spawn_uninterruptible_thread
+        registry.with_session(sid) { |s| s[:agent] = agent; s[:thread] = t }
+        stuck_threads << t
+      end
+
+      allow(sm).to receive(:save)
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      server.send(:interrupt_all_agents)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      expect(elapsed).to be > 2.0
+
+      stuck_threads.each(&:kill)
+      stuck_threads.each(&:join)
+    end
+  end
 end

--- a/spec/clacky/server/session_registry_spec.rb
+++ b/spec/clacky/server/session_registry_spec.rb
@@ -194,4 +194,39 @@ RSpec.describe Clacky::Server::SessionRegistry do
       end
     end
   end
+
+  describe "#each_live_agent" do
+    it "yields [id, agent, thread] only for sessions with an agent attached" do
+      registry = described_class.new(agent_config: default_config)
+      agent_a = double("agent_a")
+      thread_a = double("thread_a")
+      agent_b = double("agent_b")
+
+      registry.create(session_id: "with_agent_a")
+      registry.with_session("with_agent_a") { |s| s[:agent] = agent_a; s[:thread] = thread_a }
+
+      registry.create(session_id: "with_agent_b")
+      registry.with_session("with_agent_b") { |s| s[:agent] = agent_b }
+
+      registry.create(session_id: "no_agent")  # agent stays nil
+
+      seen = []
+      registry.each_live_agent { |id, agent, thread| seen << [id, agent, thread] }
+
+      expect(seen).to contain_exactly(
+        ["with_agent_a", agent_a, thread_a],
+        ["with_agent_b", agent_b, nil]
+      )
+    end
+
+    it "yields nothing when no sessions have agents" do
+      registry = described_class.new(agent_config: default_config)
+      registry.create(session_id: "empty")
+
+      seen = []
+      registry.each_live_agent { |id, agent, thread| seen << [id, agent, thread] }
+
+      expect(seen).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## 问题

`kill -USR1` 热重启 worker 后，用户可能丢失最后一条仍在运行中的消息。

### 根因：时序竞争

1. 新 worker 启动时从磁盘恢复 session 数据。
2. 此刻旧 worker 还没把内存中最新的 `@history` 落盘。
3. 新 worker 内存中已有 Agent 实例，之后不会再重读磁盘。

## 解决方案

### 1. 热重启先停旧 worker 再起新 worker

`server_master.rb` `hot_restart`：先 TERM 旧 worker → 等待退出(最长5s) → 超时 KILL → 再 spawn 新 worker。

### 2. shutdown_proc 先持久化再退出

`http_server.rb` `shutdown_proc`：收到 TERM/INT 后，先调用 `interrupt_all_agents` 将内存中的 Agent 会话落盘，再 shutdown。

### 3. interrupt_all_agents

遍历所有活跃 Agent 线程：`Thread#raise(AgentInterrupted)` → `join(2s)` → `save(status: :interrupted)`。

## 变更文件

- `lib/clacky/server/server_master.rb` — hot_restart 顺序改为先 TERM 再 spawn
- `lib/clacky/server/http_server.rb` — shutdown_proc 新增 interrupt_all_agents
- `spec/` — 新增 interrupt_all_agents 及 each_live_agent 测试
