### PR TITLE
feat: Add billing system with currency settings (USD/CNY)

### DIFF
--- a/docs/billing-system.md
+++ b/docs/billing-system.md
@@ -1,0 +1,318 @@
+# Billing System
+
+## Overview
+
+The Billing System provides persistent tracking of API usage and costs across all
+sessions. It records every LLM API call with token counts and calculated costs,
+storing them in monthly JSONL files for easy querying and analysis.
+
+## Design Principles
+
+- **Non-blocking** — Billing persistence is fire-and-forget; failures never interrupt agent flow
+- **Minimal footprint** — JSONL format, one file per month, no database dependency
+- **Privacy-first** — Data stored locally in `~/.clacky/billing/`, never uploaded
+- **Accurate costing** — Uses the same `ModelPricing` module as real-time display
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Agent                                   │
+│  CostTracker module                                             │
+│    └── track_cost()                                             │
+│          ├── Calculate cost (ModelPricing)                      │
+│          ├── Update UI (real-time)                              │
+│          └── persist_billing_record() ──────┐                   │
+└─────────────────────────────────────────────┼───────────────────┘
+                                              │
+                                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Billing Module                               │
+│  lib/clacky/billing/                                            │
+│    ├── billing_record.rb   (data structure)                     │
+│    └── billing_store.rb    (JSONL persistence)                  │
+└─────────────────────────────────────────────────────────────────┘
+                                              │
+                                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Storage                                      │
+│  ~/.clacky/billing/                                             │
+│    ├── 2026-05.jsonl                                            │
+│    ├── 2026-04.jsonl                                            │
+│    └── ...                                                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Components
+
+### BillingRecord (`lib/clacky/billing/billing_record.rb`)
+
+A Struct representing a single API call:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | String | UUID, auto-generated |
+| `session_id` | String | Associated session |
+| `timestamp` | Time | When the call was made |
+| `model` | String | Model name (e.g., "claude-sonnet-4.5") |
+| `prompt_tokens` | Integer | Input tokens |
+| `completion_tokens` | Integer | Output tokens |
+| `cache_read_tokens` | Integer | Tokens read from cache |
+| `cache_write_tokens` | Integer | Tokens written to cache |
+| `cost_usd` | Float | Calculated cost in USD |
+| `cost_source` | Symbol | `:api`, `:price`, or `:estimated` |
+
+### BillingStore (`lib/clacky/billing/billing_store.rb`)
+
+Handles persistence and querying:
+
+```ruby
+store = Clacky::Billing::BillingStore.new
+
+# Append a record
+store.append(record)
+
+# Query with filters
+records = store.query(from: 1.week.ago, model: "claude-sonnet-4.5", limit: 100)
+
+# Get summary statistics
+summary = store.summary(period: :month)
+# => { total_cost: 12.34, total_tokens: 500000, by_model: {...}, ... }
+
+# Daily breakdown for charts
+daily = store.daily_breakdown(days: 30)
+# => [{ date: "2026-05-01", cost: 1.23, tokens: 50000, requests: 42 }, ...]
+```
+
+---
+
+## Storage Format
+
+Records are stored as JSON Lines (one JSON object per line):
+
+```jsonl
+{"id":"abc123","session_id":"def456","timestamp":"2026-05-22T15:30:00+08:00","model":"claude-sonnet-4.5","prompt_tokens":1500,"completion_tokens":500,"cache_read_tokens":1000,"cache_write_tokens":0,"cost_usd":0.0045,"cost_source":"price"}
+{"id":"abc124","session_id":"def456","timestamp":"2026-05-22T15:31:00+08:00","model":"claude-sonnet-4.5","prompt_tokens":2000,"completion_tokens":800,"cache_read_tokens":1500,"cache_write_tokens":0,"cost_usd":0.0052,"cost_source":"price"}
+```
+
+**Why JSONL?**
+- Append-only writes (no file locking needed)
+- Easy to parse line-by-line (memory efficient)
+- Human-readable for debugging
+- Simple monthly rotation
+
+---
+
+## API Endpoints
+
+### GET /api/billing/summary
+
+Returns aggregated statistics for a time period.
+
+**Query Parameters:**
+- `period` — `day`, `week`, `month`, `year`, or `all` (default: `month`)
+
+**Response:**
+```json
+{
+  "period": "month",
+  "from": "2026-05-01T00:00:00+08:00",
+  "to": "2026-05-22T15:30:00+08:00",
+  "total_cost": 12.3456,
+  "total_tokens": 500000,
+  "prompt_tokens": 350000,
+  "completion_tokens": 150000,
+  "cache_read_tokens": 200000,
+  "cache_write_tokens": 50000,
+  "by_model": {
+    "claude-sonnet-4.5": { "cost": 10.00, "requests": 100 },
+    "deepseek-v4-flash": { "cost": 2.34, "requests": 50 }
+  },
+  "by_day": {
+    "2026-05-22": 1.23,
+    "2026-05-21": 2.34
+  },
+  "record_count": 150
+}
+```
+
+### GET /api/billing/daily
+
+Returns daily cost breakdown for charting.
+
+**Query Parameters:**
+- `days` — Number of days (default: 30, max: 90)
+
+**Response:**
+```json
+{
+  "days": [
+    { "date": "2026-05-22", "cost": 1.2345, "tokens": 50000, "requests": 42 },
+    { "date": "2026-05-21", "cost": 2.3456, "tokens": 80000, "requests": 65 }
+  ]
+}
+```
+
+### GET /api/billing/records
+
+Returns raw billing records.
+
+**Query Parameters:**
+- `limit` — Max records (default: 100, max: 500)
+- `model` — Filter by model name
+- `session_id` — Filter by session ID
+
+**Response:**
+```json
+{
+  "records": [
+    { "id": "...", "timestamp": "...", "model": "...", "cost_usd": 0.01, ... }
+  ],
+  "count": 100
+}
+```
+
+---
+
+## CLI Command
+
+```bash
+# Show current month's billing
+clacky billing
+
+# Show specific period
+clacky billing --period week
+clacky billing --period day
+clacky billing --period all
+
+# Output as JSON (for scripting)
+clacky billing --json
+```
+
+**Sample Output:**
+```
+📊 Billing Summary (month)
+──────────────────────────────────────────────────
+
+  💰 Total Cost:       $12.3456
+  📝 Total Tokens:     500,000
+  📥 Prompt Tokens:    350,000
+  📤 Completion:       150,000
+  🗄️  Cache Read:       200,000
+  📝 Cache Write:      50,000
+  🔢 API Requests:     150
+
+📈 By Model:
+──────────────────────────────────────────────────
+  claude-sonnet-4.5
+    Cost: $10.0000  |  Requests: 100
+  deepseek-v4-flash
+    Cost: $2.3456  |  Requests: 50
+
+📅 Recent Daily Usage:
+──────────────────────────────────────────────────
+  2026-05-22  $1.2345  ████████████
+  2026-05-21  $2.3456  ████████████████████████
+
+──────────────────────────────────────────────────
+  Data stored in: ~/.clacky/billing/
+```
+
+---
+
+## Web UI
+
+The Billing panel is accessible from the sidebar under "My Data":
+
+- **Summary cards** — Total cost, tokens, API requests
+- **Token breakdown** — Prompt, completion, cache read/write
+- **By Model table** — Cost and request count per model
+- **Daily chart** — Visual bar chart of recent usage
+- **Period selector** — Filter by day/week/month/year/all
+
+---
+
+## Currency Settings
+
+The Web UI supports multiple currencies for cost display:
+
+| Currency | Symbol | Exchange Rate |
+|----------|--------|---------------|
+| USD | $ | 1.0 (base) |
+| CNY | ¥ | 6.7944 |
+
+### Configuration
+
+1. Go to **Settings** page
+2. Find the **Currency** section
+3. Select `$ USD` or `¥ CNY`
+
+### Scope
+
+Currency settings apply to:
+- Billing panel (total cost, model costs, daily chart)
+- Session info bar (top cost display)
+- Token usage lines (per-API-call cost)
+- Task completion messages
+
+**Note:** CLI always displays costs in USD (API's native currency).
+
+### Implementation
+
+Currency preference is stored in browser `localStorage` under key `clacky-currency`.
+
+```javascript
+// Access currency utilities from Billing module
+Billing.getCurrency()       // "USD" or "CNY"
+Billing.getCurrencySymbol() // "$" or "¥"
+Billing.convertCost(usd)    // Convert USD to selected currency
+```
+
+---
+
+## Integration with CostTracker
+
+The billing system hooks into `Agent::CostTracker#track_cost`:
+
+```ruby
+def track_cost(usage, raw_api_usage: nil)
+  # ... existing cost calculation ...
+  
+  # Persist billing record (skip for subagents to avoid double-counting)
+  unless @is_subagent
+    persist_billing_record(usage, iteration_cost)
+  end
+  
+  token_data
+end
+```
+
+**Key behaviors:**
+- Subagent costs are NOT recorded separately (parent agent merges them)
+- Unknown model costs (nil) are skipped
+- Persistence failures are logged but never raise
+
+---
+
+## Data Retention
+
+- Records are stored indefinitely by default
+- Monthly files can be manually deleted from `~/.clacky/billing/`
+- Future: `BillingStore#cleanup(before: 1.year.ago)` for automated retention
+
+---
+
+## Future Enhancements
+
+- [ ] Export to CSV/JSON
+- [ ] Budget alerts (daily/monthly limits)
+- [ ] Cost comparison across models
+- [ ] Session-level cost breakdown in UI
+- [x] i18n support for billing labels (English/Chinese)
+- [x] Currency settings (USD/CNY)
+- [ ] Dynamic exchange rate updates
+- [ ] More currency options (EUR, JPY, etc.)

--- a/lib/clacky/agent/cost_tracker.rb
+++ b/lib/clacky/agent/cost_tracker.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
+require_relative "../billing/billing_store"
+require_relative "../billing/billing_record"
+
 module Clacky
   class Agent
     # Cost tracking and token usage statistics
     # Manages cost calculation, token estimation, and usage display
     module CostTracker
+      # Lazy-loaded billing store instance
+      def billing_store
+        @billing_store ||= Billing::BillingStore.new
+      end
+
       # Track cost from API usage
       # Updates total cost and displays iteration statistics
       # @param usage [Hash] Usage data from API response
@@ -89,8 +97,37 @@ module Clacky
           end
         end
 
+        # Persist billing record (skip for subagents to avoid double-counting)
+        unless @is_subagent
+          persist_billing_record(usage, iteration_cost)
+        end
+
         # Return token_data so the caller can display it at the right moment
         token_data
+      end
+
+      # Persist a billing record to the billing store
+      # @param usage [Hash] Usage data from API
+      # @param cost [Float, nil] Calculated cost for this iteration
+      def persist_billing_record(usage, cost)
+        return if cost.nil? # Skip if cost is unknown
+
+        record = Billing::BillingRecord.new(
+          session_id: @session_id,
+          timestamp: Time.now,
+          model: current_model,
+          prompt_tokens: usage[:prompt_tokens] || 0,
+          completion_tokens: usage[:completion_tokens] || 0,
+          cache_read_tokens: usage[:cache_read_input_tokens] || 0,
+          cache_write_tokens: usage[:cache_creation_input_tokens] || 0,
+          cost_usd: cost,
+          cost_source: @cost_source
+        )
+
+        billing_store.append(record)
+      rescue => e
+        # Billing persistence is non-critical; log and continue
+        @ui&.log("Failed to persist billing record: #{e.message}", level: :debug) if @config&.verbose
       end
 
       # Estimate token count for a message content

--- a/lib/clacky/billing/billing_record.rb
+++ b/lib/clacky/billing/billing_record.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Clacky
+  module Billing
+    # Data structure for a single billing record
+    # Each API call generates one record with token usage and cost
+    BillingRecord = Struct.new(
+      :id,                    # Unique record ID (UUID)
+      :session_id,            # Associated session ID
+      :timestamp,             # Time of the API call
+      :model,                 # Model used (e.g., "claude-sonnet-4.5")
+      :prompt_tokens,         # Input tokens
+      :completion_tokens,     # Output tokens
+      :cache_read_tokens,     # Tokens read from cache
+      :cache_write_tokens,    # Tokens written to cache
+      :cost_usd,              # Cost in USD
+      :cost_source,           # Cost source (:api, :price, :estimated)
+      keyword_init: true
+    ) do
+      # Convert to hash for JSON serialization
+      def to_h
+        {
+          id: id,
+          session_id: session_id,
+          timestamp: timestamp.is_a?(Time) ? timestamp.iso8601 : timestamp,
+          model: model,
+          prompt_tokens: prompt_tokens || 0,
+          completion_tokens: completion_tokens || 0,
+          cache_read_tokens: cache_read_tokens || 0,
+          cache_write_tokens: cache_write_tokens || 0,
+          cost_usd: cost_usd || 0.0,
+          cost_source: cost_source&.to_s
+        }
+      end
+
+      # Create from hash (for deserialization)
+      def self.from_h(hash)
+        new(
+          id: hash[:id] || hash["id"],
+          session_id: hash[:session_id] || hash["session_id"],
+          timestamp: parse_timestamp(hash[:timestamp] || hash["timestamp"]),
+          model: hash[:model] || hash["model"],
+          prompt_tokens: hash[:prompt_tokens] || hash["prompt_tokens"] || 0,
+          completion_tokens: hash[:completion_tokens] || hash["completion_tokens"] || 0,
+          cache_read_tokens: hash[:cache_read_tokens] || hash["cache_read_tokens"] || 0,
+          cache_write_tokens: hash[:cache_write_tokens] || hash["cache_write_tokens"] || 0,
+          cost_usd: hash[:cost_usd] || hash["cost_usd"] || 0.0,
+          cost_source: (hash[:cost_source] || hash["cost_source"])&.to_sym
+        )
+      end
+
+      # Parse timestamp from string or return as-is if already Time
+      def self.parse_timestamp(ts)
+        return ts if ts.is_a?(Time)
+        return Time.now if ts.nil?
+        Time.parse(ts)
+      rescue
+        Time.now
+      end
+
+      # Total tokens (input + output)
+      def total_tokens
+        (prompt_tokens || 0) + (completion_tokens || 0)
+      end
+    end
+  end
+end

--- a/lib/clacky/billing/billing_store.rb
+++ b/lib/clacky/billing/billing_store.rb
@@ -155,21 +155,19 @@ module Clacky
         deleted
       end
 
-      private
-
-      def ensure_billing_dir
+      private def ensure_billing_dir
         FileUtils.mkdir_p(@billing_dir) unless Dir.exist?(@billing_dir)
       end
 
-      def current_month_file
+      private def current_month_file
         File.join(@billing_dir, "#{Time.now.strftime('%Y-%m')}.jsonl")
       end
 
-      def billing_files
+      private def billing_files
         Dir.glob(File.join(@billing_dir, "*.jsonl")).sort.reverse
       end
 
-      def period_start(period)
+      private def period_start(period)
         now = Time.now
         case period
         when :day

--- a/lib/clacky/billing/billing_store.rb
+++ b/lib/clacky/billing/billing_store.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require "securerandom"
+require_relative "billing_record"
+
+module Clacky
+  module Billing
+    # Persistent storage for billing records using JSONL files
+    # Records are stored in monthly files: ~/.clacky/billing/YYYY-MM.jsonl
+    class BillingStore
+      BILLING_DIR = File.join(Dir.home, ".clacky", "billing")
+
+      def initialize(billing_dir: nil)
+        @billing_dir = billing_dir || BILLING_DIR
+        ensure_billing_dir
+      end
+
+      # Append a billing record to the current month's file
+      # @param record [BillingRecord] The record to append
+      # @return [String] The record ID
+      def append(record)
+        record.id ||= SecureRandom.uuid
+        record.timestamp ||= Time.now
+
+        month_file = current_month_file
+        File.open(month_file, "a") do |f|
+          f.puts(JSON.generate(record.to_h))
+        end
+        FileUtils.chmod(0o600, month_file)
+
+        record.id
+      end
+
+      # Query billing records with optional filters
+      # @param from [Time, nil] Start time (inclusive)
+      # @param to [Time, nil] End time (inclusive)
+      # @param model [String, nil] Filter by model name
+      # @param session_id [String, nil] Filter by session ID
+      # @param limit [Integer, nil] Maximum number of records to return
+      # @return [Array<BillingRecord>] Matching records, newest first
+      def query(from: nil, to: nil, model: nil, session_id: nil, limit: nil)
+        records = []
+
+        billing_files.each do |file|
+          File.foreach(file) do |line|
+            next if line.strip.empty?
+
+            begin
+              hash = JSON.parse(line, symbolize_names: true)
+              record = BillingRecord.from_h(hash)
+
+              # Apply filters
+              next if from && record.timestamp < from
+              next if to && record.timestamp > to
+              next if model && record.model != model
+              next if session_id && record.session_id != session_id
+
+              records << record
+            rescue JSON::ParserError
+              # Skip malformed lines
+              next
+            end
+          end
+        end
+
+        # Sort by timestamp descending (newest first)
+        records.sort_by! { |r| r.timestamp }.reverse!
+
+        # Apply limit
+        limit ? records.first(limit) : records
+      end
+
+      # Get summary statistics for a time period
+      # @param period [Symbol] :day, :week, :month, :year, or :all
+      # @return [Hash] Summary with total_cost, total_tokens, by_model, etc.
+      def summary(period: :month)
+        from_time = period_start(period)
+        records = query(from: from_time)
+
+        total_cost = records.sum { |r| r.cost_usd || 0 }
+        total_prompt = records.sum { |r| r.prompt_tokens || 0 }
+        total_completion = records.sum { |r| r.completion_tokens || 0 }
+        total_cache_read = records.sum { |r| r.cache_read_tokens || 0 }
+        total_cache_write = records.sum { |r| r.cache_write_tokens || 0 }
+
+        by_model = records.group_by(&:model).transform_values do |rs|
+          {
+            cost: rs.sum { |r| r.cost_usd || 0 },
+            prompt_tokens: rs.sum { |r| r.prompt_tokens || 0 },
+            completion_tokens: rs.sum { |r| r.completion_tokens || 0 },
+            requests: rs.size
+          }
+        end
+
+        by_day = records.group_by { |r| r.timestamp.strftime("%Y-%m-%d") }.transform_values do |rs|
+          rs.sum { |r| r.cost_usd || 0 }
+        end
+
+        {
+          period: period,
+          from: from_time&.iso8601,
+          to: Time.now.iso8601,
+          total_cost: total_cost.round(6),
+          total_tokens: total_prompt + total_completion,
+          prompt_tokens: total_prompt,
+          completion_tokens: total_completion,
+          cache_read_tokens: total_cache_read,
+          cache_write_tokens: total_cache_write,
+          by_model: by_model,
+          by_day: by_day,
+          record_count: records.size
+        }
+      end
+
+      # Get daily cost breakdown for the last N days
+      # @param days [Integer] Number of days to include
+      # @return [Array<Hash>] Daily summaries with date and cost
+      def daily_breakdown(days: 30)
+        from_time = Time.now - (days * 24 * 60 * 60)
+        records = query(from: from_time)
+
+        by_day = records.group_by { |r| r.timestamp.strftime("%Y-%m-%d") }
+
+        (0...days).map do |i|
+          date = (Time.now - (i * 24 * 60 * 60)).strftime("%Y-%m-%d")
+          day_records = by_day[date] || []
+          {
+            date: date,
+            cost: day_records.sum { |r| r.cost_usd || 0 }.round(6),
+            tokens: day_records.sum { |r| r.total_tokens },
+            requests: day_records.size
+          }
+        end.reverse
+      end
+
+      # Delete old billing records
+      # @param before [Time] Delete records before this time
+      # @return [Integer] Number of files deleted
+      def cleanup(before:)
+        deleted = 0
+        billing_files.each do |file|
+          # Parse month from filename (YYYY-MM.jsonl)
+          basename = File.basename(file, ".jsonl")
+          file_month = Time.parse("#{basename}-01") rescue nil
+          next unless file_month
+
+          # Delete if the entire month is before the cutoff
+          if file_month < before - (31 * 24 * 60 * 60)
+            File.delete(file)
+            deleted += 1
+          end
+        end
+        deleted
+      end
+
+      private
+
+      def ensure_billing_dir
+        FileUtils.mkdir_p(@billing_dir) unless Dir.exist?(@billing_dir)
+      end
+
+      def current_month_file
+        File.join(@billing_dir, "#{Time.now.strftime('%Y-%m')}.jsonl")
+      end
+
+      def billing_files
+        Dir.glob(File.join(@billing_dir, "*.jsonl")).sort.reverse
+      end
+
+      def period_start(period)
+        now = Time.now
+        case period
+        when :day
+          Time.new(now.year, now.month, now.day)
+        when :week
+          now - (7 * 24 * 60 * 60)
+        when :month
+          Time.new(now.year, now.month, 1)
+        when :year
+          Time.new(now.year, 1, 1)
+        when :all
+          nil
+        else
+          Time.new(now.year, now.month, 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/cli.rb
+++ b/lib/clacky/cli.rb
@@ -437,6 +437,14 @@ module Clacky
 
       CLI_DEFAULT_SESSION_NAME = "CLI Session"
 
+      # Format a number with thousand separators for display
+      # @param num [Integer, Float] The number to format
+      # @return [String] Formatted number string
+      private def format_number(num)
+        return "0" if num.nil? || num == 0
+        num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+      end
+
       # Auto-name a CLI session from the first user message, mirroring server-side logic.
       # Renames when the agent has no history yet (i.e. first message of the session).
       private def auto_name_session(agent, input)
@@ -929,6 +937,98 @@ module Clacky
 
 
 
+    end
+
+    # ── billing command ────────────────────────────────────────────────────────
+    desc "billing", "Show billing summary and usage statistics"
+    long_desc <<-LONGDESC
+      Display billing summary with token usage and cost breakdown.
+
+      Period options:
+        day    - Today's usage
+        week   - Last 7 days
+        month  - Current month (default)
+        year   - Current year
+        all    - All time
+
+      Examples:
+        $ clacky billing
+        $ clacky billing --period week
+        $ clacky billing --period all --json
+    LONGDESC
+    option :period, type: :string, default: "month",
+           desc: "Time period: day, week, month, year, all (default: month)"
+    option :json, type: :boolean, default: false,
+           desc: "Output as JSON"
+    option :days, type: :numeric, default: 30,
+           desc: "Number of days for daily breakdown (default: 30)"
+    option :help, type: :boolean, aliases: "-h", desc: "Show this help message"
+    def billing
+      if options[:help]
+        invoke :help, ["billing"]
+        return
+      end
+
+      require_relative "billing/billing_store"
+
+      store = Clacky::Billing::BillingStore.new
+      period = options[:period].to_sym
+      summary = store.summary(period: period)
+
+      if options[:json]
+        require "json"
+        puts JSON.pretty_generate(summary)
+        return
+      end
+
+      # Display formatted billing summary
+      puts ""
+      puts "📊 Billing Summary (#{period})"
+      puts "─" * 50
+      puts ""
+
+      # Total cost
+      cost_str = summary[:total_cost] > 0 ? "$#{format('%.4f', summary[:total_cost])}" : "$0.0000"
+      puts "  💰 Total Cost:       #{cost_str}"
+      puts "  📝 Total Tokens:     #{format_number(summary[:total_tokens])}"
+      puts "  📥 Prompt Tokens:    #{format_number(summary[:prompt_tokens])}"
+      puts "  📤 Completion:       #{format_number(summary[:completion_tokens])}"
+      puts "  🗄️  Cache Read:       #{format_number(summary[:cache_read_tokens])}"
+      puts "  📝 Cache Write:      #{format_number(summary[:cache_write_tokens])}"
+      puts "  🔢 API Requests:     #{summary[:record_count]}"
+      puts ""
+
+      # By model breakdown
+      if summary[:by_model] && !summary[:by_model].empty?
+        puts "📈 By Model:"
+        puts "─" * 50
+        summary[:by_model].each do |model, data|
+          cost = data.is_a?(Hash) ? data[:cost] : data
+          requests = data.is_a?(Hash) ? data[:requests] : "?"
+          puts "  #{model}"
+          puts "    Cost: $#{format('%.4f', cost)}  |  Requests: #{requests}"
+        end
+        puts ""
+      end
+
+      # Daily breakdown (last N days)
+      daily = store.daily_breakdown(days: [options[:days], 14].min)
+      recent_days = daily.select { |d| d[:cost] > 0 }.last(7)
+
+      if recent_days.any?
+        puts "📅 Recent Daily Usage:"
+        puts "─" * 50
+        recent_days.each do |day|
+          bar_len = [(day[:cost] * 100).to_i, 30].min
+          bar = "█" * bar_len
+          puts "  #{day[:date]}  $#{format('%.4f', day[:cost])}  #{bar}"
+        end
+        puts ""
+      end
+
+      puts "─" * 50
+      puts "  Data stored in: ~/.clacky/billing/"
+      puts ""
     end
 
     # ── server command ─────────────────────────────────────────────────────────

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -412,6 +412,9 @@ module Clacky
         when ["GET",    "/api/version"]           then api_get_version(res)
         when ["POST",   "/api/version/upgrade"]   then api_upgrade_version(req, res)
         when ["POST",   "/api/restart"]           then api_restart(req, res)
+        when ["GET",    "/api/billing/summary"]   then api_billing_summary(req, res)
+        when ["GET",    "/api/billing/daily"]     then api_billing_daily(req, res)
+        when ["GET",    "/api/billing/records"]   then api_billing_records(req, res)
         when ["PATCH",  "/api/sessions/:id/model"] then api_switch_session_model(req, res)
         when ["PATCH",  "/api/sessions/:id/working_dir"] then api_change_session_working_dir(req, res)
         else
@@ -1061,6 +1064,58 @@ module Clacky
       end
 
       # ── Version API ───────────────────────────────────────────────────────────
+
+      # ── Billing API ────────────────────────────────────────────────────────────
+
+      # GET /api/billing/summary
+      # Returns billing summary for a time period
+      # Query params: period (day|week|month|year|all, default: month)
+      def api_billing_summary(req, res)
+        require_relative "../billing/billing_store"
+
+        query  = URI.decode_www_form(req.query_string.to_s).to_h
+        period = (query["period"] || "month").to_sym
+
+        store   = Clacky::Billing::BillingStore.new
+        summary = store.summary(period: period)
+
+        json_response(res, 200, summary)
+      end
+
+      # GET /api/billing/daily
+      # Returns daily cost breakdown
+      # Query params: days (default: 30)
+      def api_billing_daily(req, res)
+        require_relative "../billing/billing_store"
+
+        query = URI.decode_www_form(req.query_string.to_s).to_h
+        days  = [(query["days"] || "30").to_i, 90].min
+
+        store = Clacky::Billing::BillingStore.new
+        daily = store.daily_breakdown(days: days)
+
+        json_response(res, 200, { days: daily })
+      end
+
+      # GET /api/billing/records
+      # Returns recent billing records
+      # Query params: limit (default: 100), model, session_id
+      def api_billing_records(req, res)
+        require_relative "../billing/billing_store"
+
+        query      = URI.decode_www_form(req.query_string.to_s).to_h
+        limit      = [(query["limit"] || "100").to_i, 500].min
+        model      = query["model"]
+        session_id = query["session_id"]
+
+        store   = Clacky::Billing::BillingStore.new
+        records = store.query(model: model, session_id: session_id, limit: limit)
+
+        json_response(res, 200, {
+          records: records.map(&:to_h),
+          count: records.size
+        })
+      end
 
       # GET /api/version
       # Returns current version and latest version from RubyGems (cached for 1 hour).

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -7839,4 +7839,172 @@ body.setup-mode[data-theme="dark"] {
   gap: 0.625rem;
 }
 
+/* ═════════════════════════════════════════════════════════════════════════
+ * BILLING PANEL
+ * ═════════════════════════════════════════════════════════════════════════ */
 
+#billing-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+#billing-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.75rem 2.25rem;
+}
+#billing-content {
+  max-width: 900px;
+  margin: 0 auto;
+}
+.billing-loading,
+.billing-error {
+  text-align: center;
+  padding: 3rem;
+  color: var(--color-text-secondary);
+}
+.billing-error {
+  color: var(--color-error);
+}
+.billing-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+.billing-header h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.billing-period-select {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border-primary);
+  border-radius: 8px;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.billing-summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+.billing-card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 12px;
+  padding: 1.25rem;
+  text-align: center;
+}
+.billing-card-primary {
+  background: linear-gradient(135deg, var(--color-accent-bg) 0%, var(--color-bg-secondary) 100%);
+  border-color: var(--color-accent);
+}
+.billing-card-label {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+.billing-card-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.billing-card-primary .billing-card-value {
+  color: var(--color-accent);
+}
+.billing-section {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+.billing-section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 1rem 0;
+}
+.billing-token-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+.billing-token-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg-primary);
+  border-radius: 8px;
+}
+.billing-token-label {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+.billing-token-value {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.billing-model-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.billing-model-table th,
+.billing-model-table td {
+  padding: 0.625rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border-primary);
+}
+.billing-model-table th {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+}
+.billing-model-table td {
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+}
+.billing-model-name {
+  font-weight: 500;
+}
+.billing-model-cost {
+  font-family: var(--font-mono);
+}
+.billing-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 120px;
+  padding-top: 1rem;
+}
+.billing-chart-bar-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+}
+.billing-chart-bar {
+  width: 100%;
+  max-width: 40px;
+  background: var(--color-accent);
+  border-radius: 4px 4px 0 0;
+  transition: height 0.3s ease;
+}
+.billing-chart-label {
+  font-size: 0.625rem;
+  color: var(--color-text-secondary);
+  margin-top: 0.25rem;
+  white-space: nowrap;
+}

