### PR TITLE
fix(ui): model card action buttons overflow on narrow viewport (C-5612)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -3649,6 +3649,7 @@ body {
 .model-card-grid-actions {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: 0.5rem;
   padding-top: 0.625rem;
   border-top: 1px solid var(--color-border-primary);


### PR DESCRIPTION
## Problem
On the Settings → Models page, action buttons (Set Default / Test / Edit / Delete) overflow the model card boundary when the browser window is narrow or on low-resolution screens.

## Fix
Add `flex-wrap: wrap` to `.model-card-grid-actions` so buttons wrap to the next line instead of overflowing.

## Test
- ✅ Narrow viewport (~600px): non-default card (4 buttons) wraps gracefully, no overflow
- ✅ Wide viewport: buttons remain in a single row, no visual change