### PR TITLE
fix(wsl): redirect_exe_stdin breaks pipe when appending </dev/null to end (C-5611)

### DIFF
--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -1407,7 +1407,15 @@ module Clacky
       private def redirect_exe_stdin(command)
         return command unless command =~ /\.exe\b/i
         return command if command =~ /<\s*[^\s|&;]/
-        "#{command} </dev/null"
+
+        # If the command has a shell-level pipe, insert </dev/null before
+        # the first pipe so only the .exe segment gets its stdin redirected,
+        # rather than starving a downstream pipe reader (e.g. `tr`, `grep`).
+        if command =~ /\|/
+          command.sub(/\s*\|/, ' </dev/null |')
+        else
+          "#{command} </dev/null"
+        end
       end
 
       # PowerShell 5 on Chinese Windows defaults [Console]::OutputEncoding


### PR DESCRIPTION
## Problem
On WSL, `redirect_exe_stdin` appends `</dev/null` to the end of the entire command. When the command contains a pipe (e.g. `powershell.exe ... 2>/dev/null | tr -d '\r'`), the redirect applies to the last pipe segment (`tr`), starving it of stdin instead of detaching the .exe's stdin.

Result: powershell output is lost, OpenClaw config detection returns empty, and the skill migration step is silently skipped.

## Fix
When the command contains `|`, insert `</dev/null` before the first pipe operator so only the .exe segment gets its stdin redirected.

## Test
`bundle exec rspec spec/clacky/tools/terminal_spec.rb` — 103 examples, 0 failures.