### PR TITLE
feat(webui): support Cmd/Ctrl+Enter to send message

### DIFF
--- a/lib/clacky/web/skills.js
+++ b/lib/clacky/web/skills.js
@@ -1113,6 +1113,13 @@ const SkillAC = (() => {
       // Let skill autocomplete consume arrow/enter/escape first
       if (_handleKey(e)) return;
 
+      // Cmd/Ctrl+Enter always sends (regardless of Shift or composition state)
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        Sessions.sendMessage();
+        return;
+      }
+
       if (e.key === "Enter" && !e.shiftKey && !e.isComposing && (Date.now() - _lastCompositionEndTime) > 20) {
         e.preventDefault();
         Sessions.sendMessage();


### PR DESCRIPTION
## Summary

Add **Cmd+Enter** (macOS) and **Ctrl+Enter** (Windows/Linux) as an alternative keyboard shortcut for sending messages in the WebUI composer.

## Motivation

Many chat interfaces (Slack, Discord, Telegram desktop) support Cmd/Ctrl+Enter to send. Users who write multi-line messages often prefer this shortcut because it eliminates accidental sends when pressing bare Enter.

The current behavior (Enter to send, Shift+Enter for newline) is preserved — this is purely additive.

## Changes

- `lib/clacky/web/skills.js`: Added a 6-line check in the composer `keydown` handler that fires `Sessions.sendMessage()` when Enter is pressed with the Meta (Cmd) or Ctrl modifier.
- The shortcut bypasses Shift and IME composition guards since the modifier key makes intent unambiguous.

## Testing

- macOS: Cmd+Enter sends the message
- Windows/Linux: Ctrl+Enter sends the message
- Existing Enter-to-send and Shift+Enter-for-newline behavior unchanged
- IME composition (CJK input) unaffected
