### PR TITLE
fix: benchmark aborted by outer 10s request timeout (C-5600)

### DIFF
--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -10,7 +10,7 @@ module Clacky
 
     attr_reader :provider_id
 
-    def initialize(api_key, base_url:, model:, anthropic_format: false)
+    def initialize(api_key, base_url:, model:, anthropic_format: false, read_timeout: nil)
       @api_key = api_key
       @base_url = base_url
       @model = model
@@ -38,6 +38,10 @@ module Clacky
       # Non-vision models (DeepSeek, Kimi, MiniMax, etc.) reject image_url
       # content blocks; the conversion layer strips them when this is false.
       @vision_supported = Providers.supports?(provider_id, :vision, model_name: @model)
+
+      # Optional override for Faraday read_timeout (e.g. benchmark calls).
+      # nil means use the default (300s for streaming).
+      @read_timeout = read_timeout
     end
 
     # Returns true when the client is using the AWS Bedrock Converse API.
@@ -447,7 +451,7 @@ module Clacky
       @bedrock_connection ||= Faraday.new(url: @base_url) do |conn|
         conn.headers["Content-Type"]  = "application/json"
         conn.headers["Authorization"] = "Bearer #{@api_key}"
-        conn.options.timeout      = 300
+        conn.options.timeout      = @read_timeout || 300
         conn.options.open_timeout = 10
         conn.ssl.verify           = false
         conn.adapter Faraday.default_adapter
@@ -458,7 +462,7 @@ module Clacky
       @openai_connection ||= Faraday.new(url: @base_url) do |conn|
         conn.headers["Content-Type"]  = "application/json"
         conn.headers["Authorization"] = "Bearer #{@api_key}"
-        conn.options.timeout      = 300
+        conn.options.timeout      = @read_timeout || 300
         conn.options.open_timeout = 10
         conn.ssl.verify           = false
         conn.adapter Faraday.default_adapter
@@ -494,7 +498,7 @@ module Clacky
         if @provider_id == "kimi-coding"
           conn.headers["User-Agent"] = "claude-cli/1.0.51 (external, cli)"
         end
-        conn.options.timeout      = 300
+        conn.options.timeout      = @read_timeout || 300
         conn.options.open_timeout = 10
         conn.ssl.verify           = false
         conn.adapter Faraday.default_adapter

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -368,6 +368,8 @@ module Clacky
           90
         elsif path == "/api/tool/browser"
           30
+        elsif path.end_with?("/benchmark")
+          20
         else
           10
         end
@@ -3619,8 +3621,12 @@ module Clacky
         end
 
         results = threads.map do |t|
-          t.join(per_model_timeout + 3)
-          t.value rescue { ok: false, error: "thread failed" }
+          if t.join(per_model_timeout + 3)
+            t.value rescue { ok: false, error: "thread failed" }
+          else
+            t.kill
+            { ok: false, error: "Request timed out" }
+          end
         end
 
         json_response(res, 200, { ok: true, results: results })
@@ -3641,7 +3647,8 @@ module Clacky
           model_cfg["api_key"].to_s,
           base_url:         model_cfg["base_url"].to_s,
           model:            model_name,
-          anthropic_format: model_cfg["anthropic_format"] || false
+          anthropic_format: model_cfg["anthropic_format"] || false,
+          read_timeout:     timeout_sec
         )
 
         # Override Faraday timeouts via a short-lived env var isn't ideal;


### PR DESCRIPTION
## Problem

Clicking "⚡ Speed Test" in the model picker triggers a full benchmark, but if any model takes longer than 10s the **entire request** is killed by the global REST timeout handler — returning a 503 to the frontend which then clears all pending results. Users see "失败: Request timed out" with no latency data for any model.

## Root Cause

`http_server.rb` wraps every REST request in `Timeout.timeout(timeout_sec)`. The benchmark path fell into the `else` branch → **10 seconds**. But `per_model_timeout` is 15s internally, making timeout inevitable when any model responds slowly.

Additionally, `t.join` followed by `t.value` would block indefinitely if a thread got stuck, and Faraday had no explicit read_timeout for benchmark calls (defaulting to 300s streaming timeout).

## Fix

| Layer | Timeout | Purpose |
|-------|---------|---------|
| Faraday `read_timeout` | 15s | Network-level: cut dead connections |
| `t.join(18)` + `t.kill` | 18s | Thread-level: reclaim stuck threads |
| Outer `Timeout.timeout` | 20s | Request-level: final safety net |

Each layer is strictly wider than the one below, so under normal conditions the innermost layer fires first and the outer ones are just insurance.

## Changes

- `http_server.rb`: Add `elsif path.end_with?("/benchmark") → 20` to the outer timeout selector
- `http_server.rb`: Replace blind `t.join; t.value` with conditional check — kill thread on timeout instead of blocking
- `http_server.rb`: Pass `read_timeout: timeout_sec` when constructing the benchmark Client
- `client.rb`: Accept optional `read_timeout:` param, apply to all Faraday connection builders (defaults to 300s when nil)

## Testing

Verified on v1.2.3 test environment — all models now return latency results even when one or more models time out individually.