### PR TITLE
feat(http): unify POST /api/file-action with download support for remote deployments

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -407,7 +407,7 @@ module Clacky
         when ["GET",    "/api/channels"]          then api_list_channels(res)
         when ["POST",   "/api/tool/browser"]      then api_tool_browser(req, res)
         when ["POST",   "/api/upload"]            then api_upload_file(req, res)
-        when ["POST",   "/api/open-file"]         then api_open_file(req, res)
+        when ["POST",   "/api/file-action"]       then api_file_action(req, res)
         when ["GET",    "/api/local-image"]       then api_serve_local_image(req, res)
         when ["GET",    "/api/version"]           then api_get_version(res)
         when ["POST",   "/api/version/upgrade"]   then api_upgrade_version(req, res)
@@ -1552,12 +1552,16 @@ module Clacky
         json_response(res, 500, { ok: false, error: e.message })
       end
 
-      # POST /api/open-file
-      # Opens a local file or directory using the OS default handler.
-      # Used by the Web UI to handle file:// links — browsers block direct
-      # file:// navigation from http:// pages for security reasons.
-      def api_open_file(req, res)
-        path = parse_json_body(req)["path"]
+      # POST /api/file-action
+      # Unified file action endpoint — open locally or download.
+      # Body: { path: String, action: "open" | "download" }
+      #   open:     opens the file with the OS default handler (local deployments).
+      #   download: returns the file as a download (remote deployments).
+      def api_file_action(req, res)
+        body = parse_json_body(req)
+        path = body["path"]
+        action = body["action"] || "open"
+
         return json_response(res, 400, { error: "path is required" }) unless path && !path.empty?
 
         # Expand ~ to the user's home directory (e.g. "~/Desktop/file.pdf").
@@ -1570,11 +1574,31 @@ module Clacky
 
         return json_response(res, 404, { error: "file not found" }) unless File.exist?(linux_path)
 
-        result = Utils::EnvironmentDetector.open_file(linux_path)
-        return json_response(res, 501, { error: "unsupported OS" }) if result.nil?
-        json_response(res, 200, { ok: true })
+        case action
+        when "open"
+          result = Utils::EnvironmentDetector.open_file(linux_path)
+          return json_response(res, 501, { error: "unsupported OS" }) if result.nil?
+          json_response(res, 200, { ok: true })
+        when "download"
+          serve_file_download(res, linux_path)
+        else
+          json_response(res, 400, { error: "invalid action. Must be 'open' or 'download'" })
+        end
       rescue => e
         json_response(res, 500, { ok: false, error: e.message })
+      end
+
+      # Stream a file to the client as a download.
+      # Content-Type is always application/octet-stream — the browser determines
+      # file type and handling from the filename extension in Content-Disposition.
+      def serve_file_download(res, path)
+        filename = File.basename(path)
+
+        res.status                  = 200
+        res["Content-Type"]         = "application/octet-stream"
+        res["Content-Disposition"]  = "attachment; filename=\"#{filename}\""
+        res["Content-Length"]       = File.size(path).to_s
+        res.body = File.binread(path)
       end
 
       # GET /api/local-image?path=file:///path/to/image.png

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1605,8 +1605,10 @@ const Sessions = (() => {
       // Re-render session list (badges/labels) when the user switches language
       document.addEventListener("langchange", () => Sessions.renderList());
       // Browsers block file:// navigation from http:// pages. Intercept clicks on
-      // file:// links and delegate to the backend API (OS default handler).
-      document.addEventListener("click", (e) => {
+      // file:// links and delegate to the backend API.
+      // Local deployments (localhost / 127.0.0.1 / ::1): open the file with the
+      // OS default handler.  Remote deployments: download the file.
+      document.addEventListener("click", async (e) => {
         const link = e.target.closest("a[href^='file://']");
         if (!link) return;
         e.preventDefault();
@@ -1614,11 +1616,32 @@ const Sessions = (() => {
         // file:///C:/foo → /C:/foo after replace; strip the leading slash for Windows drive letters
         if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.substring(1);
         if (!filePath) return;
-        fetch("/api/open-file", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ path: filePath })
-        });
+
+        const hostname = window.location.hostname;
+        const isLocal = ["localhost", "127.0.0.1", "::1"].includes(hostname);
+        const action = isLocal ? "open" : "download";
+
+        try {
+          const resp = await fetch("/api/file-action", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ path: filePath, action })
+          });
+
+          if (action === "download" && resp.ok) {
+            const blob = await resp.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = filePath.split("/").pop() || "download";
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+          }
+        } catch (err) {
+          console.error("file-action failed:", err);
+        }
       });
     },
 


### PR DESCRIPTION
## Problem

`[text](file:///path/to/file)` links only worked on local deployments — the backend opened files on the server machine via`open` / `xdg-open`. On remote / cloud deployments, users clicking these links saw nothing happen because the server tried to open files in a headless environment.

## Fix

- **Unified endpoint**: `POST /api/open-file` → `POST /api/file-action` with `action: "open" | "download"` parameter.
- **Hostname detection**: frontend checks `window.location.hostname` — `localhost` / `127.0.0.1` / `::1` → open, anything else → download.
- **Download mode**: reads file, sets `Content-Disposition: attachment`, triggers browser download via Blob + createObjectURL.
- Zero config, zero frontend UI changes.

## Test

✅ Local (localhost) — file links open with OS default handler  
✅ Remote (LAN IP) — file links trigger browser download  
✅ No regression on WSL path conversion or file-not-found handling