### PR TITLE
fix(anthropic): extract thinking blocks as reasoning_content

### DIFF
--- a/lib/clacky/anthropic_stream_aggregator.rb
+++ b/lib/clacky/anthropic_stream_aggregator.rb
@@ -89,6 +89,8 @@ module Clacky
               JSON.parse(b[:input_str]) rescue b[:input_str]
             end
           { "type" => "tool_use", "id" => b[:id], "name" => b[:name], "input" => input_value }
+        when :thinking
+          { "type" => "thinking", "thinking" => b[:thinking].to_s }
         else
           { "type" => "text", "text" => b[:text].to_s }
         end

--- a/lib/clacky/message_format/anthropic.rb
+++ b/lib/clacky/message_format/anthropic.rb
@@ -90,6 +90,8 @@ module Clacky
 
         content = blocks.select { |b| b["type"] == "text" }.map { |b| b["text"] }.join("")
 
+        reasoning_content = blocks.select { |b| b["type"] == "thinking" }.map { |b| b["thinking"] }.join("")
+
         # tool_calls use canonical format (id, function: {name, arguments})
         tool_calls = blocks.select { |b| b["type"] == "tool_use" }.map do |tc|
           args = tc["input"].is_a?(String) ? tc["input"] : tc["input"].to_json
@@ -151,8 +153,12 @@ module Clacky
         usage_data[:cache_read_input_tokens]     = cache_read     if cache_read     > 0
         usage_data[:cache_creation_input_tokens] = cache_creation if cache_creation > 0
 
-        { content: content, tool_calls: tool_calls, finish_reason: finish_reason,
-          usage: usage_data, raw_api_usage: usage }
+        result = {
+          content: content, tool_calls: tool_calls, finish_reason: finish_reason,
+          usage: usage_data, raw_api_usage: usage
+        }
+        result[:reasoning_content] = reasoning_content unless reasoning_content.empty?
+        result
       end
 
       # ── Tool result formatting ────────────────────────────────────────────────

--- a/spec/clacky/anthropic_stream_aggregator_spec.rb
+++ b/spec/clacky/anthropic_stream_aggregator_spec.rb
@@ -76,6 +76,38 @@ RSpec.describe Clacky::AnthropicStreamAggregator do
     expect(parsed[:usage][:cache_read_input_tokens]).to eq(50)
   end
 
+  it "assembles thinking blocks into the response" do
+    agg = described_class.new
+
+    agg.handle("content_block_start", {
+      index: 0, content_block: { type: "thinking", thinking: "" }
+    }.to_json)
+    agg.handle("content_block_delta", {
+      index: 0, delta: { type: "thinking_delta", thinking: "Let me think" }
+    }.to_json)
+    agg.handle("content_block_delta", {
+      index: 0, delta: { type: "thinking_delta", thinking: " about this..." }
+    }.to_json)
+    agg.handle("content_block_stop", { index: 0 }.to_json)
+    agg.handle("content_block_start", {
+      index: 1, content_block: { type: "text", text: "" }
+    }.to_json)
+    agg.handle("content_block_delta", {
+      index: 1, delta: { type: "text_delta", text: "Hello!" }
+    }.to_json)
+    agg.handle("content_block_stop", { index: 1 }.to_json)
+
+    result = agg.to_h
+    expect(result["content"]).to eq([
+      { "type" => "thinking", "thinking" => "Let me think about this..." },
+      { "type" => "text", "text" => "Hello!" }
+    ])
+
+    parsed = Clacky::MessageFormat::Anthropic.parse_response(result)
+    expect(parsed[:reasoning_content]).to eq("Let me think about this...")
+    expect(parsed[:content]).to eq("Hello!")
+  end
+
   it "ignores ping events and unparseable payloads" do
     agg = described_class.new
     expect { agg.handle("ping", {}.to_json) }.not_to raise_error

