### PR TITLE
fix(mcp): hot-reload registry after config write (C-5604)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1798,6 +1798,7 @@ module Clacky
 
         data["mcpServers"][name] = spec
         mcp_write_raw_config(data)
+        @mcp_registry_mutex.synchronize { @mcp_registry&.reload }
         json_response(res, 200, { ok: true, name: name, config_path: mcp_config_path })
       end
 
@@ -1821,6 +1822,7 @@ module Clacky
 
         data["mcpServers"][name] = spec
         mcp_write_raw_config(data)
+        @mcp_registry_mutex.synchronize { @mcp_registry&.reload }
         json_response(res, 200, { ok: true, name: name })
       end
 
@@ -1836,6 +1838,7 @@ module Clacky
 
         data["mcpServers"].delete(name)
         mcp_write_raw_config(data)
+        @mcp_registry_mutex.synchronize { @mcp_registry&.reload }
         json_response(res, 200, { ok: true, name: name })
       end
 


### PR DESCRIPTION
## Problem

After creating, updating, or deleting an MCP server via the REST API (`POST /api/mcp`, `PUT /api/mcp/:name`, `DELETE /api/mcp/:name`), the in-process `@mcp_registry` singleton still holds stale data. Subsequent calls to `/api/mcp/:name/call` and `/api/mcp/:name/tools` return 404 until the server is restarted.

## Fix

Add `@mcp_registry_mutex.synchronize { @mcp_registry&.reload }` after `mcp_write_raw_config(data)` in all three write endpoints, consistent with the existing behavior in `api_mcp_toggle`.

## Test

✅ `bundle exec rspec spec/clacky/mcp_registry_spec.rb spec/clacky/server/http_server_mcp_spec.rb` — 68 examples, 0 failures