### PR TITLE
fix: support --json with -m

### DIFF
--- a/lib/clacky/cli.rb
+++ b/lib/clacky/cli.rb
@@ -403,6 +403,23 @@ module Clacky
         agent.rename(auto_name)
       end
 
+      # Format error message and backtrace (first 3 lines) for session saving
+      private def format_error(e)
+        "#{e.message}\n#{e.backtrace&.first(3)&.join("\n")}"
+      end
+
+      # Validates non-interactive file paths and maps them to hashes with detected MIME types
+      private def prepare_non_interactive_files(file_paths)
+        file_paths.each do |path|
+          raise ArgumentError, "File not found: #{path}" unless File.exist?(path)
+        end
+        # Convert file paths to file hashes — agent.run decides how to handle each
+        file_paths.map do |path|
+          mime = Utils::FileProcessor.detect_mime_type(path) rescue "application/octet-stream"
+          { name: File.basename(path), mime_type: mime, path: path }
+        end
+      end
+
       def validate_working_directory(path, config = nil)
         working_dir = path || Dir.pwd
 
@@ -540,7 +557,7 @@ module Clacky
           session_manager&.save(agent.to_session_data(status: :interrupted))
           ui_controller.show_warning("Task interrupted by user")
         else
-          error_message = "#{exception.message}\n#{exception.backtrace&.first(3)&.join("\n")}"
+          error_message = format_error(exception)
           session_manager&.save(agent.to_session_data(status: :error, error_message: error_message))
           ui_controller.show_error("Error: #{exception.message}")
         end
@@ -553,31 +570,61 @@ module Clacky
         # Force auto-approve — no one is around to confirm anything
         agent_config.permission_mode = :auto_approve
 
-        # Validate paths up-front so we fail fast with a clear message
-        file_paths.each do |path|
-          raise ArgumentError, "File not found: #{path}" unless File.exist?(path)
+        is_json = !!options[:json]
+
+        # Validate and prepare files up-front (DRY)
+        begin
+          files = prepare_non_interactive_files(file_paths)
+        rescue => e
+          session_manager&.save(agent.to_session_data(status: :error, error_message: format_error(e)))
+
+          if is_json
+            ui = Clacky::JsonUIController.new
+            ui.emit("error", message: e.message)
+            ui.set_idle_status
+          else
+            $stderr.puts "Error: #{e.message}"
+          end
+          exit(1)
         end
 
-        # Convert file paths to file hashes — agent.run decides how to handle each
-        files = file_paths.map do |path|
-          mime = Utils::FileProcessor.detect_mime_type(path) rescue "application/octet-stream"
-          { name: File.basename(path), mime_type: mime, path: path }
+
+        # Wire up the appropriate UI controller and execute
+        if is_json
+          ui = Clacky::JsonUIController.new
+          agent.instance_variable_set(:@ui, ui)
+          ui.emit("system", message: "Agent started", model: agent_config.model_name, working_dir: agent.working_dir)
+
+          status = run_json_task(agent, ui, session_manager) do
+            auto_name_session(agent, message)
+            agent.run(message, files: files)
+          end
+
+          if status == :success
+            ui.emit("done", total_cost: agent.total_cost, total_tasks: agent.total_tasks)
+            exit(0)
+          else
+            exit(1)
+          end
+        else
+          ui = Clacky::PlainUIController.new
+          agent.instance_variable_set(:@ui, ui)
+
+          begin
+            auto_name_session(agent, message)
+            agent.run(message, files: files)
+            session_manager&.save(agent.to_session_data(status: :success))
+            exit(0)
+          rescue Clacky::AgentInterrupted
+            session_manager&.save(agent.to_session_data(status: :interrupted))
+            $stderr.puts "\nInterrupted."
+            exit(1)
+          rescue => e
+            session_manager&.save(agent.to_session_data(status: :error, error_message: format_error(e)))
+            $stderr.puts "Error: #{e.message}"
+            exit(1)
+          end
         end
-
-        # Wire up plain-text stdout UI so all agent output is visible
-        plain_ui = Clacky::PlainUIController.new
-        agent.instance_variable_set(:@ui, plain_ui)
-
-        auto_name_session(agent, message)
-        agent.run(message, files: files)
-        session_manager&.save(agent.to_session_data(status: :success))
-        exit(0)
-      rescue Clacky::AgentInterrupted
-        $stderr.puts "\nInterrupted."
-        exit(1)
-      rescue => e
-        $stderr.puts "Error: #{e.message}"
-        exit(1)
       end
 
       # Run agent with JSON (NDJSON) output mode — persistent process.
@@ -620,6 +667,7 @@ module Clacky
               next
             end
 
+
             # Handle built-in commands
             case content.downcase
             when "/exit", "/quit"
@@ -658,12 +706,15 @@ module Clacky
         yield
         session_manager&.save(agent.to_session_data(status: :success))
         json_ui.update_sessionbar(tasks: agent.total_tasks, cost: agent.total_cost)
+        :success
       rescue Clacky::AgentInterrupted
         session_manager&.save(agent.to_session_data(status: :interrupted))
         json_ui.emit("interrupted")
