### PR TITLE
feat(webui): table horizontal scroll + streaming typing cursor

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -1840,12 +1840,17 @@ body {
   border-radius: 0 4px 4px 0;
 }
 .msg-assistant blockquote p { margin: 0; }
+.msg-assistant .table-wrapper {
+  overflow-x: auto;
+  margin: 0.5em 0;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-primary);
+}
 .msg-assistant table {
   border-collapse: collapse;
-  margin: 0.5em 0;
   font-size: 0.9em;
-  width: auto;
-  max-width: 100%;
+  width: 100%;
+  margin: 0;
 }
 .msg-assistant th, .msg-assistant td {
   border: 1px solid var(--color-border-primary);
@@ -1994,6 +1999,16 @@ body {
 .msg-success   { color: var(--color-success); align-self: flex-start; font-size: 0.8125rem; }
 .tool-name     { color: var(--color-warning); font-weight: 600; }
 .progress-msg  { color: var(--color-accent-primary); font-size: 0.75rem; align-self: center; }
+.progress-msg::after {
+  content: "▍";
+  display: inline-block;
+  animation: blink-cursor 0.8s steps(2) infinite;
+  margin-left: 2px;
+}
+@keyframes blink-cursor {
+  0%   { opacity: 1; }
+  100% { opacity: 0; }
+}
 
 /* ── Token usage line ────────────────────────────────────────────────────── */
 .token-usage-line {

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -126,6 +126,10 @@ const Sessions = (() => {
           `</div>`
         );
       };
+      const originalTable = marked.Renderer.prototype.table;
+      renderer.table = function(token) {
+        return `<div class="table-wrapper">${originalTable.call(this, token)}</div>`;
+      };
       html = marked.parse(prepared, { breaks: true, gfm: true, renderer });
     } else {
       html = escapeHtml(prepared).replace(/\n/g, "<br>");


### PR DESCRIPTION
## Changes

### 1. Table horizontal scroll wrapper
Wide markdown tables now scroll horizontally instead of breaking layout on narrow screens.
- Override `renderer.table` in marked to wrap `<table>` in `.table-wrapper`
- `.table-wrapper` has `overflow-x: auto` + rounded border

### 2. Streaming typing cursor
Adds a blinking `▍` cursor to the progress indicator during LLM generation, making it visually clear that output is still streaming.
- Pure CSS `::after` pseudo-element on `.progress-msg`
- `steps(2)` animation for a sharp blink effect

---

**Files changed:** `lib/clacky/web/sessions.js`, `lib/clacky/web/app.css`
