### PR TITLE
feat(web): sequential image naming with upload order guarantee

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -486,6 +486,7 @@ const Sessions = (() => {
 
   const _pendingImages = [];
   const _pendingFiles  = [];
+  let   _imageSeq      = 0;
   const MAX_IMAGE_SIZE        = 5 * 1024 * 1024;   // 5 MB — hard reject before compression
   const MAX_IMAGE_BYTES_SEND  = 512 * 1024;         // 512 KB — target after compression
   const MAX_IMAGE_LONG_EDGE   = 1920;               // px — scale down if larger
@@ -612,9 +613,13 @@ const Sessions = (() => {
       alert(`Image too large: ${file.name} (max 5 MB)`);
       return;
     }
+    const seq = ++_imageSeq;
+    const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+    const displayName = `IMG_${String(seq).padStart(3, '0')}.${ext}`;
+
     _compressImage(file)
       .then(dataUrl => {
-        _pendingImages.push({ dataUrl, name: file.name, mimeType: "image/jpeg" });
+        _pendingImages.push({ dataUrl, name: displayName, mimeType: "image/jpeg", seq });
         _renderAttachmentPreviews();
       })
       .catch(err => alert(`Image processing failed: ${err.message}`));
@@ -782,6 +787,8 @@ const Sessions = (() => {
     Sessions.appendMsg("user", bubbleHtml, { time: new Date() });
 
     // Merge images and files into unified files array for WS payload.
+    _pendingImages.sort((a, b) => a.seq - b.seq);
+
     const files = [
       ..._pendingImages.map(img => ({
         name:      img.name,
@@ -796,6 +803,7 @@ const Sessions = (() => {
     ];
     _pendingImages.length = 0;
     _pendingFiles.length  = 0;
+    _imageSeq = 0;
     _renderAttachmentPreviews();
 
     WS.send({ type: "message", session_id: Sessions.activeId, content, files });


### PR DESCRIPTION
## Problem

When users upload multiple images and describe them in sequence (e.g. "the first image shows X, the second shows Y"), the AI cannot reliably match descriptions to images because:

1. **Lost filenames on paste** — `clipboardData.getAsFile()` produces `image.png` for every pasted screenshot, making all images indistinguishable.
2. **Async race in upload queue** — `_compressImage` is async and `forEach` fires all compressions in parallel. Smaller images finish first and push to `_pendingImages` earlier, breaking the original upload order.
3. **No filename-content link for the LLM** — the AI receives bare inline data URLs with no attached filename, so it can only rely on implicit position (already broken by #2).

## Fix

- **Sequential naming**: all images entering `_addImageFile` are renamed to `IMG_001.png`, `IMG_002.jpg`, etc. The extension is preserved from the original file. This gives the AI an explicit, ordered reference.
- **Monotonic `seq` capture**: the sequence number is assigned synchronously *before* `_compressImage`, unaffected by async completion order.
- **Sort before send**: `_pendingImages` is sorted by `seq` before assembling the WS payload, guaranteeing send order matches upload order.
- **Reset per batch**: `_imageSeq` resets to 0 after each message send, so every message round starts from IMG_001.

No changes to the server-side file processor or WS protocol.

## Test

✅ Paste 3 screenshots → filenames are IMG_001.png, IMG_002.png, IMG_003.png
✅ Drag 2 images + paste 1 → sequential numbering across mixed input methods
✅ Send → server receives images in correct order
✅ Send second batch → numbering restarts from IMG_001
✅ File picker and document uploads unaffected
✅ Async race: a 50KB image uploaded after a 5MB image still gets the correct (higher) sequence number