### PR TITLE
fix(web): restore interactive feedback card in history replay (C-5599)

### DIFF
--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -497,18 +497,9 @@ module Clacky
               question = args.is_a?(Hash) ? (args[:question] || args["question"]).to_s : ""
               context  = args.is_a?(Hash) ? (args[:context]  || args["context"]).to_s  : ""
               options  = args.is_a?(Hash) ? (args[:options]  || args["options"])        : nil
+              options  = Array(options) if options && !options.is_a?(Array)
 
-              unless question.empty?
-                parts = []
-                parts << "**Context:** #{context.strip}" << "" unless context.strip.empty?
-                parts << "**Question:** #{question.strip}"
-                # Guard: options must be an Array to iterate with each_with_index
-                if options.is_a?(Array) && !options.empty?
-                  parts << "" << "**Options:**"
-                  options.each_with_index { |opt, i| parts << "  #{i + 1}. #{opt}" }
-                end
-                ui.show_assistant_message(parts.join("\n"), files: [])
-              end
+              ui.show_feedback_request(question, context, options || []) unless question.empty?
             else
               ui.show_tool_call(name, args)
             end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -89,6 +89,11 @@ module Clacky
         @events << { type: "token_usage", session_id: @session_id }.merge(token_data)
       end
 
+      def show_feedback_request(question, context, options)
+        @events << { type: "request_feedback", session_id: @session_id,
+                     question: question, context: context, options: options }
+      end
+
       # Ignore all other UI methods (progress, errors, etc.) during history replay
       def method_missing(name, *args, **kwargs); end
       def respond_to_missing?(name, include_private = false); true; end

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -97,6 +97,10 @@ module Clacky
         forward_to_subscribers { |sub| sub.show_assistant_message(content, files: files) }
       end
 
+      def show_feedback_request(question, context, options)
+        emit("request_feedback", question: question, context: context, options: options)
+      end
+
       def show_tool_call(name, args)
         args_data = args.is_a?(String) ? (JSON.parse(args) rescue args) : args
 

--- a/lib/clacky/ui_interface.rb
+++ b/lib/clacky/ui_interface.rb
@@ -8,6 +8,7 @@ module Clacky
     # @param content [String] text portion of the assistant reply (file:// links stripped)
     # @param files   [Array<Hash>] extracted file refs: [{ name:, path:, inline: }]
     def show_assistant_message(content, files:); end
