### PR TITLE
feat: add agent inbox for non-blocking message queuing during runs

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -46,9 +46,17 @@ module Clacky
       @inbox_needs_follow_up = attrs[:inbox_needs_follow_up] || false
     end
 
-    def success?     = @status == :success
-    def error?       = @status == :error
-    def interrupted? = @status == :interrupted
+    def success?
+      @status == :success
+    end
+
+    def error?
+      @status == :error
+    end
+
+    def interrupted?
+      @status == :interrupted
+    end
 
     # Backward-compatible Hash-style access so existing callers
     # (specs, CLI, etc.) don't break during the transition.
@@ -700,6 +708,37 @@ module Clacky
     # run loop's "LLM said done — but should we really break?" check.
     private def inbox_pending?
       @state_mutex.synchronize { !@inbox.empty? }
+    end
+
+    # Public: count of pending :user_msg items in the inbox.
+    # Used by WebSocket reconnect to replay queue status to newly subscribed tabs.
+    def inbox_user_message_count
+      @state_mutex.synchronize { @inbox.count { |i| i[:kind] == :user_msg } }
+    end
+
+    # Public: snapshot of pending :user_msg items in the inbox, in a format
+    # ready for replay via UI#show_user_message on WebSocket reconnect.
+    # Each entry: { content:, files:, created_at: } — files is an array of
+    # display-file hashes (name, data_url, mime_type).
+    def inbox_user_messages_snapshot
+      @state_mutex.synchronize do
+        @inbox.select { |i| i[:kind] == :user_msg }.map do |item|
+          created_at = item[:enqueued_at] || Time.now
+          if item[:processed]
+            {
+              content:    item[:processed][:user_content],
+              files:      item[:processed][:display_files] || [],
+              created_at: created_at.to_f
+            }
+          else
+            {
+              content:    item[:content],
+              files:      [],
+              created_at: created_at.to_f
+            }
+          end
+        end
+      end
     end
 
     # Set @discard_threshold to now and (best-effort) raise AgentInterrupted

--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -25,6 +25,45 @@ require_relative "agent/skill_reflector"
 require_relative "agent/skill_auto_creator"
 
 module Clacky
+  # Result object returned by Agent#run.  Carries enough metadata for the
+  # caller (http_server, CLI, etc.) to decide what to do next without
+  # reaching back into the agent's internal state.
+  class RunResult
+    attr_reader :status, :session_id, :iterations, :duration_seconds,
+                :total_cost_usd, :cost_source, :cache_stats, :history,
+                :error, :inbox_needs_follow_up
+
+    def initialize(attrs = {})
+      @status                = attrs[:status]                || :success
+      @session_id            = attrs[:session_id]
+      @iterations            = attrs[:iterations]            || 0
+      @duration_seconds      = attrs[:duration_seconds]      || 0.0
+      @total_cost_usd        = attrs[:total_cost_usd]        || 0.0
+      @cost_source           = attrs[:cost_source]           || :estimated
+      @cache_stats           = attrs[:cache_stats]           || {}
+      @history               = attrs[:history]
+      @error                 = attrs[:error]
+      @inbox_needs_follow_up = attrs[:inbox_needs_follow_up] || false
+    end
+
+    def success?     = @status == :success
+    def error?       = @status == :error
+    def interrupted? = @status == :interrupted
+
+    # Backward-compatible Hash-style access so existing callers
+    # (specs, CLI, etc.) don't break during the transition.
+    # Whitelist prevents accidental exposure of Object methods.
+    HASH_KEYS = %i[
+      status session_id iterations duration_seconds
+      total_cost_usd cost_source cache_stats history
+      error inbox_needs_follow_up
+    ].freeze
+
+    def [](key)
+      public_send(key) if HASH_KEYS.include?(key)
+    end
+  end
+
   class Agent
     # Include all functionality modules
     include MessageCompressorHelper
@@ -102,6 +141,17 @@ module Clacky
       @pending_injections = []     # Pending inline skill injections to flush after observe()
       @pending_script_tmpdirs = [] # Decrypted-script tmpdirs to shred when agent.run completes
       @pending_error_rollback = false  # Deferred rollback flag set by restore_session on error
+      @in_run_loop = false         # True while agent.run() is active (set under @state_mutex)
+      # Unified inbox for user messages that should land in @history at the
+      # next iteration boundary inside the run loop. Items structure:
+      #   {kind: :user_msg, content:, files:, enqueued_at:}
+      # Drained chronologically by drain_inbox_into_history! (run loop top).
+      @inbox = []
+      @inbox_run_pending = false   # Set true after enqueue_user_message decides to spawn a run; cleared at run() entry. Dedupes concurrent spawns.
+      @state_mutex = Mutex.new     # Protects @in_run_loop, @inbox, @inbox_run_pending, @current_run_thread, @discard_threshold
+      @run_mutex = Mutex.new       # Serializes every Agent#run invocation regardless of caller
+      @current_run_thread = nil    # Thread currently inside run()'s body — set under @state_mutex; used by interrupt_current_run!
+      @discard_threshold = nil     # Time. Stale run attempts whose enqueue time predates this are dropped.
 
       # Compression tracking
       @compression_level = 0  # Tracks how many times we've compressed (for progressive summarization)
@@ -217,7 +267,40 @@ module Clacky
       @name = new_name.to_s.strip
     end
 
-    def run(user_input, files: [])
+    # Entry point for an agent turn. Two modes:
+    #
+    #   run("user typed this")  — user message mode
+    #   run                     — drain-only mode: nothing to append directly;
+    #                              the inbox drain at iteration top is expected
+    #                              to find something. If the inbox is also empty,
+    #                              the loop exits immediately (no wasted LLM call).
+    def run(user_input = nil, files: [])
+      # Serialize every Agent#run invocation so concurrent callers cannot
+      # mutate @history, @iterations, etc. simultaneously.
+      @run_mutex.synchronize do
+        @state_mutex.synchronize do
+          @in_run_loop = true
+          @current_run_thread = Thread.current
+          # We're entering run() — any concurrent caller that observed
+          # @inbox_run_pending == true and decided NOT to spawn can rely
+          # on this run absorbing their inbox items. Clear the flag.
+          @inbox_run_pending = false
+        end
+
+        # Drain-only mode: no direct input, and nothing queued either. Don't
+        # bother the LLM with an empty turn.
+        if user_input.nil?
+          empty_inbox = @state_mutex.synchronize { @inbox.empty? }
+          if empty_inbox
+            @state_mutex.synchronize do
+              @in_run_loop = false
+              @current_run_thread = nil
+            end
+            Clacky::Logger.info("agent.drain_only_run_empty_inbox", session_id: @session_id)
+            return RunResult.new(session_id: @session_id, status: :empty_inbox)
+          end
+        end
+
       # Show the "thinking" indicator as early as possible so the user gets
       # immediate feedback after sending a message. Without this the UI stays
       # silent during synchronous setup work (system prompt assembly, file
@@ -274,104 +357,23 @@ module Clacky
       # Inject chunk index card if archived chunks exist and index is stale
       inject_chunk_index_if_needed
 
-      # Split files into vision images and disk files; downgrade oversized images to disk
-      image_files, disk_files = partition_files(Array(files))
-      vision_images, downgraded = resolve_vision_images(image_files)
-      all_disk_files = disk_files + downgraded
+      if user_input.nil? || user_input.empty?
+        # Drain-only mode: nothing to append now. The iteration drain at the
+        # top of the loop will pick up whatever's in @inbox (which is why we
+        # were started — see http_server's follow-up run spawn).
+      else
+        # Normal user message mode — files may or may not be attached.
+        # Both branches end with the same append shape; the only difference
+        # is whether file processing is needed.
+        processed = process_files_for_user_message(user_input, files)
+        append_processed_user_message_to_history!(processed, task_id)
 
-      # Format user message — text + inline vision images
-      # Store the tmp path alongside the data_url so the history replay can
-      # reconstruct the image if the base64 was stripped (e.g. after compression).
-      user_content = format_user_content(user_input, vision_images.map { |v| { url: v[:url], path: v[:path] } })
-
-      # Parse disk files — agent's responsibility, not the upload layer.
-      # process_path runs the parser script and returns a FileRef with preview_path or parse_error.
-      all_disk_files = all_disk_files.map do |f|
-        path = f[:path] || f["path"]
-        name = f[:name] || f["name"]
-        next f unless path && File.exist?(path.to_s)
-        # Preserve the downgrade_reason tag across the remap (process_path
-        # returns a fresh FileRef that doesn't know about it). Without this,
-        # the file_prompt builder can't emit the "not supported by model" /
-        # "too large" note for downgraded images.
-        downgrade_reason = f[:downgrade_reason] || f["downgrade_reason"]
-        ref = Utils::FileProcessor.process_path(path, name: name)
-        { name: ref.name, type: ref.type.to_s, path: ref.original_path,
-          preview_path: ref.preview_path, parse_error: ref.parse_error, parser_path: ref.parser_path,
-          downgrade_reason: downgrade_reason }
+        # If the user typed a slash command targeting a skill with disable-model-invocation: true,
+        # inject the skill content as a synthetic assistant message so the LLM can act on it.
+        # Skills already in the system prompt (model_invocation_allowed?) are skipped.
+        # Only relevant when there's actual user input — drain-only mode has nothing to inject.
+        inject_skill_command_as_assistant_message(user_input, task_id)
       end
