### PR TITLE
fix(ui): reset save button state when reopening model edit modal (C-5607)

### DIFF
--- a/lib/clacky/web/settings.js
+++ b/lib/clacky/web/settings.js
@@ -169,6 +169,11 @@ const Settings = (() => {
       providerValue.classList.add("placeholder");
     }
 
+    // Reset save button
+    const saveBtn = document.getElementById("model-modal-save");
+    saveBtn.textContent = I18n.t("settings.models.btn.save");
+    saveBtn.disabled = false;
+
     // Clear test result
     document.getElementById("model-modal-test-result").textContent = "";
     document.getElementById("model-modal-test-result").className = "model-test-result";


### PR DESCRIPTION
## Problem
After saving a model in the edit modal, reopening any model's edit modal shows the save button stuck in "Saved ✓" disabled state, preventing further edits.

## Fix
Reset save button text and `disabled` state in `_openModal()`, alongside the existing form field and test result resets.

## Test
- ✅ Edit model → save → reopen edit modal: button shows "Save" and is clickable
- ✅ Add new model flow unaffected
- ✅ Save failure path still correctly re-enables button