--- a/spec/clacky/message_format_anthropic_spec.rb
+++ b/spec/clacky/message_format_anthropic_spec.rb
@@ -3,6 +3,65 @@
 require "spec_helper"
 
 RSpec.describe Clacky::MessageFormat::Anthropic do
+  describe ".parse_response" do
+    it "extracts text content from response blocks" do
+      data = {
+        "content" => [
+          { "type" => "text", "text" => "Hello world" }
+        ],
+        "usage" => { "input_tokens" => 10, "output_tokens" => 5 },
+        "stop_reason" => "end_turn"
+      }
+
+      result = described_class.parse_response(data)
+      expect(result[:content]).to eq("Hello world")
+      expect(result[:reasoning_content]).to be_nil
+    end
+
+    it "extracts thinking blocks as reasoning_content" do
+      data = {
+        "content" => [
+          { "type" => "thinking", "thinking" => "Let me analyze this..." },
+          { "type" => "text", "text" => "The answer is 42." }
+        ],
+        "usage" => { "input_tokens" => 10, "output_tokens" => 15 },
+        "stop_reason" => "end_turn"
+      }
+
+      result = described_class.parse_response(data)
+      expect(result[:content]).to eq("The answer is 42.")
+      expect(result[:reasoning_content]).to eq("Let me analyze this...")
+    end
+
+    it "joins multiple thinking blocks" do
+      data = {
+        "content" => [
+          { "type" => "thinking", "thinking" => "First thought." },
+          { "type" => "thinking", "thinking" => "Second thought." },
+          { "type" => "text", "text" => "Done." }
+        ],
+        "usage" => { "input_tokens" => 5, "output_tokens" => 10 },
+        "stop_reason" => "end_turn"
+      }
+
+      result = described_class.parse_response(data)
+      expect(result[:reasoning_content]).to eq("First thought.Second thought.")
+    end
+
+    it "omits reasoning_content when no thinking blocks present" do
+      data = {
+        "content" => [
+          { "type" => "text", "text" => "Just text." }
+        ],
+        "usage" => { "input_tokens" => 5, "output_tokens" => 3 },
+        "stop_reason" => "end_turn"
+      }
+
+      result = described_class.parse_response(data)
+      expect(result).not_to have_key(:reasoning_content)
+    end
+  end
+
   describe ".build_request_body" do
     let(:model) { "claude-sonnet-4" }
     let(:tools) { [] }


### PR DESCRIPTION
<!-- Write this PR description in English. -->

## What

Extract `thinking` content blocks from Anthropic API responses into `reasoning_content`, matching the existing OpenAI-format behavior.

## Why

Kimi Coding (`kimi-for-coding` via `anthropic-messages` API) and other Anthropic-format providers with thinking mode return reasoning in `thinking` type content blocks. `MessageFormat::Anthropic.parse_response` only extracted `text` blocks, so reasoning was silently dropped — users saw no "Thoughts" section in the UI.

## User-visible impact

Users of Kimi Coding and other Anthropic-format thinking models will now see the reasoning/thinking content in the UI (collapsible "Thoughts" section), same as DeepSeek V4 users already do.

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [x] Smallest possible diff for the need
- [x] No new configuration knobs (or justified below)
- [x] No new dependencies (or justified below)
- [x] Fits the existing design / naming / layering

### 2. Need

- [x] Common need that benefits most users, **or** scope and side effects are explained below
- [x] No unintended impact on other users' workflows or defaults

### 3. Code

- [x] All tests pass
- [x] Coverage does not drop; new code has new tests
- [x] Commit messages and this PR are written in English

### Bonus

- [x] This PR was authored using OpenClacky itself

---

## Notes for reviewers

- The `reasoning_content` field is only included when thinking blocks are present, preserving backward compatibility for non-thinking responses
- Multiple thinking blocks are concatenated (same pattern as text blocks)
- Added 4 test cases covering: text-only response, single thinking block, multiple thinking blocks, and absence of reasoning_content key when no thinking blocks