-
-      # Build display_files for replay: lightweight metadata so the UI can reconstruct
-      # file badges (PDF, doc, etc.) on page refresh. Images are NOT stored here — they
-      # are recovered from the image_url blocks in user_content by extract_image_files_from_content.
-      display_files = all_disk_files.filter_map do |f|
-        name = f[:name] || f["name"]
-        next unless name
-        { name: name, type: f[:type] || f["type"] || "file",
-          preview_path: f[:preview_path] || f["preview_path"] }
-      end
-
-      @history.append({ role: "user", content: user_content, task_id: task_id, created_at: Time.now.to_f,
-                        display_files: display_files.empty? ? nil : display_files })
-      @total_tasks += 1
-
-      # Inject disk file references as a system_injected message so:
-      #   - LLM sees the file info (system_injected is NOT stripped from to_api)
-      #   - replay_history skips it (next if ev[:system_injected]), keeping the user bubble clean
-      #
-      # Images: also injected here (alongside vision inline) so LLM knows filename + size.
-      all_meta_files = vision_images.map { |v|
-        { name: v[:name], type: "image", size_bytes: v[:size_bytes], path: v[:path] }
-      } + all_disk_files
-
-      unless all_meta_files.empty?
-        file_prompt = all_meta_files.filter_map do |f|
-          name             = f[:name]             || f["name"]
-          type             = f[:type]             || f["type"]
-          path             = f[:path]             || f["path"]
-          preview_path     = f[:preview_path]     || f["preview_path"]
-          size_bytes       = f[:size_bytes]       || f["size_bytes"]
-          parse_error      = f[:parse_error]      || f["parse_error"]
-          parser_path      = f[:parser_path]      || f["parser_path"]
-          downgrade_reason = f[:downgrade_reason] || f["downgrade_reason"]
-
-          next unless name
-
-          lines = ["[File: #{name}]", "Type: #{type || "file"}"]
-          lines << "Size: #{format_size(size_bytes)}" if size_bytes
-          lines << "Original: #{path}" if path
-          lines << "Preview (Markdown): #{preview_path}" if preview_path
-
-          # Inline note explaining why an image was *not* sent as vision
-          # content. Colocated with the file info (not in system prompt) so
-          # it reflects the exact reason for *this* upload under *this*
-          # model — switching models later won't leave stale warnings.
-          note = downgrade_note_for(downgrade_reason)
-          lines << "Note: #{note}" if note
-
-          # Parser failed — instruct LLM to fix and re-run
-          if preview_path.nil? && parse_error
-            lines << "Parse failed: #{parse_error}"
-            if parser_path
-              expected_preview = "#{path}.preview.md"
-              lines << "Action required: fix the parser at #{parser_path}, then run:"
-              lines << "  ruby #{parser_path} #{path} > #{expected_preview}"
-              lines << "Once done, read #{expected_preview} to continue helping the user."
-            end
-          end
-
-          lines.join("\n")
-        end.join("\n\n")
-
-        unless file_prompt.empty?
-          @history.append({ role: "user", content: file_prompt, system_injected: true, task_id: task_id })
-        end
-      end
-
-      # If the user typed a slash command targeting a skill with disable-model-invocation: true,
-      # inject the skill content as a synthetic assistant message so the LLM can act on it.
-      # Skills already in the system prompt (model_invocation_allowed?) are skipped.
-      inject_skill_command_as_assistant_message(user_input, task_id)
 
       @hooks.trigger(:on_start, user_input)
 
@@ -384,6 +386,11 @@ module Clacky
         loop do
           @iterations += 1
           @hooks.trigger(:on_iteration, @iterations)
+
+          # Drain any inbox items (queued user messages) since the last
+          # iteration. Without this, items sit in the queue until the WHOLE
+          # run completes — latency drops from "minutes" to "one LLM turn".
+          drain_inbox_into_history!(task_id)
 
           # Think: LLM reasoning with tool support
           response = think
@@ -463,6 +470,18 @@ module Clacky
                 preview = response[:content].length > 200 ? response[:content][0...200] + "..." : response[:content]
                 @ui&.log("Response content: #{preview}", level: :debug)
               end
+            end
+
+            # A queued user message may have landed between this think() and
+            # now. Don't break — loop back so the next iteration's drain
+            # injects it and the LLM addresses it within the same warm-cache
+            # run. Saves the full-context replay of a fresh run().
+            if inbox_pending?
+              Clacky::Logger.info("agent.loop_continue_for_pending_inbox",
+                session_id: @session_id,
+                iteration: @iterations
+              )
+              next
             end
 
             break
@@ -556,7 +575,7 @@ module Clacky
           )
         end
         @hooks.trigger(:on_complete, result)
-        result
+        RunResult.new(result.merge(inbox_needs_follow_up: inbox_pending?))
       rescue Clacky::AgentInterrupted
         # Let CLI handle the interrupt message
         raise
@@ -580,6 +599,11 @@ module Clacky
         result = build_result(:error, error: e.message)  # rubocop:disable Lint/UselessAssignment
         raise
       ensure
+        @state_mutex.synchronize do
+          @in_run_loop = false
+          @current_run_thread = nil
+        end
+
         # Safety net: ensure any lingering progress spinner is stopped.
         # Normal paths close their own spinners; this guards against exceptions
         # raised between a progress slot's active/done pair.
@@ -594,6 +618,189 @@ module Clacky
         # Tracks daily active users (distinct devices per day) and task volume.
         Clacky::Telemetry.task!
       end