--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -47,6 +47,7 @@ const PANELS = [
   "channels-panel",
   "trash-panel",
   "profile-panel",
+  "billing-panel",
   "settings-panel",
   "creator-panel",
 ];
@@ -82,6 +83,7 @@ const Router = (() => {
     // Legacy: #memories redirects to #profile (memories are now merged into
     // the profile panel). Kept so bookmarks / external links don't 404.
     if (h === "memories")             return { view: "profile",  params: {} };
+    if (h === "billing")              return { view: "billing",  params: {} };
     if (h === "settings")             return { view: "settings", params: {} };
     if (h === "creator")              return { view: "creator",  params: {} };
     const m = h.match(/^session\/(.+)$/);
@@ -98,6 +100,7 @@ const Router = (() => {
     channels: "channels-sidebar-item",
     trash:    "trash-sidebar-item",
     profile:  "profile-sidebar-item",
+    billing:  "billing-sidebar-item",
     creator:  "creator-sidebar-item",
   };
 
@@ -209,6 +212,13 @@ const Router = (() => {
         _setHash("profile");
         $("profile-panel").style.display = "flex";
         Profile.onPanelShow();
+        Sessions.renderList();
+        break;
+
+      case "billing":
+        _setHash("billing");
+        $("billing-panel").style.display = "flex";
+        Billing.open();
         Sessions.renderList();
         break;
 

--- a/lib/clacky/web/billing.js
+++ b/lib/clacky/web/billing.js
@@ -1,0 +1,246 @@
+// billing.js — Billing panel logic
+// Handles displaying billing summary, daily breakdown, and usage statistics.
+
+const Billing = (() => {
+  let _summary = null;
+  let _daily = [];
+  let _currentPeriod = "month";
+
+  // ── Currency Settings ─────────────────────────────────────────────────────
+  const CURRENCY_STORAGE_KEY = "clacky-currency";
+  const USD_TO_CNY_RATE = 6.7944; // Exchange rate: 1 USD ≈ 6.7944 CNY
+
+  function _getCurrency() {
+    try { return localStorage.getItem(CURRENCY_STORAGE_KEY) || "USD"; } catch (_) { return "USD"; }
+  }
+
+  function _convertCost(usdCost) {
+    const currency = _getCurrency();
+    if (currency === "CNY") {
+      return usdCost * USD_TO_CNY_RATE;
+    }
+    return usdCost;
+  }
+
+  function _getCurrencySymbol() {
+    return _getCurrency() === "CNY" ? "¥" : "$";
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  function open() {
+    _load();
+    // Listen for currency changes
+    document.removeEventListener("currencychange", _onCurrencyChange);
+    document.addEventListener("currencychange", _onCurrencyChange);
+  }
+
+  function _onCurrencyChange() {
+    if (_summary) _render();
+  }
+
+  // ── Data Loading ────────────────────────────────────────────────────────────
+
+  async function _load() {
+    const container = document.getElementById("billing-content");
+    if (!container) return;
+
+    container.innerHTML = `<div class="billing-loading">${I18n.t("billing.loading") || "Loading billing data..."}</div>`;
+
+    try {
+      const [summaryRes, dailyRes] = await Promise.all([
+        fetch(`/api/billing/summary?period=${_currentPeriod}`),
+        fetch("/api/billing/daily?days=30")
+      ]);
+
+      _summary = await summaryRes.json();
+      const dailyData = await dailyRes.json();
+      _daily = dailyData.days || [];
+
+      _render();
+    } catch (e) {
+      container.innerHTML = `<div class="billing-error">${I18n.t("billing.error") || "Failed to load billing data"}: ${e.message}</div>`;
+    }
+  }
+
+  // ── Rendering ───────────────────────────────────────────────────────────────
+
+  function _render() {
+    const container = document.getElementById("billing-content");
+    if (!container || !_summary) return;
+
+    const periodOptions = ["day", "week", "month", "year", "all"].map(p => 
+      `<option value="${p}" ${p === _currentPeriod ? "selected" : ""}>${_periodLabel(p)}</option>`
+    ).join("");
+
+    container.innerHTML = `
+      <div class="billing-header">
+        <h2>${I18n.t("billing.title") || "💰 Billing"}</h2>
+        <select id="billing-period-select" class="billing-period-select">
+          ${periodOptions}
+        </select>
+      </div>
+
+      <div class="billing-summary-cards">
+        <div class="billing-card billing-card-primary">
+          <div class="billing-card-label">${I18n.t("billing.totalCost") || "Total Cost"}</div>
+          <div class="billing-card-value">${_getCurrencySymbol()}${_formatCost(_convertCost(_summary.total_cost))}</div>
+        </div>
+        <div class="billing-card">
+          <div class="billing-card-label">${I18n.t("billing.totalTokens") || "Total Tokens"}</div>
+          <div class="billing-card-value">${_formatNumber(_summary.total_tokens)}</div>
+        </div>
+        <div class="billing-card">
+          <div class="billing-card-label">${I18n.t("billing.requests") || "API Requests"}</div>
+          <div class="billing-card-value">${_formatNumber(_summary.record_count)}</div>
+        </div>
+      </div>
+
+      <div class="billing-details">
+        <div class="billing-section">
+          <h3>${I18n.t("billing.tokenBreakdown") || "Token Breakdown"}</h3>
+          <div class="billing-token-grid">
+            <div class="billing-token-item">
+              <span class="billing-token-label">📥 ${I18n.t("billing.promptTokens") || "Prompt"}</span>
+              <span class="billing-token-value">${_formatNumber(_summary.prompt_tokens)}</span>
+            </div>
+            <div class="billing-token-item">
+              <span class="billing-token-label">📤 ${I18n.t("billing.completionTokens") || "Completion"}</span>
+              <span class="billing-token-value">${_formatNumber(_summary.completion_tokens)}</span>
+            </div>
+            <div class="billing-token-item">
+              <span class="billing-token-label">🗄️ ${I18n.t("billing.cacheRead") || "Cache Read"}</span>
+              <span class="billing-token-value">${_formatNumber(_summary.cache_read_tokens)}</span>
+            </div>
+            <div class="billing-token-item">
+              <span class="billing-token-label">📝 ${I18n.t("billing.cacheWrite") || "Cache Write"}</span>
+              <span class="billing-token-value">${_formatNumber(_summary.cache_write_tokens)}</span>
+            </div>
+          </div>
+        </div>
+
+        ${_renderModelBreakdown()}
+        ${_renderDailyChart()}
+      </div>
+    `;
+
+    // Bind period change handler
+    document.getElementById("billing-period-select")?.addEventListener("change", (e) => {
+      _currentPeriod = e.target.value;
+      _load();
+    });
+  }
+
+  function _renderModelBreakdown() {
+    if (!_summary.by_model || Object.keys(_summary.by_model).length === 0) {
+      return "";
+    }
+
+    const rows = Object.entries(_summary.by_model)
+      .sort((a, b) => (b[1].cost || b[1]) - (a[1].cost || a[1]))
+      .map(([model, data]) => {
+        const cost = typeof data === "object" ? data.cost : data;
+        const requests = typeof data === "object" ? data.requests : "—";
+        return `
+          <tr>
+            <td class="billing-model-name">${_esc(model)}</td>
+            <td class="billing-model-cost">${_getCurrencySymbol()}${_formatCost(_convertCost(cost))}</td>
+            <td class="billing-model-requests">${requests}</td>
+          </tr>
+        `;
+      }).join("");
+
+    return `
+      <div class="billing-section">
+        <h3>${I18n.t("billing.byModel") || "By Model"}</h3>
+        <table class="billing-model-table">
+          <thead>
+            <tr>
+              <th>${I18n.t("billing.model") || "Model"}</th>
+              <th>${I18n.t("billing.cost") || "Cost"}</th>
+              <th>${I18n.t("billing.requests") || "Requests"}</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function _renderDailyChart() {
+    if (!_daily || _daily.length === 0) {
+      return "";
+    }
+
+    // Get last 14 days with activity
+    const recentDays = _daily.filter(d => d.cost > 0).slice(-14);
+    if (recentDays.length === 0) {
+      return "";
+    }
+
+    const maxCost = Math.max(...recentDays.map(d => d.cost), 0.01);
+
+    const bars = recentDays.map(d => {
+      const height = Math.max((d.cost / maxCost) * 100, 2);
+      const date = d.date.slice(5); // MM-DD
+      return `
+        <div class="billing-chart-bar-wrapper" title="${d.date}: ${_getCurrencySymbol()}${_formatCost(_convertCost(d.cost))}">
+          <div class="billing-chart-bar" style="height: ${height}%"></div>
+          <div class="billing-chart-label">${date}</div>
+        </div>
+      `;
+    }).join("");
+
+    return `
+      <div class="billing-section">
+        <h3>${I18n.t("billing.dailyUsage") || "Daily Usage"}</h3>
+        <div class="billing-chart">
+          ${bars}
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  function _formatCost(cost) {
+    if (cost == null || cost === 0) return "0.0000";
+    return cost.toFixed(4);
+  }
+
+  function _formatNumber(num) {
+    if (num == null || num === 0) return "0";
+    return num.toLocaleString();
+  }
+
+  function _periodLabel(period) {
+    const labels = {
+      day: I18n.t("billing.period.day") || "Today",
+      week: I18n.t("billing.period.week") || "This Week",
+      month: I18n.t("billing.period.month") || "This Month",
+      year: I18n.t("billing.period.year") || "This Year",
+      all: I18n.t("billing.period.all") || "All Time"
+    };
+    return labels[period] || period;
+  }
+
+  function _esc(str) {
+    if (!str) return "";
+    const div = document.createElement("div");
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  // ── Expose Public API ───────────────────────────────────────────────────────
+
+  return { 
+    open,
+    // Expose currency utilities for other modules
+    getCurrency: _getCurrency,
+    convertCost: _convertCost,
+    getCurrencySymbol: _getCurrencySymbol,
+    USD_TO_CNY_RATE
+  };
+})();

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -26,6 +26,7 @@ const I18n = (() => {
       "sidebar.creator":       "Creator Hub",
       "sidebar.creatorSection": "Creator",
       "sidebar.settings": "Settings",
+      "sidebar.billing": "Usage",
 
       // ── Welcome screen ──
       "welcome.title":  "Welcome to {{brand}}",
@@ -498,6 +499,10 @@ const I18n = (() => {
       "settings.fontSize.medium":          "Medium",
       "settings.fontSize.large":           "Large",
 
+      "settings.currency.title":           "Currency",
+      "settings.currency.usd":             "$ USD",
+      "settings.currency.cny":             "¥ CNY",
+
       // ── Onboard ──
       "onboard.title":              "Welcome to {{brand}}",
       "onboard.subtitle":           "Let's get you set up in a minute.",
@@ -559,6 +564,28 @@ const I18n = (() => {
       "sib.bench.latencyTooltip": "TTFT {{ttft}} · tested {{time}}",
 
       "onboard.welcome":         "Welcome to {{name}}",
+
+      // ── Billing panel ──
+      "billing.title":           "Billing",
+      "billing.loading":         "Loading billing data...",
+      "billing.error":           "Failed to load billing data",
+      "billing.totalCost":       "Total Cost",
+      "billing.totalTokens":     "Total Tokens",
+      "billing.requests":        "API Requests",
+      "billing.tokenBreakdown":  "Token Breakdown",
+      "billing.promptTokens":    "Prompt",
+      "billing.completionTokens": "Completion",
+      "billing.cacheRead":       "Cache Read",
+      "billing.cacheWrite":      "Cache Write",
+      "billing.byModel":         "By Model",
+      "billing.model":           "Model",
+      "billing.cost":            "Cost",
+      "billing.dailyUsage":      "Daily Usage",
+      "billing.period.day":      "Today",
+      "billing.period.week":     "This Week",
+      "billing.period.month":    "This Month",
+      "billing.period.year":     "This Year",
+      "billing.period.all":      "All Time",
     },
 
     zh: {
@@ -575,6 +602,7 @@ const I18n = (() => {
       "sidebar.creator":       "创作者中心",
       "sidebar.creatorSection": "创作者",
       "sidebar.settings": "设置",
+      "sidebar.billing": "用量信息",
 
       // ── Welcome screen ──
       "welcome.title":  "欢迎使用 {{brand}}",
@@ -1042,6 +1070,10 @@ const I18n = (() => {
       "settings.fontSize.medium":          "中",
       "settings.fontSize.large":           "大",
 
+      "settings.currency.title":           "货币",
+      "settings.currency.usd":             "$ 美元",
+      "settings.currency.cny":             "¥ 人民币",
+
       // ── Onboard ──
       "onboard.title":              "欢迎使用 {{brand}}",
       "onboard.subtitle":           "一分钟完成配置，马上开始。",
@@ -1103,6 +1135,28 @@ const I18n = (() => {
       "sib.bench.latencyTooltip": "TTFT {{ttft}} · 测试于 {{time}}",
 
       "onboard.welcome":         "欢迎使用 {{name}}",
+
+      // ── Billing panel ──
+      "billing.title":           "账单",
+      "billing.loading":         "加载账单数据中...",
+      "billing.error":           "加载账单数据失败",
+      "billing.totalCost":       "总费用",
+      "billing.totalTokens":     "总 Token",
+      "billing.requests":        "API 请求数",
+      "billing.tokenBreakdown":  "Token 明细",
+      "billing.promptTokens":    "输入",
+      "billing.completionTokens": "输出",
+      "billing.cacheRead":       "缓存读取",
+      "billing.cacheWrite":      "缓存写入",
+      "billing.byModel":         "按模型",
+      "billing.model":           "模型",
+      "billing.cost":            "费用",
+      "billing.dailyUsage":      "每日用量",
+      "billing.period.day":      "今日",
+      "billing.period.week":     "本周",
+      "billing.period.month":    "本月",
+      "billing.period.year":     "今年",
+      "billing.period.all":      "全部",
     }
   };
 

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -196,6 +196,17 @@
               </div>
             </div>
           </div>
+          <div id="billing-sidebar-item" class="task-item task-item-summary">
+            <div class="task-row">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="task-icon">
+                <line x1="12" y1="1" x2="12" y2="23"/>
+                <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+              </svg>
+              <div class="task-info">
+                <span class="task-name" id="billing-sidebar-label" data-i18n="sidebar.billing">Billing</span>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -651,6 +662,15 @@
       </div>
     </div>
 
+    <!-- ── BILLING PANEL ───────────────────────────────────────────────── -->
+    <div id="billing-panel" style="display:none">
+      <div id="billing-body">
+        <div id="billing-content">
+          <!-- Content loaded dynamically by billing.js -->
+        </div>
+      </div>
+    </div>
+
     <!-- ── SETTINGS PANEL ──────────────────────────────────────────────── -->
     <div id="settings-panel" style="display:none">
       <header id="settings-header">
@@ -715,6 +735,17 @@
             <button id="settings-btn-font-small" class="settings-lang-btn" data-font="small" data-i18n="settings.fontSize.small">小</button>
             <button id="settings-btn-font-medium" class="settings-lang-btn" data-font="medium" data-i18n="settings.fontSize.medium">中</button>
             <button id="settings-btn-font-large" class="settings-lang-btn" data-font="large" data-i18n="settings.fontSize.large">大</button>
+          </div>
+        </section>
+
+        <!-- Currency section -->
+        <section class="settings-section" id="currency-section">
+          <div class="settings-section-title">
+            <span data-i18n="settings.currency.title">Currency</span>
+          </div>
+          <div class="settings-lang-btns">
+            <button id="settings-btn-currency-usd" class="settings-lang-btn" data-currency="USD">$ USD</button>
+            <button id="settings-btn-currency-cny" class="settings-lang-btn" data-currency="CNY">¥ CNY</button>
           </div>
         </section>
 
@@ -1029,6 +1060,7 @@
 <script src="/skills.js"></script>
 <script src="/channels.js"></script>
 <script src="/settings.js"></script>
+<script src="/billing.js"></script>
 <script src="/onboard.js"></script>
 <script src="/brand.js"></script>
 <script src="/creator.js"></script>

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -2288,7 +2288,9 @@ const Sessions = (() => {
       const sibCost = $("sib-cost");
       if (sibCost) {
         if (s.cost_source && s.cost_source !== "estimated") {
-          sibCost.textContent = `$${(s.total_cost || 0).toFixed(2)}`;
+          const symbol = typeof Billing !== "undefined" ? Billing.getCurrencySymbol() : "$";
+          const cost = typeof Billing !== "undefined" ? Billing.convertCost(s.total_cost || 0) : (s.total_cost || 0);
+          sibCost.textContent = `${symbol}${cost.toFixed(2)}`;
         } else {
           sibCost.textContent = "N/A";
         }
@@ -2456,14 +2458,16 @@ const Sessions = (() => {
       // :api       => "$0.00123"   (exact, from API response)
       // :price     => "~$0.00123"  (estimated from pricing table)
       // :estimated => "N/A"        (model unknown in pricing table)
-      const cost = ev.cost || 0;
+      const rawCost = ev.cost || 0;
+      const symbol = typeof Billing !== "undefined" ? Billing.getCurrencySymbol() : "$";
+      const cost = typeof Billing !== "undefined" ? Billing.convertCost(rawCost) : rawCost;
       let costStr;
       if (!ev.cost_source || ev.cost_source === "estimated") {
         costStr = "N/A";
       } else if (ev.cost_source === "price") {
-        costStr = `~$${cost.toFixed(5)}`;
+        costStr = `~${symbol}${cost.toFixed(5)}`;
       } else {
-        costStr = `$${cost.toFixed(5)}`;
+        costStr = `${symbol}${cost.toFixed(5)}`;
       }
 
       // Always-visible: label, delta, cache indicator, cost
@@ -3675,5 +3679,9 @@ const Sessions = (() => {
 })();
 
 document.addEventListener("langchange", () => {
+  if (Sessions._lastSession) Sessions.updateInfoBar(Sessions._lastSession);
+});
+
+document.addEventListener("currencychange", () => {
   if (Sessions._lastSession) Sessions.updateInfoBar(Sessions._lastSession);
 });

--- a/lib/clacky/web/settings.js
+++ b/lib/clacky/web/settings.js
@@ -1142,9 +1142,39 @@ const Settings = (() => {
 
     _initLangBtns();
     _initFontBtns();
+    _initCurrencyBtns();
 
     // Re-render model cards when language changes (dynamic HTML, not data-i18n)
     document.addEventListener("langchange", () => _renderCards());
+  }
+
+  // ── Currency ──────────────────────────────────────────────────────────
+  const CURRENCY_STORAGE_KEY = "clacky-currency";
+  const CURRENCY_DEFAULT     = "USD";
+
+  function _applyCurrency(currency) {
+    try { localStorage.setItem(CURRENCY_STORAGE_KEY, currency); } catch (_) {}
+    // Update active state on all currency buttons
+    document.querySelectorAll("#currency-section .settings-lang-btn").forEach(btn => {
+      btn.classList.toggle("active", btn.dataset.currency === currency);
+    });
+    // Dispatch event for billing panel to update
+    document.dispatchEvent(new CustomEvent("currencychange", { detail: { currency } }));
+  }
+
+  function _initCurrencyBtns() {
+    // Apply saved preference (or default) on page load
+    let saved = null;
+    try { saved = localStorage.getItem(CURRENCY_STORAGE_KEY); } catch (_) {}
+    const current = saved || CURRENCY_DEFAULT;
+
+    // Wire up button clicks
+    document.querySelectorAll("#currency-section .settings-lang-btn").forEach(btn => {
+      btn.classList.toggle("active", btn.dataset.currency === current);
+      btn.addEventListener("click", () => {
+        _applyCurrency(btn.dataset.currency);
+      });
+    });
   }
 
   // ── Font Size ──────────────────────────────────────────────────────────

--- a/lib/clacky/web/sidebar.js
+++ b/lib/clacky/web/sidebar.js
@@ -26,6 +26,7 @@ const Sidebar = (() => {
     document.getElementById("channels-sidebar-item").addEventListener("click", () => Router.navigate("channels"));
     document.getElementById("trash-sidebar-item").addEventListener("click", () => Router.navigate("trash"));
     document.getElementById("profile-sidebar-item").addEventListener("click", () => Router.navigate("profile"));
+    document.getElementById("billing-sidebar-item").addEventListener("click", () => Router.navigate("billing"));
 
     // memories-sidebar-item is retained as a hidden legacy placeholder — no click handler.
 

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -200,9 +200,12 @@ WS.onEvent(ev => {
       Sessions.collapseToolGroup();
       {
         const costSource = ev.cost_source;
+        const symbol = typeof Billing !== "undefined" ? Billing.getCurrencySymbol() : "$";
+        const rawCost = ev.cost || 0;
+        const cost = typeof Billing !== "undefined" ? Billing.convertCost(rawCost) : rawCost;
         const costDisplay = (!costSource || costSource === "estimated")
           ? "N/A"
-          : `$${(ev.cost || 0).toFixed(4)}`;
+          : `${symbol}${cost.toFixed(4)}`;
         let mainLine = I18n.t("chat.done", { n: ev.iterations, cost: costDisplay });
         if (typeof ev.duration === "number" && ev.duration > 0) {
           mainLine += I18n.t("chat.done.duration", { duration: ev.duration.toFixed(1) });


### PR DESCRIPTION
- Add persistent billing storage (~/.clacky/billing/*.jsonl)
- Add CLI command: clacky billing
- Add Web API endpoints for billing data
- Add Web UI billing panel with i18n support
- Add currency settings (USD/CNY, rate: 6.7944)
- Apply currency to all cost displays in Web UI