+        :interrupted
       rescue => e
-        session_manager&.save(agent.to_session_data(status: :error, error_message: e.message))
+        session_manager&.save(agent.to_session_data(status: :error, error_message: format_error(e)))
         json_ui.emit("error", message: e.message)
+        :error
       ensure
         json_ui.set_idle_status
       end

--- a/spec/clacky/cli_non_interactive_spec.rb
+++ b/spec/clacky/cli_non_interactive_spec.rb
@@ -7,20 +7,35 @@ require "clacky/plain_ui_controller"
 RSpec.describe "CLI --message / -i non-interactive mode" do
   let(:cli) { Clacky::CLI.new }
 
-  # Extract the private helper so we can unit-test it directly
-  let(:run_non_interactive) do
-    # Expose private method for testing
-    cli.class.send(:public, :run_non_interactive)
-    method(:call_run_non_interactive)
-  end
-
   def call_run_non_interactive(agent, message, images, agent_config, session_manager)
     cli.send(:run_non_interactive, agent, message, images, agent_config, session_manager)
+  end
+
+
+  # Capture stdout and stderr helper to eliminate boilerplate
+  def capture_stdio
+    stdout = StringIO.new
+    stderr = StringIO.new
+    original_stdout = $stdout
+    original_stderr = $stderr
+    $stdout = stdout
+    $stderr = stderr
+    begin
+      yield
+      [stdout.string, stderr.string]
+    ensure
+      $stdout = original_stdout
+      $stderr = original_stderr
+    end
   end
 
   let(:agent) { instance_double(Clacky::Agent, to_session_data: {}, history: [], rename: nil) }
   let(:agent_config) { Clacky::AgentConfig.new }
   let(:session_manager) { nil }
+
+  before do
+    allow(cli).to receive(:options).and_return(json: false)
+  end
 
   describe "image path validation" do
     it "exits with status 1 for a missing image file" do
@@ -70,6 +85,177 @@ RSpec.describe "CLI --message / -i non-interactive mode" do
       }.to raise_error(SystemExit)
 
       expect(agent_config.permission_mode).to eq(:auto_approve)
+    end
+  end
+
+  describe "JSON mode (--json)" do
+    before do
+      allow(cli).to receive(:options).and_return(json: true)
+      allow(agent).to receive(:instance_variable_set)
+      allow(agent).to receive(:working_dir).and_return("/dummy")
+      allow(agent).to receive(:total_tasks).and_return(1)
+      allow(agent).to receive(:total_cost).and_return(0.0005)
+    end
+
+    it "outputs NDJSON events on success and saves session" do
+      allow(agent).to receive(:run)
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(anything)
+
+      stdout, _ = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", [], agent_config, session_mgr)
+        }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      end
+
+      lines = stdout.strip.split("\n").map { |l| JSON.parse(l) }
+      expect(lines.first["type"]).to eq("system")
+      expect(lines.last["type"]).to eq("done")
+      expect(lines.last["total_cost"]).to eq(0.0005)
+    end
+
+    it "emits error event and saves session on early validation failure" do
+      allow(agent).to receive(:to_session_data).with(status: :error, error_message: anything).and_return(stats: { last_status: "error" })
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(hash_including(stats: hash_including(last_status: "error")))
+
+      stdout, _ = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", ["/nonexistent/image.png"], agent_config, session_mgr)
+        }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+
+      lines = stdout.strip.split("\n").map { |l| JSON.parse(l) }
+      expect(lines.any? { |l| l["type"] == "error" && l["message"].include?("File not found") }).to be true
+      expect(lines.last["status"]).to eq("idle")
+    end
+
+    it "emits interrupted event and saves session on AgentInterrupted" do
+      allow(agent).to receive(:run).and_raise(Clacky::AgentInterrupted.new("interrupted"))
+      allow(agent).to receive(:to_session_data).with(status: :interrupted).and_return(stats: { last_status: "interrupted" })
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(hash_including(stats: hash_including(last_status: "interrupted")))
+
+      stdout, _ = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", [], agent_config, session_mgr)
+        }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+
+      lines = stdout.strip.split("\n").map { |l| JSON.parse(l) }
+      expect(lines.any? { |l| l["type"] == "interrupted" }).to be true
+      expect(lines.last["status"]).to eq("idle")
+    end
+
+    it "emits events in precise sequence: system -> working -> update_sessionbar -> idle -> done on success" do
+      allow(agent).to receive(:run)
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(anything)
+
+      stdout, _ = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", [], agent_config, session_mgr)
+        }.to raise_error(SystemExit)
+      end
+
+      lines = stdout.strip.split("\n").map { |l| JSON.parse(l) }
+      types = lines.map { |l| l["type"] }
+      
+      expect(types[0]).to eq("system")
+      
+      # Should contain working status update
+      working_idx = lines.find_index { |l| l["type"] == "session_update" && l["status"] == "working" }
+      expect(working_idx).not_to be_nil
+
+      # Should contain sessionbar update after working status
+      sessionbar_idx = lines.find_index { |l| l["type"] == "session_update" && l["tasks"] == 1 }
+      expect(sessionbar_idx).not_to be_nil
+      expect(sessionbar_idx).to be > working_idx
+
+      # Should contain idle status update
+      idle_idx = lines.find_index { |l| l["type"] == "session_update" && l["status"] == "idle" }
+      expect(idle_idx).not_to be_nil
+      expect(idle_idx).to be > sessionbar_idx
+
+      # Done should be the last event
+      expect(types.last).to eq("done")
+    end
+
+    it "early validation failure in JSON mode does NOT emit working or system status" do
+      allow(agent).to receive(:to_session_data).with(status: :error, error_message: anything).and_return(stats: { last_status: "error" })
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(anything)
+
+      stdout, _ = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", ["/nonexistent/image.png"], agent_config, session_mgr)
+        }.to raise_error(SystemExit)
+      end
+
+      lines = stdout.strip.split("\n").map { |l| JSON.parse(l) }
+      has_working = lines.any? { |l| l["type"] == "session_update" && l["status"] == "working" }
+      expect(has_working).to be false
+      has_system = lines.any? { |l| l["type"] == "system" }
+      expect(has_system).to be false
+    end
+
+  end
+
+  describe "Plain mode regression" do
+    it "saves session on success and outputs plain text" do
+      allow(agent).to receive(:instance_variable_set)
+      allow(agent).to receive(:run)
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(anything)
+
+      stdout, _ = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", [], agent_config, session_mgr)
+        }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      end
+
+      expect(stdout).not_to include('{"type":')
+    end
+
+    it "saves session on early failure and outputs to stderr" do
+      allow(agent).to receive(:instance_variable_set)
+      allow(agent).to receive(:to_session_data).with(status: :error, error_message: anything).and_return(stats: { last_status: "error" })
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(hash_including(stats: hash_including(last_status: "error")))
+
+      stdout, stderr = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", ["/nonexistent/image.png"], agent_config, session_mgr)
+        }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+
+      expect(stdout).to be_empty
+      expect(stderr).to include("Error: File not found")
+    end
+
+    it "saves session on AgentInterrupted and outputs to stderr" do
+      allow(agent).to receive(:instance_variable_set)
+      allow(agent).to receive(:run).and_raise(Clacky::AgentInterrupted.new("interrupted"))
+      allow(agent).to receive(:to_session_data).with(status: :interrupted).and_return(stats: { last_status: "interrupted" })
+
+      session_mgr = double("SessionManager")
+      expect(session_mgr).to receive(:save).with(hash_including(stats: hash_including(last_status: "interrupted")))
+
+      stdout, stderr = capture_stdio do
+        expect {
+          call_run_non_interactive(agent, "hello", [], agent_config, session_mgr)
+        }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+
+      expect(stdout).to be_empty
+      expect(stderr).to include("Interrupted")
     end
   end
 end