+      end  # @run_mutex.synchronize
+    end
+
+    # Drain ALL pending inbox items into @history. Called at the top of every
+    # iteration inside the run loop so messages land within one LLM turn of
+    # arrival — never deferred until the whole run completes.
+    #
+    # Returns true if anything was drained, false if the inbox was empty.
+    private def drain_inbox_into_history!(task_id)
+      items = nil
+      @state_mutex.synchronize do
+        return false if @inbox.empty?
+        items = @inbox.dup
+        @inbox.clear
+      end
+
+      items.each do |item|
+        case item[:kind]
+        when :user_msg
+          created_at = item[:enqueued_at] || Time.now
+
+          if item[:processed]
+            append_processed_user_message_to_history!(item[:processed], task_id)
+            @ui&.show_user_message(
+              item[:processed][:user_content],
+              files: item[:processed][:display_files] || [],
+              created_at: created_at.to_f,
+              source: :web
+            )
+          else
+            @history.append({
+              role:       "user",
+              content:    item[:content],
+              task_id:    task_id,
+              created_at: created_at.to_f
+            })
+            @total_tasks += 1
+            @ui&.show_user_message(item[:content], created_at: created_at.to_f, source: :web)
+          end
+        else
+          Clacky::Logger.warn("agent.unknown_inbox_kind", kind: item[:kind])
+        end
+      end
+
+      remaining = @state_mutex.synchronize { @inbox.count { |i| i[:kind] == :user_msg } }
+      broadcast_user_message_queue_status(remaining)
+
+      Clacky::Logger.info("agent.inbox_drained",
+        session_id: @session_id,
+        count:      items.size,
+        kinds:      items.group_by { |i| i[:kind] }.transform_values(&:size)
+      )
+      true
+    rescue => e
+      # Drain failed partway through: unprocessed items are lost from @inbox
+      # because we cleared it before the loop. Re-queue the survivors so the
+      # next run (or a fresh spawn) can retry them.
+      processed_count = items.size - items.compact.size
+      survivors = items.compact
+      unless survivors.empty?
+        @state_mutex.synchronize do
+          @inbox.unshift(*survivors)
+        end
+        Clacky::Logger.warn("agent.drain_inbox_recovered",
+          session_id: @session_id,
+          recovered:  survivors.size,
+          error:      e.message
+        )
+      end
+      Clacky::Logger.error("agent.drain_inbox_error",
+        session_id:    @session_id,
+        error:         e,
+        processed:     processed_count,
+        survivors:     survivors.size
+      )
+      false
+    end
+
+    # True if at least one item is currently queued in the inbox. Used by the
+    # run loop's "LLM said done — but should we really break?" check.
+    private def inbox_pending?
+      @state_mutex.synchronize { !@inbox.empty? }
+    end
+
+    # Set @discard_threshold to now and (best-effort) raise AgentInterrupted
+    # into the thread currently inside Agent#run. Called by http_server's
+    # interrupt_session in addition to the existing session[:thread].raise —
+    # the existing path only catches user-msg runs (whose thread is tracked
+    # in session[:thread]).
+    #
+    # Idempotent: harmless to call multiple times. Best-effort: Thread#raise
+    # against a thread blocked deep in a syscall may not fire immediately;
+    # the watchdog in http_server escalates if needed.
+    def interrupt_current_run!
+      target = nil
+      @state_mutex.synchronize do
+        @discard_threshold = Time.now
+        target = @current_run_thread
+      end
+      return false unless target
+      begin
+        target.raise(Clacky::AgentInterrupted, "Interrupted by user")
+      rescue StandardError
+        # Thread may have just exited; nothing to do.
+      end
+      true
+    end
+
+    # True iff a thread is currently inside Agent#run (between acquiring
+    # @run_mutex and releasing it). Server-layer callers use this to decide
+    # whether a new user message can be enqueued (run in flight will drain
+    # it) or needs a fresh run() to be spawned (agent is idle).
+    def in_run_loop?
+      @state_mutex.synchronize { @in_run_loop }
+    end
+
+    # Queue a user message (text and/or files) into the inbox. Returns a
+    # tristate describing what the caller should do next:
+    #   :running       — a run is currently in flight; the in-loop drain at
+    #                    the next iteration boundary will pick this up.
+    #                    Caller does NOT spawn a new run.
+    #   :spawn         — agent is idle AND no other caller has been told to
+    #                    spawn yet. Caller IS responsible for spawning a
+    #                    drain-only run (typically via run_agent_task so the
+    #                    thread is registered for interrupt_session).
+    #   :spawn_pending — agent is idle BUT another concurrent caller has
+    #                    already been told to spawn. Caller does NOT spawn —
+    #                    the other run will absorb this message too.
+    #
+    # Files are processed eagerly **on the caller's thread** (typically the
+    # HTTP-handler thread) so the processed payload is fully formed by the
+    # time it sits in the inbox. The agent thread's drain then just appends
+    # to @history — no @history mutation off-thread.
+    def enqueue_user_message(content, files: [])
+      processed = nil
+      if files && !files.empty?
+        processed = process_files_for_user_message(content, files)
+      end
+
+      result = nil
+      pending_user_msgs = 0
+      @state_mutex.synchronize do
+        @inbox << {
+          kind:        :user_msg,
+          content:     content.to_s,
+          processed:   processed,
+          enqueued_at: Time.now
+        }
+        pending_user_msgs = @inbox.count { |i| i[:kind] == :user_msg }
+        if @in_run_loop
+          result = :running
+        elsif @inbox_run_pending
+          result = :spawn_pending
+        else
+          @inbox_run_pending = true
+          result = :spawn
+        end
+      end
+
+      # Only broadcast the "N waiting" hint when the message will actually
+      # WAIT behind an in-flight run. For :spawn / :spawn_pending the agent
+      # will drain it within milliseconds, so flashing a count then
+      # immediately clearing it would just be visual noise.
+      if result == :running
+        broadcast_user_message_queue_status(pending_user_msgs)
+      end
+
+      Clacky::Logger.info("agent.user_message_enqueued",
+        session_id: @session_id,
+        decision: result,
+        has_files: !processed.nil?,
+        pending_user_msgs: pending_user_msgs
+      )
+      result
+    end
+
+    private def broadcast_user_message_queue_status(count)
+      @ui&.update_user_message_queue_status(pending: count)
+    rescue => e
+      Clacky::Logger.error("agent.user_queue_status_error",
+        session_id: @session_id,
+        error: e
+      )
     end
 
     private def think
@@ -1342,6 +1549,126 @@ module Clacky
     # @param images [Array<String>] Array of image file paths or data: URLs
     # @param files [Array] Unused — kept for signature compatibility
     # @return [String|Array] String if no images, Array with content blocks otherwise
+    # Pure: process a user message's text + file attachments into the data
+    # structures needed for @history append, WITHOUT touching @history itself.
+    # Safe to call from any thread (HTTP-handler thread or agent thread) —
+    # only mutates argument-local state and runs the FileProcessor subprocess.
+    #
+    # Returns a Hash:
+    #   {
+    #     user_content:  String or content-block Array (text + vision blocks),
+    #     display_files: Array<{name, type, preview_path}> for replay bubbles,
+    #     file_prompt:   String (system_injected file references for LLM, "" if none)
+    #   }
+    #
+    # The companion +append_processed_user_message_to_history!+ takes this
+    # hash and does the actual append — that part MUST run on the
+    # @run_mutex-holding thread.
+    private def process_files_for_user_message(content, files)
+      image_files, disk_files = partition_files(Array(files))
+      vision_images, downgraded = resolve_vision_images(image_files)
+      all_disk_files = disk_files + downgraded
+
+      # Format user message — text + inline vision images
+      user_content = format_user_content(content, vision_images.map { |v| { url: v[:url], path: v[:path] } })
+
+      # Parse disk files — process_path runs the parser script and returns a FileRef.
+      all_disk_files = all_disk_files.map do |f|
+        path = f[:path] || f["path"]
+        name = f[:name] || f["name"]
+        next f unless path && File.exist?(path.to_s)
+        downgrade_reason = f[:downgrade_reason] || f["downgrade_reason"]
+        ref = Utils::FileProcessor.process_path(path, name: name)
+        { name: ref.name, type: ref.type.to_s, path: ref.original_path,
+          preview_path: ref.preview_path, parse_error: ref.parse_error, parser_path: ref.parser_path,
+          downgrade_reason: downgrade_reason }
+      end
+
+      display_files = all_disk_files.filter_map do |f|
+        name = f[:name] || f["name"]
+        next unless name
+        { name: name, type: f[:type] || f["type"] || "file",
+          preview_path: f[:preview_path] || f["preview_path"] }
+      end
+
+      all_meta_files = vision_images.map { |v|
+        { name: v[:name], type: "image", size_bytes: v[:size_bytes], path: v[:path] }
+      } + all_disk_files
+
+      file_prompt = build_file_prompt(all_meta_files)
+
+      {
+        user_content:  user_content,
+        display_files: display_files,
+        file_prompt:   file_prompt
+      }
+    end
+
+    # Mutates @history. Caller MUST hold @run_mutex (i.e. this is called
+    # from inside Agent#run, either from the user-message-mode branch
+    # directly or from drain_inbox_into_history! processing a user_msg
+    # item whose files were pre-processed at HTTP-entry time).
+    private def append_processed_user_message_to_history!(processed, task_id)
+      @history.append({
+        role:          "user",
+        content:       processed[:user_content],
+        task_id:       task_id,
+        created_at:    Time.now.to_f,
+        display_files: processed[:display_files].empty? ? nil : processed[:display_files]
+      })
+      @total_tasks += 1
+
+      file_prompt = processed[:file_prompt]
+      unless file_prompt.nil? || file_prompt.empty?
+        @history.append({
+          role:            "user",
+          content:         file_prompt,
+          system_injected: true,
+          task_id:         task_id
+        })
+      end
+    end
+
+    # Build the system_injected file-prompt string from an Array of file
+    # metadata hashes. Returns "" if there are no files. Extracted so both
+    # process_files_for_user_message and any future caller share one shape.
+    private def build_file_prompt(all_meta_files)
+      return "" if all_meta_files.empty?
+
+      all_meta_files.filter_map do |f|
+        name             = f[:name]             || f["name"]
+        type             = f[:type]             || f["type"]
+        path             = f[:path]             || f["path"]
+        preview_path     = f[:preview_path]     || f["preview_path"]
+        size_bytes       = f[:size_bytes]       || f["size_bytes"]
+        parse_error      = f[:parse_error]      || f["parse_error"]
+        parser_path      = f[:parser_path]      || f["parser_path"]
+        downgrade_reason = f[:downgrade_reason] || f["downgrade_reason"]
+
+        next unless name
+
+        lines = ["[File: #{name}]", "Type: #{type || "file"}"]
+        lines << "Size: #{format_size(size_bytes)}" if size_bytes
+        lines << "Original: #{path}" if path
+        lines << "Preview (Markdown): #{preview_path}" if preview_path
+
+        note = downgrade_note_for(downgrade_reason)
+        lines << "Note: #{note}" if note
+
+        if preview_path.nil? && parse_error
+          lines << "Parse failed: #{parse_error}"
+          if parser_path
+            expected_preview = "#{path}.preview.md"
+            lines << "Action required: fix the parser at #{parser_path}, then run:"
+            lines << "  ruby #{parser_path} #{path} > #{expected_preview}"
+            lines << "Once done, read #{expected_preview} to continue helping the user."
+          end
+        end
+
+        lines.join("\n")
+      end.join("\n\n")
+    end
+
     # Partition files array into [image_files, non_image_files].
     # Image files: have mime_type starting with "image/" OR have data_url present.
     private def partition_files(files)

--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -25,53 +25,6 @@ require_relative "agent/skill_reflector"
 require_relative "agent/skill_auto_creator"
 
 module Clacky
