### PR TITLE
fix: command suggestions dropdown scrolling

### DIFF
--- a/lib/clacky/ui2/components/command_suggestions.rb
+++ b/lib/clacky/ui2/components/command_suggestions.rb
@@ -145,7 +145,11 @@ module Clacky
 
           output = []
           max_items = 5  # Maximum visible items
-          visible_commands = @filtered_commands.take(max_items)
+
+          # Sliding window: keep selected item visible
+          start_idx = [@selected_index - max_items + 1, 0].max
+          start_idx = [start_idx, [@filtered_commands.size - max_items, 0].max].min
+          visible_commands = @filtered_commands[start_idx, max_items] || []
 
           # Header
           header = @pastel.dim("┌─ Commands ") + @pastel.dim("─" * (width - 13)) + @pastel.dim("┐")
@@ -153,7 +157,7 @@ module Clacky
 
           # Items
           visible_commands.each_with_index do |cmd, idx|
-            is_selected = (idx == @selected_index)
+            is_selected = (start_idx + idx == @selected_index)
             line = render_command_item(cmd, is_selected, width)
             output << position_cursor(row + 1 + idx, col) + line
           end


### PR DESCRIPTION
## Problem

When navigating the  command suggestions dropdown with arrow keys, the list does not scroll to follow the selection. Once the selection moves past the 5th item, the highlighted item becomes invisible because the visible list always shows the first 5 commands.

## Root Cause

In , the visible commands are always sliced from the beginning:

```ruby
visible_commands = @filtered_commands.take(max_items)
```

This means  can exceed the visible range, but the displayed list never shifts.

## Fix

Replace the fixed  with a sliding window that adjusts based on :

```ruby
start_idx = [@selected_index - max_items + 1, 0].max
start_idx = [start_idx, [@filtered_commands.size - max_items, 0].max].min
visible_commands = @filtered_commands[start_idx, max_items] || []
```

Also updates  to use the correct offset:

```ruby
is_selected = (start_idx + idx == @selected_index)
```

This ensures the selected item is always visible within the 5-item viewport.