### PR DESCRIPTION
  <!-- Write this PR description in English. -->
  ## What
  Adds `--json` support to non-interactive one-shot mode (`-m` / `--message`), emitting the same NDJSON event stream used by interactive JSON mode. 
  Refactors shared helpers (`format_error`, `prepare_non_interactive_files`) and reuses `run_json_task` for consistent lifecycle handling.
  ## Why
  `--json` previously worked only in persistent interactive mode. Scripts and automations that run a single prompt with `-m` (e.g. skill evaluation, 
  CI pipelines) had no structured output option and had to parse plain text instead. This closes that gap so one-shot invocations can be
  machine-consumed reliably.
  ## User-visible impact
  - **New behavior:** `clacky -m "..." --json` now writes NDJSON events to stdout (`system`, `session_update`, `done`, `error`, `interrupted`, etc.) 
  and exits with status 0/1 as before.
  - **Plain mode unchanged:** `-m` without `--json` still prints plain text; no new flags or config.
  - **Minor improvement:** plain `-m` mode now persists session state on error and interrupt (matching JSON mode).
  - **No breaking changes** for existing defaults or workflows.
  ---
  ## Self-review
  Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
  ### 1. Architecture
  - [x] Smallest possible diff for the need
  - [x] No new configuration knobs (or justified below)
  - [x] No new dependencies (or justified below)
  - [x] Fits the existing design / naming / layering
  ### 2. Need
  - [x] Common need that benefits most users, **or** scope and side effects are explained below
  - [x] No unintended impact on other users' workflows or defaults
  ### 3. Code
  - [x] All tests pass
  - [x] Coverage does not drop; new code has new tests
  - [x] Commit messages and this PR are written in English
  ### Bonus
  - [x] This PR was authored using OpenClacky itself
  ---
  ## Notes for reviewers
  - Focus on `run_non_interactive` branching: JSON path delegates to `run_json_task` (which now returns `:success` / `:interrupted` / `:error`); plain
   path keeps existing stderr output.
  - Early validation failures (missing image/file) emit JSON `error` + `idle` events without a preceding `system`/`working` event — covered by specs.
  - `format_error` is shared with interactive error handling for consistent session error payloads (message + first 3 backtrace lines).
  - New specs in `spec/clacky/cli_non_interactive_spec.rb` cover JSON success/error/interrupt sequences and plain-mode regressions.