-  # Result object returned by Agent#run.  Carries enough metadata for the
-  # caller (http_server, CLI, etc.) to decide what to do next without
-  # reaching back into the agent's internal state.
-  class RunResult
-    attr_reader :status, :session_id, :iterations, :duration_seconds,
-                :total_cost_usd, :cost_source, :cache_stats, :history,
-                :error, :inbox_needs_follow_up
-
-    def initialize(attrs = {})
-      @status                = attrs[:status]                || :success
-      @session_id            = attrs[:session_id]
-      @iterations            = attrs[:iterations]            || 0
-      @duration_seconds      = attrs[:duration_seconds]      || 0.0
-      @total_cost_usd        = attrs[:total_cost_usd]        || 0.0
-      @cost_source           = attrs[:cost_source]           || :estimated
-      @cache_stats           = attrs[:cache_stats]           || {}
-      @history               = attrs[:history]
-      @error                 = attrs[:error]
-      @inbox_needs_follow_up = attrs[:inbox_needs_follow_up] || false
-    end
-
-    def success?
-      @status == :success
-    end
-
-    def error?
-      @status == :error
-    end
-
-    def interrupted?
-      @status == :interrupted
-    end
-
-    # Backward-compatible Hash-style access so existing callers
-    # (specs, CLI, etc.) don't break during the transition.
-    # Whitelist prevents accidental exposure of Object methods.
-    HASH_KEYS = %i[
-      status session_id iterations duration_seconds
-      total_cost_usd cost_source cache_stats history
-      error inbox_needs_follow_up
-    ].freeze
-
-    def [](key)
-      public_send(key) if HASH_KEYS.include?(key)
-    end
-  end
-
   class Agent
     # Include all functionality modules
     include MessageCompressorHelper
@@ -305,7 +258,7 @@ module Clacky
               @current_run_thread = nil
             end
             Clacky::Logger.info("agent.drain_only_run_empty_inbox", session_id: @session_id)
-            return RunResult.new(session_id: @session_id, status: :empty_inbox)
+            return
           end
         end
 
@@ -583,7 +536,7 @@ module Clacky
           )
         end
         @hooks.trigger(:on_complete, result)
-        RunResult.new(result.merge(inbox_needs_follow_up: inbox_pending?))
+        result
       rescue Clacky::AgentInterrupted
         # Let CLI handle the interrupt message
         raise

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3456,6 +3456,22 @@ module Clacky
             # If a shell command is still running, replay progress + buffered stdout
             # to the newly subscribed tab so it sees the live state it may have missed.
             @registry.with_session(session_id) { |s| s[:ui]&.replay_live_state }
+            # Replay inbox queue status AND pending message content so the
+            # reconnected tab sees both the count hint AND the pending
+            # ghost bubbles for messages still waiting to be drained.
+            @registry.with_session(session_id) do |s|
+              if (agent = s[:agent])
+                pending = agent.inbox_user_message_count
+                if pending > 0
+                  s[:ui]&.update_user_message_queue_status(pending: pending)
+                  conn.send_json({
+                    type:       "pending_user_messages",
+                    session_id: session_id,
+                    messages:   agent.inbox_user_messages_snapshot
+                  })
+                end
+              end
+            end
           else
             conn.send_json(type: "error", message: "Session not found: #{session_id}")
           end
@@ -3761,7 +3777,20 @@ module Clacky
           @registry.update(session_id, status: :idle)
           broadcast_session_update(session_id)
           broadcast(session_id, { type: "interrupted", session_id: session_id })
+          # Re-broadcast inbox queue status so the frontend shows the
+          # accurate pending count after interruption (messages queued
+          # during the run are preserved, not discarded).
+          pending = agent.inbox_user_message_count
+          s = nil
+          @registry.with_session(session_id) { |sess| s = sess }
+          s[:ui]&.update_user_message_queue_status(pending: pending)
           @session_manager.save(agent.to_session_data(status: :interrupted))
+
+          # If the inbox still has queued messages after interruption,
+          # immediately resume draining them — don't go idle.
+          if pending > 0
+            run_agent_task(session_id, agent) { agent.run }
+          end
         rescue => e
           @registry.update(session_id, status: :error, error: e.message)
           broadcast_session_update(session_id)

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3435,6 +3435,10 @@ module Clacky
 
       def on_ws_message(conn, raw)
         msg = JSON.parse(raw)
+        unless msg.is_a?(Hash)
+          Clacky::Logger.warn("[on_ws_message] Ignoring non-Hash message: #{raw[0,200].inspect}")
+          return
+        end
         type = msg["type"]
 
         case type
@@ -3509,9 +3513,12 @@ module Clacky
       def handle_user_message(session_id, content, files = [])
         return unless @registry.exist?(session_id)
 
-        session = @registry.get(session_id)
-        
+        agent = nil
+        @registry.with_session(session_id) { |s| agent = s[:agent] }
+        return unless agent
+
         # If session is running, interrupt it first (mimics CLI behavior)
+        session = @registry.get(session_id)
         if session[:status] == :running
           interrupt_session(session_id)
 
@@ -3526,10 +3533,6 @@ module Clacky
           old_thread&.join(2)
         end
 
-        agent = nil
-        @registry.with_session(session_id) { |s| agent = s[:agent] }
-        return unless agent
-
         # Auto-name the session from the first user message (before agent starts running).
         # Skip if the name looks like it was set by the user (not a system-generated "Session N").
         if agent.history.empty? && agent.name.match?(/\ASession \d+\z/)
@@ -3539,14 +3542,26 @@ module Clacky
           broadcast(session_id, { type: "session_renamed", session_id: session_id, name: auto_name })
         end
 
-        # Broadcast user message through web_ui so channel subscribers (飞书/企微) receive it.
-        web_ui = nil
-        @registry.with_session(session_id) { |s| web_ui = s[:ui] }
-        web_ui&.show_user_message(content, source: :web)
+        # The frontend always renders a ghost bubble on send. The real
+        # bubble is rendered by the agent when it drains the inbox —
+        # this avoids duplicate bubbles for idle agents.
 
-        # File references are now handled inside agent.run — injected as a system_injected
-        # message after the user message, so replay_history skips them automatically.
-        run_agent_task(session_id, agent) { agent.run(content, files: files) }
+        # Enqueue — files (if any) are processed eagerly on this HTTP thread
+        # inside enqueue_user_message, so the inbox carries a fully-formed
+        # payload by the time it lands. The agent decides whether to drain
+        # in an in-flight run or spawn a fresh drain-only one.
+        decision = agent.enqueue_user_message(content, files: files)
+        case decision
+        when :running, :spawn_pending
+          # Existing or imminent run will drain the inbox at its next
+          # iteration. Nothing more to do here.
+          return
+        when :spawn
+          # Agent was idle and we won the right to spawn. Kick off a
+          # drain-only run; it will pick up our queued message (and any
+          # other items queued concurrently) at iteration top.
+          run_agent_task(session_id, agent) { agent.run }
+        end
       end
 
       def deliver_confirmation(session_id, conf_id, result)
@@ -3580,19 +3595,25 @@ module Clacky
       # fire — that's our signal to dig deeper on the underlying block.
       def interrupt_session(session_id)
         thread = nil
+        agent  = nil
         @registry.with_session(session_id) do |s|
           s[:idle_timer]&.cancel
           thread = s[:thread]
+          agent  = s[:agent]
 
-          next unless thread&.alive?
-
-          Clacky::Logger.info("[interrupt] session=#{session_id} tier=1 raise")
-          begin
-            thread.raise(Clacky::AgentInterrupted, "Interrupted by user")
-          rescue ThreadError => e
-            Clacky::Logger.warn("[interrupt] tier=1 raise failed: #{e.message}")
+          if thread&.alive?
+            Clacky::Logger.info("[interrupt] session=#{session_id} tier=1 raise")
+            begin
+              thread.raise(Clacky::AgentInterrupted, "Interrupted by user")
+            rescue ThreadError => e
+              Clacky::Logger.warn("[interrupt] tier=1 raise failed: #{e.message}")
+            end
           end
         end
+
+        # Also set @discard_threshold + raise into Agent's tracked run thread.
+        # This covers drain-only inbox runs that may bypass session[:thread].
+        agent&.interrupt_current_run!
 
         return unless thread&.alive?
 
@@ -3722,10 +3743,18 @@ module Clacky
         broadcast_session_update(session_id)
 
         thread = Thread.new do
-          task.call
+          result = task.call
           @registry.update(session_id, status: :idle, error: nil)
           broadcast_session_update(session_id)
           @session_manager.save(agent.to_session_data(status: :success))