+    def show_feedback_request(question, context, options); end
     def show_tool_call(name, args); end
     def show_tool_result(result); end
     def show_tool_stdout(lines); end

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -807,6 +807,15 @@ const Sessions = (() => {
     _renderAttachmentPreviews();
 
     WS.send({ type: "message", session_id: Sessions.activeId, content, files });
+
+    // Disable any pending feedback cards — user has replied (either by clicking
+    // an option button or by typing directly). The backend has already consumed
+    // the feedback; make the frontend reflect that immediately.
+    document.querySelectorAll(".feedback-card:not(.feedback-card--submitted)").forEach(card => {
+      card.querySelectorAll(".feedback-option-btn").forEach(b => { b.disabled = true; });
+      card.classList.add("feedback-card--submitted");
+    });
+
     input.value        = "";
     input.style.height = "auto";
     setTimeout(() => { _sending = false; }, 300);
@@ -1239,6 +1248,63 @@ const Sessions = (() => {
         break;
       }
 
+      case "request_feedback": {
+        // Collapse any open tool group
+        if (historyCtx.group) { _collapseToolGroup(historyCtx.group); historyCtx.group = null; }
+
+        const rfQuestion = ev.question || "";
+        const rfContext  = ev.context  || "";
+        const rfOptions  = ev.options;
+        const rfHasOptions = Array.isArray(rfOptions) && rfOptions.length > 0;
+
+        if (!rfHasOptions) {
+          // No options — render as plain assistant bubble
+          const normalizeBullets = (t) => t ? t.replace(/^[•·‣▸▪\-–]\s*/gm, "- ") : t;
+          const parts = [rfContext && rfContext.trim(), rfQuestion].filter(Boolean);
+          const rfText = parts.map(normalizeBullets).join("\n\n");
+          const rfEl = document.createElement("div");
+          rfEl.className = "msg msg-assistant";
+          rfEl.dataset.raw = rfText;
+          rfEl.innerHTML = _renderMarkdown(rfText);
+          _appendCopyButton(rfEl);
+          container.appendChild(rfEl);
+          break;
+        }
+
+        // Has options — answered → disabled card; pending → active card (same as live)
+        const rfAnswered = ev._answered === true;
+        const rfCard = document.createElement("div");
+        rfCard.className = rfAnswered ? "feedback-card feedback-card--submitted" : "feedback-card";
+        let rfHtml = "";
+        if (rfContext && rfContext.trim()) {
+          rfHtml += `<div class="feedback-context msg-assistant">${_renderMarkdown(rfContext)}</div>`;
+        }
+        rfHtml += `<div class="feedback-question msg-assistant">${_renderMarkdown(rfQuestion)}</div>`;
+        rfHtml += `<div class="feedback-options">`;
+        rfOptions.forEach((opt, idx) => {
+          rfHtml += `<button class="feedback-option-btn" data-option-index="${idx}"${rfAnswered ? " disabled" : ""}>${escapeHtml(opt)}</button>`;
+        });
+        rfHtml += `</div>`;
+        rfHtml += `<div class="feedback-hint">${I18n.t("chat.feedback_hint")}</div>`;
+        rfCard.innerHTML = rfHtml;
+
+        // If still pending, wire up click handlers (same as showFeedbackRequest)
+        if (!rfAnswered) {
+          rfCard.querySelectorAll(".feedback-option-btn").forEach(btn => {
+            btn.onclick = () => {
+              rfCard.querySelectorAll(".feedback-option-btn").forEach(b => b.disabled = true);
+              rfCard.classList.add("feedback-card--submitted");
+              const input = $("user-input");
+              if (input) input.value = btn.textContent.trim();
+              _sendMessage();
+            };
+          });
+        }
+
+        container.appendChild(rfCard);
+        break;
+      }
+
       default:
         return; // skip unknown types
     }
@@ -1307,6 +1373,20 @@ const Sessions = (() => {
           }
         }
       });
+
+      // Pre-scan: mark each request_feedback as answered.
+      // A feedback card is disabled as soon as any subsequent history_user_message appears
+      // (user either clicked an option or typed a reply).
+      {
+        let lastFeedbackIdx = -1;
+        events.forEach((ev, i) => {
+          if (ev.type === "request_feedback") { ev._answered = false; lastFeedbackIdx = i; }
+          if (ev.type === "history_user_message" && lastFeedbackIdx >= 0 && i > lastFeedbackIdx) {
+            events[lastFeedbackIdx]._answered = true;
+            lastFeedbackIdx = -1;
+          }
+        });
+      }
 
       // Dedup by created_at: skip rounds already rendered (e.g. arrived via live WS)
       const dedup = _renderedCreatedAt[id] || (_renderedCreatedAt[id] = new Set());


### PR DESCRIPTION
## Problem

After a page refresh, `request_user_feedback` cards were missing from the conversation history. `HistoryCollector` rendered them as plain assistant messages instead of interactive cards, losing the answered/pending state entirely. Additionally, typing a reply directly (without clicking an option button) left the card interactive even after the backend had already consumed the feedback.

## Fix

- ✅ Add `show_feedback_request` to `HistoryCollector` (`http_server.rb`) and `ui_interface.rb` so the event is emitted as `request_feedback` during replay
- ✅ Replace the manual markdown formatting in `session_serializer.rb` with a direct `show_feedback_request` call (removes ~10 lines of dead-end code)
- ✅ Handle `request_feedback` in `_fetchHistory` switch: render answered cards as disabled, pending cards as fully interactive with wired-up click handlers
- ✅ Pre-scan history events to infer answered state: a card is disabled as soon as any subsequent `history_user_message` exists
- ✅ In `_sendMessage()`, immediately disable all pending feedback cards on send — covers the direct-reply path that the option-button handler missed

## Test

- ✅ Refresh after clicking an option → card shown as disabled
- ✅ Refresh after typing a direct reply → card shown as disabled
- ✅ Refresh before replying → card shown as interactive, options clickable
- ✅ Type direct reply and send → card disabled immediately (no refresh needed)