+
+          # If the agent run left user messages in the inbox, spawn a
+          # registered drain-only run so they are processed under the same
+          # interrupt / idle-timer lifecycle as any other task.
+          if result.is_a?(Clacky::RunResult) && result.inbox_needs_follow_up
+            run_agent_task(session_id, agent) { agent.run }
+          end
+
           # Start idle compression timer now that the agent is idle
           idle_timer&.start
         rescue Clacky::AgentInterrupted

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3767,7 +3767,7 @@ module Clacky
           # If the agent run left user messages in the inbox, spawn a
           # registered drain-only run so they are processed under the same
           # interrupt / idle-timer lifecycle as any other task.
-          if result.is_a?(Clacky::RunResult) && result.inbox_needs_follow_up
+          if agent.inbox_user_message_count > 0
             run_agent_task(session_id, agent) { agent.run }
           end
 

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3533,22 +3533,6 @@ module Clacky
         @registry.with_session(session_id) { |s| agent = s[:agent] }
         return unless agent
 
-        # If session is running, interrupt it first (mimics CLI behavior)
-        session = @registry.get(session_id)
-        if session[:status] == :running
-          interrupt_session(session_id)
-
-          # Give the old thread a short window to exit cleanly.
-          # In the common case it returns within milliseconds (Thread#raise
-          # lands on a tight loop or LLM read). If it can't be reached in
-          # time (e.g. blocked in a slow subagent syscall), we proceed anyway:
-          # the agent's check_stale! checkpoints will refuse to mutate
-          # history once the new thread takes over.
-          old_thread = nil
-          @registry.with_session(session_id) { |s| old_thread = s[:thread] }
-          old_thread&.join(2)
-        end
-
         # Auto-name the session from the first user message (before agent starts running).
         # Skip if the name looks like it was set by the user (not a system-generated "Session N").
         if agent.history.empty? && agent.name.match?(/\ASession \d+\z/)

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -344,6 +344,10 @@ module Clacky
         forward_to_subscribers { |sub| sub.set_idle_status }
       end
 
+      def update_user_message_queue_status(pending: 0)
+        emit("user_message_queue_status", pending: pending.to_i)
+      end
+
       # === Blocking interaction ===
       # Emits a request_confirmation event and blocks until the browser responds.
       # Timeout after 5 minutes to avoid hanging threads forever.

--- a/lib/clacky/ui_interface.rb
+++ b/lib/clacky/ui_interface.rb
@@ -125,6 +125,16 @@ module Clacky
     def set_working_status; end
     def set_idle_status; end
 
+    # Broadcast the count of user messages currently sitting in @inbox waiting
+    # for the next iteration-boundary drain. Web renders a small "{{n}} messages
+    # waiting" hint above the input. Emitted by Agent on two occasions:
+    #   - enqueue_user_message returned :running (msg will wait behind an in-flight run)
+    #   - drain_inbox_into_history! consumed items (count typically drops to 0)
+    # CLI / JSON / channel UIs no-op by default.
+    #
+    # @param pending [Integer] number of user_msg items still queued
+    def update_user_message_queue_status(pending: 0); end
+
     # === Blocking interaction ===
     def request_confirmation(message, default: true); end
 

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -1666,6 +1666,26 @@ body {
 [data-theme="dark"] .msg-user { background: var(--color-accent-hover); }
 .msg-assistant { background: var(--color-bg-tertiary); border: 1px solid var(--color-border-primary); align-self: flex-start; }
 
+/* Pending user message — ghost state shown while agent is busy */
+.msg-pending {
+  opacity: 0.55;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+.msg-pending-spinner {
+  display: inline-block;
+  width: 12px; height: 12px;
+  margin-left: 8px;
+  border: 2px solid var(--color-button-primary-text);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: pending-spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+@keyframes pending-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* ── Copy button on assistant messages ────────────────────────────────────
    Hidden by default, revealed on bubble hover (same pattern as .msg-time).
    On touch devices (hover: none) we keep the button visible at low opacity
@@ -3001,6 +3021,28 @@ body {
 }
 
 /* ── Input bar ───────────────────────────────────────────────────────────── */
+
+/* "N messages waiting" hint shown above input bar while agent is running.
+   Rendered on demand (inbox); hidden when count hits zero. */
+.input-queue-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 6px 0;
+  padding: 6px 12px;
+  background: var(--color-bg-secondary, rgba(120, 120, 120, 0.06));
+  border-left: 3px solid #f59e0b;
+  border-radius: 4px;
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  user-select: none;
+}
+.input-queue-hint::before {
+  content: "⏳";
+  font-size: 13px;
+  opacity: 0.8;
+}
+
 #input-bar {
   margin-top: auto;
   margin-bottom: auto;

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -37,6 +37,9 @@ const I18n = (() => {
       "chat.status.idle":    "idle",
       "chat.status.running": "running",
       "chat.status.error":   "error",
+      // ── Inbox queue hint (above the input bar) ──
+      "inbox.queue.one":   "1 message waiting — the agent will read it next.",
+      "inbox.queue.many":  "{{n}} messages waiting — the agent will read them next.",
       "chat.input.placeholder": "Message… (Enter to send, Shift+Enter for newline)",
       "chat.input.placeholderRunning": "AI is working — you can still send extra info anytime...",
       "chat.input.placeholderMobile": "Message…",
@@ -619,6 +622,9 @@ const I18n = (() => {
       "chat.status.idle":    "空闲",
       "chat.status.running": "运行中",
       "chat.status.error":   "出错",
+      // ── Inbox queue hint (above the input bar) ──
+      "inbox.queue.one":   "1 条消息排队中 — agent 处理完手头的事会马上看。",
+      "inbox.queue.many":  "{{n}} 条消息排队中 — agent 处理完手头的事会马上看。",
       "chat.input.placeholder": "输入消息…（Enter 发送，Shift+Enter 换行）",
       "chat.input.placeholderRunning": "AI 正在工作，你仍然可以随时补充新信息给它...",
       "chat.input.placeholderMobile": "输入消息…",

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -367,6 +367,10 @@
         </div>
         <!-- Image preview strip (hidden when empty) -->
         <div id="image-preview-strip" style="display:none"></div>
+        <!-- "N messages waiting" hint — only visible when the agent has
+             pending user messages it'll drain at the next iteration boundary -->
+        <div id="input-queue-hint" class="input-queue-hint" style="display:none"
+             role="status" aria-live="polite"></div>
         <div id="input-bar">
           <!-- Hidden file picker -->
           <input type="file" id="image-file-input" accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,application/zip,application/x-zip-compressed,application/gzip,application/x-gzip,application/x-tar,application/x-compressed-tar,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-powerpoint,text/csv,application/csv,text/markdown,text/plain,.csv,.md,.markdown,.txt,.log,.tar,.gz,.tgz,.tar.gz" multiple style="display:none">

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -779,7 +779,19 @@ const Sessions = (() => {
       }).join(" ");
       bubbleHtml = badges + (bubbleHtml ? "<br>" + bubbleHtml : "");
     }
-    Sessions.appendMsg("user", bubbleHtml, { time: new Date() });
+
+    // Always render a ghost bubble first. The real bubble replaces it
+    // when the agent drains the inbox and the server emits
+    // history_user_message — this avoids duplicate bubbles for idle agents.
+    const container = $("messages");
+    if (container) {
+      const el = document.createElement("div");
+      el.className = "msg msg-user msg-pending";
+      const spinner = `<span class="msg-pending-spinner"></span>`;
+      el.innerHTML = bubbleHtml + spinner;
+      container.appendChild(el);
+      container.scrollTop = container.scrollHeight;
+    }
 
     // Merge images and files into unified files array for WS payload.
     const files = [
@@ -1132,6 +1144,9 @@ const Sessions = (() => {
       case "history_user_message": {
         // Collapse any open tool group from the previous round
         if (historyCtx.group) { _collapseToolGroup(historyCtx.group); historyCtx.group = null; }
+        // Remove any pending (ghost) user bubbles — the real bubble from
+        // the server replaces them, keeping the timeline clean.
+        container.querySelectorAll(".msg-pending").forEach(el => el.remove());
         const el = document.createElement("div");
         el.className = "msg msg-user";
         // Render image thumbnails and PDF badges (if any) followed by the text content
@@ -1995,6 +2010,10 @@ const Sessions = (() => {
     /** Set _activeId directly (called by Router when activating a session). */
     _setActiveId(id) {
       _activeId = id;
+      // Inbox-queue hint is per-session; clear stale display until the new
+      // session's first user_message_queue_status arrives (or doesn't, in
+      // which case the hint stays hidden — correct).
+      Sessions.setInputQueueHint(0);
     },
 
     /** Restore cached messages for a session into the #messages container. */
@@ -2724,6 +2743,25 @@ const Sessions = (() => {
         messages.appendChild(sub);
       }
       _scrollToBottomIfNeeded(messages);
+    },
+
+    /**
+     * Show / hide the "{{n}} messages waiting" hint above the input bar.
+     * pending === 0 hides the element; pending > 0 shows it with the count.
+     * Called from the WS dispatcher when "user_message_queue_status" arrives.
+     */
+    setInputQueueHint(pending) {
+      const hint = document.getElementById("input-queue-hint");
+      if (!hint) return;
+      const n = Number(pending) || 0;
+      if (n <= 0) {
+        hint.style.display = "none";
+        hint.textContent = "";
+        return;
+      }
+      const key = n === 1 ? "inbox.queue.one" : "inbox.queue.many";
+      hint.textContent = I18n.t(key, { n: n });
+      hint.style.display = "";
     },
 
     // Display a request_user_feedback UI card with optional clickable option buttons.

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -2764,6 +2764,59 @@ const Sessions = (() => {
       hint.style.display = "";
     },
 
+    /**
+     * Render pending inbox messages as ghost bubbles with spinners.
+     * Called from ws-dispatcher on "pending_user_messages" (WebSocket
+     * subscribe replay). Each ghost is a .msg-pending div that the
+     * history_user_message handler will replace when the agent drains it.
+     */
+    renderPendingMessages(messages) {
+      const container = $("messages");
+      if (!container) return;
+      if (!Array.isArray(messages) || messages.length === 0) return;
+
+      messages.forEach(msg => {
+        const el = document.createElement("div");
+        el.className = "msg msg-user msg-pending";
+
+        let bubbleHtml = msg.content ? escapeHtml(msg.content) : "";
+        const files = msg.files || [];
+
+        // Image thumbnails (files with data_url)
+        const imageFiles = files.filter(f => f.data_url);
+        if (imageFiles.length > 0) {
+          const thumbs = imageFiles.map(f =>
+            `<img src="${f.data_url}" alt="${escapeHtml(f.name || '')}" class="msg-image-thumb">`
+          ).join("");
+          bubbleHtml = thumbs + (bubbleHtml ? "<br>" + bubbleHtml : "");
+        }
+
+        // File badges (files without data_url)
+        const otherFiles = files.filter(f => !f.data_url);
+        if (otherFiles.length > 0) {
+          const badges = otherFiles.map(f => {
+            const icon = _docTypeIcon(f.mime_type, f.name);
+            const ext = (f.name || "").split(".").pop() || "file";
+            const displayExt = ext.toUpperCase();
+            return `<span class="msg-pdf-badge">` +
+              `<span class="msg-pdf-badge-icon">${icon}</span>` +
+              `<span class="msg-pdf-badge-info">` +
+                `<span class="msg-pdf-badge-name">${escapeHtml(f.name)}</span>` +
+                `<span class="msg-pdf-badge-type">${escapeHtml(displayExt)}</span>` +
+              `</span>` +
+            `</span>`;
+          }).join(" ");
+          bubbleHtml = badges + (bubbleHtml ? "<br>" + bubbleHtml : "");
+        }
+
+        const spinner = `<span class="msg-pending-spinner"></span>`;
+        el.innerHTML = bubbleHtml + spinner;
+        container.appendChild(el);
+      });
+
+      container.scrollTop = container.scrollHeight;
+    },
+
     // Display a request_user_feedback UI card with optional clickable option buttons.
     // Called when the agent needs user input to continue.
     showFeedbackRequest(question, context, options) {

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -147,8 +147,56 @@ WS.onEvent(ev => {
 
     // ── Chat messages ──────────────────────────────────────────────────
     case "history_user_message":
-      // Emitted only during history replay — never from live WS.
-      // Rendered by Sessions._fetchHistory; nothing to do here.
+      // During history replay, HistoryCollector sends events via HTTP — they
+      // never hit the WS dispatcher. Events arriving here are always live
+      // (agent just drained a queued message from the inbox). Remove the
+      // ghost bubble and render the real user message.
+      // Only remove the first pending ghost — subsequent ghosts belong
+      // to other queued messages that haven't been drained yet.
+      if (ev.session_id !== Sessions.activeId) break;
+      const firstGhost = document.querySelector(".msg-pending");
+      if (firstGhost) firstGhost.remove();
+      let userHtml = "";
+      if (Array.isArray(ev.images) && ev.images.length > 0) {
+        userHtml += ev.images.map(src => {
+          if (typeof src !== "string" || !src) return "";
+          if (src.startsWith("pdf:")) {
+            const fname = src.slice(4);
+            const lower = fname.toLowerCase();
+            const ext = (fname.split(".").pop() || "file").toUpperCase();
+            const displayExt = lower.endsWith(".tar.gz") ? "TAR.GZ" : ext;
+            const icon = ext === "PDF" ? "📄" :
+              (ext === "ZIP" || ext === "GZ" || ext === "TGZ" || ext === "TAR" ||
+               ext === "RAR" || ext === "7Z" || lower.endsWith(".tar.gz")) ? "🗜️" :
+              (ext === "DOC" || ext === "DOCX") ? "📝" :
+              (ext === "XLS" || ext === "XLSX" || ext === "CSV") ? "📊" :
+              (ext === "PPT" || ext === "PPTX") ? "📋" :
+              (ext === "MD" || ext === "MARKDOWN") ? "📝" :
+              (ext === "TXT" || ext === "LOG") ? "📄" : "📎";
+            return `<span class="msg-pdf-badge">` +
+              `<span class="msg-pdf-badge-icon">${icon}</span>` +
+              `<span class="msg-pdf-badge-info">` +
+                `<span class="msg-pdf-badge-name">${escapeHtml(fname)}</span>` +
+                `<span class="msg-pdf-badge-type">${escapeHtml(displayExt)}</span>` +
+              `</span>` +
+            `</span>`;
+          }
+          if (src.startsWith("expired:")) {
+            const fname = src.slice(8);
+            return `<span class="msg-pdf-badge msg-image-expired">` +
+              `<span class="msg-pdf-badge-icon">🖼️</span>` +
+              `<span class="msg-pdf-badge-info">` +
+                `<span class="msg-pdf-badge-name">${escapeHtml(fname || "image")}</span>` +
+                `<span class="msg-pdf-badge-type">${I18n.t("chat.image_expired") || "Expired"}</span>` +
+              `</span>` +
+            `</span>`;
+          }
+          return `<img src="${escapeHtml(src)}" alt="image" class="msg-image-thumb">`;
+        }).join("");
+        if (ev.content) userHtml += "<br>";
+      }
+      userHtml += escapeHtml(ev.content || "");
+      Sessions.appendMsg("user", userHtml, { time: ev.created_at });
       break;
 
     case "assistant_message":
@@ -248,6 +296,14 @@ WS.onEvent(ev => {
     // ── Info / errors ──────────────────────────────────────────────────
     case "info":
       Sessions.appendInfo(ev.message);
+      break;
+
+    case "user_message_queue_status":
+      // Agent broadcast: N user messages are sitting in the inbox waiting
+      // to be drained at the next iteration boundary. Show/hide the
+      // "{{n}} messages waiting" hint above the input bar.
+      if (ev.session_id !== Sessions.activeId) break;
+      Sessions.setInputQueueHint(ev.pending || 0);
       break;
 
     case "warning":

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -199,6 +199,15 @@ WS.onEvent(ev => {
       Sessions.appendMsg("user", userHtml, { time: ev.created_at });
       break;
 
+    case "pending_user_messages":
+      // Replayed on WebSocket (re)subscribe — messages still in the
+      // inbox queue. Render them as pending ghost bubbles that the
+      // regular history_user_message handler will replace when the
+      // agent drains each one.
+      if (ev.session_id !== Sessions.activeId) break;
+      Sessions.renderPendingMessages(ev.messages || []);
+      break;
+
     case "assistant_message":
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.clearProgress();

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Clacky::Agent do
     it "executes Think-Act-Observe loop" do
       result = agent.run("Calculate 1+1")
 
-      expect(result.status).to eq(:success)
-      expect(result.iterations).to be > 0
+      expect(result[:status]).to eq(:success)
+      expect(result[:iterations]).to be > 0
       expect(client).to have_received(:send_messages_with_tools).at_least(:once)
     end
 
@@ -81,19 +81,18 @@ RSpec.describe Clacky::Agent do
       expect(agent.total_cost).to be > 0
     end
 
-    it "returns a RunResult with inbox_needs_follow_up false when no pending messages" do
+    it "returns a Hash with success status when no pending messages" do
       allow(client).to receive(:send_messages_with_tools)
         .and_return(mock_api_response(content: "done"))
 
       result = agent.run("test")
-      expect(result).to be_a(Clacky::RunResult)
-      expect(result.status).to eq(:success)
-      expect(result.inbox_needs_follow_up).to be false
+      expect(result).to be_a(Hash)
+      expect(result[:status]).to eq(:success)
     end
 
-    it "returns a RunResult with inbox_needs_follow_up false when inbox was drained during run" do
+    it "returns a Hash with success status when inbox was drained during run" do
       # Enqueueing during a run triggers a next iteration that drains + processes it.
-      # When the LLM responds "done" after that, inbox_needs_follow_up should be false
+      # When the LLM responds "done" after that, the result should be success
       # because the follow-up was fully consumed.
       call_count = 0
       allow(client).to receive(:send_messages_with_tools) do
@@ -105,8 +104,7 @@ RSpec.describe Clacky::Agent do
       end
 
       result = agent.run("test")
-      expect(result.status).to eq(:success)
-      expect(result.inbox_needs_follow_up).to be false
+      expect(result[:status]).to eq(:success)
     end
   end
 
@@ -197,7 +195,7 @@ RSpec.describe Clacky::Agent do
         .and_return(mock_api_response(content: "done"))
 
       result = agent.run("test")
-      expect(result.status).to eq(:success)
+      expect(result[:status]).to eq(:success)
 
       # Both messages survived the exception and were processed on retry
       history = agent.history.to_a
@@ -975,7 +973,7 @@ RSpec.describe Clacky::Agent do
       result = agent.run("Create a very complex document")
 
       # Should have given up and returned a helpful message
-      expect(result.status).to eq(:success)
+      expect(result[:status]).to eq(:success)
       
       # Find the assistant message that gave up
       assistant_messages = agent.history.to_a.select { |m| 
@@ -1059,7 +1057,7 @@ RSpec.describe Clacky::Agent do
 
       result = agent.run("keep going")
 
-      expect(result.status).to eq(:success)
+      expect(result[:status]).to eq(:success)
       # Exactly two attempts: the original failing one + the padded retry.
       expect(call_count).to eq(2)
 

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -209,6 +209,72 @@ RSpec.describe Clacky::Agent do
     end
   end
 
+  describe "#inbox_user_message_count" do
+    it "returns 0 when inbox is empty" do
+      expect(agent.inbox_user_message_count).to eq(0)
+    end
+
+    it "returns count of queued :user_msg items" do
+      agent.enqueue_user_message("first")
+      agent.enqueue_user_message("second")
+      expect(agent.inbox_user_message_count).to eq(2)
+    end
+
+    it "returns 0 after inbox is drained" do
+      agent.enqueue_user_message("hello")
+      expect(agent.inbox_user_message_count).to eq(1)
+
+      allow(client).to receive(:send_messages_with_tools)
+        .and_return(mock_api_response(content: "done"))
+      agent.run("test")
+      expect(agent.inbox_user_message_count).to eq(0)
+    end
+
+    it "is thread-safe under concurrent enqueues" do
+      threads = 10.times.map do |i|
+        Thread.new { agent.enqueue_user_message("msg #{i}") }
+      end
+      threads.each(&:join)
+      expect(agent.inbox_user_message_count).to eq(10)
+    end
+  end
+
+  describe "#inbox_user_messages_snapshot" do
+    it "returns empty array when inbox is empty" do
+      expect(agent.inbox_user_messages_snapshot).to eq([])
+    end
+
+    it "returns queued :user_msg items with content and files" do
+      agent.enqueue_user_message("hello")
+      agent.enqueue_user_message("world")
+      snap = agent.inbox_user_messages_snapshot
+      expect(snap.size).to eq(2)
+      expect(snap[0][:content]).to eq("hello")
+      expect(snap[0][:files]).to eq([])
+      expect(snap[0][:created_at]).to be_a(Float)
+      expect(snap[1][:content]).to eq("world")
+    end
+
+    it "excludes non-user_msg items" do
+      agent.enqueue_user_message("hi")
+      # Inject a non-user_msg item directly (internal queue manipulation)
+      agent.instance_variable_get(:@state_mutex).synchronize do
+        agent.instance_variable_get(:@inbox) << { kind: :other }
+      end
+      snap = agent.inbox_user_messages_snapshot
+      expect(snap.size).to eq(1)
+      expect(snap[0][:content]).to eq("hi")
+    end
+
+    it "is thread-safe" do
+      5.times.map { |i|
+        Thread.new { agent.enqueue_user_message("msg #{i}") }
+      }.each(&:join)
+      snap = agent.inbox_user_messages_snapshot
+      expect(snap.size).to eq(5)
+    end
+  end
+
   describe "#add_hook" do
     it "allows adding hooks" do
       hook_called = false

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Clacky::Agent do
     it "executes Think-Act-Observe loop" do
       result = agent.run("Calculate 1+1")
 
-      expect(result[:status]).to eq(:success)
-      expect(result[:iterations]).to be > 0
+      expect(result.status).to eq(:success)
+      expect(result.iterations).to be > 0
       expect(client).to have_received(:send_messages_with_tools).at_least(:once)
     end
 
@@ -81,7 +81,132 @@ RSpec.describe Clacky::Agent do
       expect(agent.total_cost).to be > 0
     end
 
+    it "returns a RunResult with inbox_needs_follow_up false when no pending messages" do
+      allow(client).to receive(:send_messages_with_tools)
+        .and_return(mock_api_response(content: "done"))
 
+      result = agent.run("test")
+      expect(result).to be_a(Clacky::RunResult)
+      expect(result.status).to eq(:success)
+      expect(result.inbox_needs_follow_up).to be false
+    end
+
+    it "returns a RunResult with inbox_needs_follow_up false when inbox was drained during run" do
+      # Enqueueing during a run triggers a next iteration that drains + processes it.
+      # When the LLM responds "done" after that, inbox_needs_follow_up should be false
+      # because the follow-up was fully consumed.
+      call_count = 0
+      allow(client).to receive(:send_messages_with_tools) do
+        call_count += 1
+        if call_count == 1
+          agent.enqueue_user_message("follow up")
+        end
+        mock_api_response(content: "done")
+      end
+
+      result = agent.run("test")
+      expect(result.status).to eq(:success)
+      expect(result.inbox_needs_follow_up).to be false
+    end
+  end
+
+  describe "#enqueue_user_message" do
+    before do
+      allow(client).to receive(:send_messages_with_tools)
+        .and_return(mock_api_response(content: "done"))
+    end
+
+    it "adds message to inbox and returns :spawn when agent is idle" do
+      result = agent.enqueue_user_message("hello")
+      expect(result).to eq(:spawn)
+      inbox = agent.instance_variable_get(:@inbox)
+      expect(inbox.size).to eq(1)
+      expect(inbox.first[:content]).to eq("hello")
+    end
+
+    it "returns :running when agent is in run loop" do
+      # Use a mutex/condition variable to synchronize with the running thread
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+      in_run_loop = false
+
+      allow(client).to receive(:send_messages_with_tools) do
+        mutex.synchronize do
+          in_run_loop = true
+          cv.broadcast
+        end
+        # Block until test signals us to continue
+        mutex.synchronize do
+          cv.wait(mutex, 5) unless in_run_loop == :continue
+        end
+        mock_api_response(content: "done")
+      end
+
+      thread = Thread.new { agent.run("block") }
+
+      # Wait for run to enter the loop
+      mutex.synchronize do
+        cv.wait(mutex, 5) until in_run_loop
+      end
+
+      result = agent.enqueue_user_message("queued")
+      expect(result).to eq(:running)
+
+      # Signal the run thread to continue
+      mutex.synchronize do
+        in_run_loop = :continue
+        cv.broadcast
+      end
+      thread.join(5)
+    end
+
+    it "returns :spawn_pending when another enqueue already triggered spawn" do
+      agent.enqueue_user_message("first")
+      result = agent.enqueue_user_message("second")
+      expect(result).to eq(:spawn_pending)
+    end
+
+    it "drains inbox into history during run" do
+      agent.enqueue_user_message("queued message")
+      result = agent.run("direct message")
+
+      history = agent.history.to_a
+      user_msgs = history.select { |m| m[:role] == "user" }
+      contents = user_msgs.map { |m| m[:content] }
+
+      expect(contents).to include("queued message")
+      expect(contents).to include("direct message")
+      expect(agent.instance_variable_get(:@inbox)).to be_empty
+    end
+
+    it "recovers inbox items when drain_inbox_into_history! raises" do
+      agent.enqueue_user_message("msg1")
+      agent.enqueue_user_message("msg2")
+
+      # Force an error during drain by making @ui.show_user_message raise on first call
+      call_count = 0
+      allow(agent).to receive(:broadcast_user_message_queue_status)
+      bad_ui = double("ui").as_null_object
+      allow(bad_ui).to receive(:show_user_message) do
+        call_count += 1
+        raise "boom" if call_count == 1
+      end
+      agent.instance_variable_set(:@ui, bad_ui)
+
+      allow(client).to receive(:send_messages_with_tools)
+        .and_return(mock_api_response(content: "done"))
+
+      result = agent.run("test")
+      expect(result.status).to eq(:success)
+
+      # Both messages survived the exception and were processed on retry
+      history = agent.history.to_a
+      user_msgs = history.select { |m| m[:role] == "user" }
+      contents = user_msgs.map { |m| m[:content] }
+      expect(contents).to include("msg1")
+      expect(contents).to include("msg2")
+      expect(agent.instance_variable_get(:@inbox)).to be_empty
+    end
   end
 
   describe "#add_hook" do
@@ -784,7 +909,7 @@ RSpec.describe Clacky::Agent do
       result = agent.run("Create a very complex document")
 
       # Should have given up and returned a helpful message
-      expect(result[:status]).to eq(:success)
+      expect(result.status).to eq(:success)
       
       # Find the assistant message that gave up
       assistant_messages = agent.history.to_a.select { |m| 
@@ -868,7 +993,7 @@ RSpec.describe Clacky::Agent do
 
       result = agent.run("keep going")
 
-      expect(result[:status]).to eq(:success)
+      expect(result.status).to eq(:success)
       # Exactly two attempts: the original failing one + the padded retry.
       expect(call_count).to eq(2)
 

--- a/spec/clacky/server/http_server_spec.rb
+++ b/spec/clacky/server/http_server_spec.rb
@@ -981,6 +981,159 @@ RSpec.describe Clacky::Server::HttpServer do
     end
   end
 
+  # ── WebSocket subscribe replay ───────────────────────────────────────────
+  #
+  # When a tab reconnects, the subscribe handler must re-push inbox queue
+  # status so the frontend can render the spinner + pending count. Without
+  # this, a page refresh clears the inbox UI even though messages are queued.
+
+  describe "WebSocket subscribe replays inbox state" do
+    let(:sessions_dir) { Dir.mktmpdir("clacky_ws_sub_spec") }
+
+    after { FileUtils.rm_rf(sessions_dir) }
+
+    it "pushes user_message_queue_status AND pending_user_messages for inbox messages" do
+      server = described_class.new(
+        agent_config:   agent_config,
+        client_factory: -> { double("client") },
+        sessions_dir:   sessions_dir
+      )
+      registry = server.instance_variable_get(:@registry)
+
+      session_id = "ws-test-session"
+      registry.create(session_id: session_id)
+
+      # Build a mock agent with queued inbox messages.
+      inbox_snapshot = [
+        { content: "msg1", files: [], created_at: 1001.0 },
+        { content: "msg2", files: [{ name: "a.png", data_url: "data:img", mime_type: "image/png" }], created_at: 1002.0 }
+      ]
+      mock_agent = double("Agent")
+      allow(mock_agent).to receive(:inbox_user_message_count).and_return(2)
+      allow(mock_agent).to receive(:inbox_user_messages_snapshot).and_return(inbox_snapshot)
+
+      # Mock UI that captures sent queue status updates.
+      captured_status = nil
+      mock_ui = double("UI")
+      allow(mock_ui).to receive(:replay_live_state)
+      allow(mock_ui).to receive(:update_user_message_queue_status) { |pending:|
+        captured_status = pending
+      }
+
+      registry.with_session(session_id) do |s|
+        s[:agent]  = mock_agent
+        s[:ui]     = mock_ui
+        s[:status] = :running
+      end
+
+      # Mock WebSocket connection.
+      sent = []
+      mock_conn = double("WebSocketConnection")
+      allow(mock_conn).to receive(:session_id=)
+      allow(mock_conn).to receive(:send_json) { |data| sent << data }
+
+      # Simulate a WebSocket subscribe message.
+      subscribe_msg = { type: "subscribe", session_id: session_id }
+      server.send(:on_ws_message, mock_conn, subscribe_msg.to_json)
+
+      # Should receive the standard subscribed event.
+      expect(sent.map { |m| m[:type] }).to include("subscribed")
+
+      # UI got the count update.
+      expect(captured_status).to eq(2)
+
+      # A single pending_user_messages event carries the full snapshot.
+      pending_ev = sent.find { |m| m[:type] == "pending_user_messages" }
+      expect(pending_ev).not_to be_nil
+      expect(pending_ev[:messages].size).to eq(2)
+      expect(pending_ev[:messages][0][:content]).to eq("msg1")
+      expect(pending_ev[:messages][1][:content]).to eq("msg2")
+    end
+
+    it "does NOT push user_message_queue_status when inbox is empty" do
+      server = described_class.new(
+        agent_config:   agent_config,
+        client_factory: -> { double("client") },
+        sessions_dir:   sessions_dir
+      )
+      registry = server.instance_variable_get(:@registry)
+
+      session_id = "ws-empty-inbox"
+      registry.create(session_id: session_id)
+
+      mock_agent = double("Agent")
+      allow(mock_agent).to receive(:inbox_user_message_count).and_return(0)
+
+      mock_ui = double("UI")
+      allow(mock_ui).to receive(:replay_live_state)
+      allow(mock_ui).to receive(:update_user_message_queue_status)
+
+      registry.with_session(session_id) do |s|
+        s[:agent] = mock_agent
+        s[:ui]    = mock_ui
+        s[:status] = :running
+      end
+
+      sent = []
+      mock_conn = double("WebSocketConnection")
+      allow(mock_conn).to receive(:session_id=)
+      allow(mock_conn).to receive(:send_json)
+
+      subscribe_msg = { type: "subscribe", session_id: session_id }
+      server.send(:on_ws_message, mock_conn, subscribe_msg.to_json)
+
+      expect(mock_ui).not_to have_received(:update_user_message_queue_status)
+    end
+  end
+
+  describe "interrupt re-broadcasts inbox queue status" do
+    let(:sessions_dir) { Dir.mktmpdir("clacky_interrupt_inbox_spec") }
+
+    after { FileUtils.rm_rf(sessions_dir) }
+
+    it "re-broadcasts user_message_queue_status with current pending count after AgentInterrupted" do
+      server = described_class.new(
+        agent_config:   agent_config,
+        client_factory: -> { double("client") },
+        sessions_dir:   sessions_dir
+      )
+      registry = server.instance_variable_get(:@registry)
+
+      session_id = "interrupt-inbox-test"
+      registry.create(session_id: session_id)
+
+      # Agent that raises AgentInterrupted when run() is called,
+      # simulating a user interrupt mid-run.
+      pending_calls = [2, 0]  # 2 on first check, 0 on recursive check (stops loop)
+      mock_agent = double("Agent")
+      allow(mock_agent).to receive(:run).and_raise(Clacky::AgentInterrupted, "Interrupted")
+      allow(mock_agent).to receive(:inbox_user_message_count) { pending_calls.shift || 0 }
+      allow(mock_agent).to receive(:to_session_data).and_return({})
+
+      captured_queue_status = nil
+      mock_ui = double("UI")
+      allow(mock_ui).to receive(:update_user_message_queue_status) { |pending:|
+        captured_queue_status = pending
+      }
+      allow(mock_ui).to receive(:replay_live_state)
+
+      registry.with_session(session_id) do |s|
+        s[:agent]  = mock_agent
+        s[:ui]     = mock_ui
+        s[:thread] = Thread.new { sleep 1 } # To pass alive? check
+      end
+
+      # Trigger a run that will be interrupted.
+      server.send(:run_agent_task, session_id, mock_agent) { mock_agent.run }
+
+      # Wait for the rescue block to execute.
+      sleep 0.2
+
+      # The rescue block should have re-broadcast the current inbox count.
+      expect(captured_queue_status).to eq(2)
+    end
+  end
+
   # ── interrupt_all_agents (private) ───────────────────────────────────────
   #
   # Worker shutdown path. The `:interrupted` rescue branch in run_agent_task


### PR DESCRIPTION
## What

This PR introduces an "agent inbox" — a message queuing system that allows users to send messages while an agent is running without interrupting the current task. Instead of the fragile `interrupt_session` + `sleep 0.1` pattern, incoming messages are queued in an inbox, picked up between iterations, and drained into the agent's history before the next response starts.

## Why

Previously, sending a message while the agent was running required forcefully interrupting the session and racing to inject the message — the old `interrupt_session` + `sleep 0.1` pattern was fragile and caused unpredictable behavior. This made conversational workflows awkward: users could not naturally queue follow-up messages while the agent continued its current work.

## User-visible impact

- **New behavior:** messages sent during an active agent run are queued instead of interrupting the session
- After the agent finishes its current response, queued messages are drained into history before the next iteration
- A `RunResult#inbox_needs_follow_up` flag lets the HTTP server know when to spawn a follow-up run
- No breaking changes; existing single-message workflows are unaffected

## WebSocket reconnect & state recovery

- On reconnect, the `subscribe` handler replays inbox queue status (`user_message_queue_status`) and pending message content via a dedicated `pending_user_messages` event
- Pending messages render as **ghost bubbles with spinners** (`.msg-pending`), not as regular user messages — the `history_user_message` handler replaces each ghost when the agent drains it
- After an interrupt, inbox count is re-broadcast so the frontend stays in sync

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [x] Smallest possible diff for the need
- [x] No new configuration knobs (or justified below)
- [x] No new dependencies (or justified below)
- [x] Fits the existing design / naming / layering

### 2. Need

- [x] Common need that benefits most users, **or** scope and side effects are explained below
- [x] No unintended impact on other users' workflows or defaults
