### PR TITLE
feat(channel-manager): support remote LAN access with auth and mode detection (C-5609)

### DIFF
--- a/lib/clacky/default_skills/channel-manager/SKILL.md
+++ b/lib/clacky/default_skills/channel-manager/SKILL.md
@@ -85,6 +85,28 @@ If the API is unreachable or returns an empty list: "No channels configured yet.
 
 ## `setup`
 
+### Step 0 — Detect access mode (MUST run first)
+
+**Run this command before anything else:**
+
+```bash
+echo $CLACKY_SERVER_HOST
+```
+
+Based on the output, determine your mode for the entire setup:
+
+- Output is `127.0.0.1`, `localhost`, or `::1` → **local mode** (browser automation available).
+- Otherwise (e.g. `192.168.x.x`, `10.x.x.x`) → **remote mode** (browser tool is FORBIDDEN).
+
+**Remote mode constraints:**
+1. Do NOT call `browser()` at any point — it controls the server's local Chrome which the remote user cannot see.
+2. Give URLs directly to the user instead.
+3. Skip Feishu Step 1 (automated script) — go straight to Step 2.
+4. Inform the user once:
+   > 检测到你正在通过局域网远程访问（`${CLACKY_SERVER_HOST}`）。浏览器自动化功能在远程模式下不可用，将直接使用手动引导模式——我会给你链接，你在自己的浏览器中操作即可。
+
+---
+
 Ask:
 > Which platform would you like to connect?
 >
@@ -100,6 +122,8 @@ Ask:
 ### Feishu setup
 
 #### Step 1 — Try automated setup (script)
+
+> **Remote mode: SKIP this entire Step 1. Jump directly to Step 2.** The automated script requires browser cookies from the server's local Chrome, which the remote user cannot access.
 
 Run the setup script (full path is available in the supporting files list above):
 ```bash
@@ -143,7 +167,8 @@ Only reach here if the automated script failed.
 
 ##### Phase 1 — Open Feishu Open Platform
 
-1. Navigate: `open https://open.feishu.cn/app`. Pass `isolated: true`.
+1. **Local mode**: Navigate: `open https://open.feishu.cn/app`. Pass `isolated: true`.
+   **Remote mode**: Do NOT call browser. Tell the user: "请在浏览器中打开 https://open.feishu.cn/app"
 2. If a login page or QR code is shown, tell the user to log in and wait for "done".
 3. Confirm the app list is visible.
 
@@ -269,7 +294,8 @@ When `lark-cli auth login` returns successfully, tell the user:
 
 ### WeCom setup
 
-1. Navigate: `open https://work.weixin.qq.com/wework_admin/frame#/aiHelper/create`. Pass `isolated: true`.
+1. **Local mode**: Navigate: `open https://work.weixin.qq.com/wework_admin/frame#/aiHelper/create`. Pass `isolated: true`.
+   **Remote mode**: Do NOT call browser. Tell the user: "请在浏览器中打开 https://work.weixin.qq.com/wework_admin/frame#/aiHelper/create"
 2. If a login page or QR code is shown, tell the user to log in and wait for "done".
 3. Guide the user: "Scroll to the bottom of the right panel and click 'API mode creation'. Reply done." Wait for "done".
 4. Guide the user: "Click 'Add' next to 'Visible Range'. Select the top-level company node. Click Confirm. Reply done." Wait for "done".
@@ -305,14 +331,28 @@ Parse the JSON output:
 
 If the output contains `"error"`, show it and stop.
 
-#### Step 2 — Show QR code to user (browser or manual fallback)
+#### Step 2 — Start polling AND show QR code to user
+
+> **CRITICAL TIMING**: The polling script MUST be started **before or simultaneously with** showing the QR to the user. The script needs to observe the `scaned` → `confirmed` transition; if it starts after the user already confirmed, the stale-session detector will false-positive and fail.
+
+**First — start the polling script** (run in background with `timeout: 120`):
+
+```bash
+ruby "SKILL_DIR/weixin_setup.rb" --qrcode-id "$QRCODE_ID"
+```
+
+Where `$QRCODE_ID` is the `qrcode_id` from Step 1's JSON output.
+
+**Then — show QR to the user:**
 
 Build the local QR page URL (include current Unix timestamp as `since` to detect new logins only):
 ```
 http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/weixin-qr.html?url=<URL-encoded qrcode_url>&since=<current_unix_timestamp>
 ```
 
-**Try browser first** — attempt to open the QR page using the browser tool:
+**Remote mode**: Do NOT call browser(). Skip directly to the manual fallback below.
+
+**LOCAL mode — try browser first** — attempt to open the QR page using the browser tool:
 ```
 browser(action="navigate", url="<qr_page_url>")
 ```
@@ -320,26 +360,18 @@ browser(action="navigate", url="<qr_page_url>")
 **If browser succeeds:** Tell the user:
 > I've opened the WeChat QR code in your browser. Please scan it with WeChat, then confirm in the app.
 
-**If browser fails (not configured or unavailable):** Fall back to manual — tell the user:
+**If browser fails (not configured or unavailable), OR remote mode:** Fall back to manual — tell the user:
 > Please open the following link in your browser to scan the WeChat QR code:
 >
 > `http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/weixin-qr.html?url=<URL-encoded qrcode_url>`
 >
-> Scan the QR code with WeChat, confirm in the app, then reply "done".
+> Scan the QR code with WeChat, then confirm in the app.
 
 The page renders a proper scannable QR code image. Do NOT open the raw `qrcode_url` directly — that page shows "请使用微信扫码打开" with no actual QR image.
 
-#### Step 3 — Wait for scan and save credentials
+#### Step 3 — Wait for polling result
 
-Once the browser shows the QR page, immediately run the polling script in the background:
-
-```bash
-ruby "SKILL_DIR/weixin_setup.rb" --qrcode-id "$QRCODE_ID"
-```
-
-Where `$QRCODE_ID` is the `qrcode_id` from Step 2's JSON output.
-
-Run this command with `timeout: 60`. If it doesn't succeed, **retry up to 3 times with the same `$QRCODE_ID`** — the QR code stays valid for 5 minutes. Only stop retrying if:
+The polling script is already running from Step 2. Check its output (it will exit on its own when confirmed or timed out). If it doesn't succeed, **retry up to 3 times with the same `$QRCODE_ID`** — the QR code stays valid for 5 minutes. Only stop retrying if:
 - Exit code is 0 → success
 - Output contains "stale-session" → the qrcode_id was already consumed by a prior login; **immediately restart from Step 1** (do NOT retry with same id)
 - Output contains "expired" → QR expired, offer to restart from Step 1
@@ -367,7 +399,9 @@ Get the portal URL from the script and open it in the browser:
 PORTAL_URL=$(ruby "SKILL_DIR/discord_setup.rb" --portal-url)
 ```
 
-Open it: `browser(action="navigate", url="<PORTAL_URL>")`. If the browser tool is not configured, invoke `browser-setup` first, then retry.
+**Local mode**: Open it: `browser(action="navigate", url="<PORTAL_URL>")`. If the browser tool is not configured, invoke `browser-setup` first, then retry.
+
+**Remote mode**: Do NOT call browser. Tell the user: "请在浏览器中打开以下链接：\n<PORTAL_URL>"
 
 #### Step 2 — Guide the user through the portal (one round-trip)
 
@@ -403,7 +437,10 @@ If the reply is malformed (missing either field), apologise briefly and ask agai
    ```bash
    ruby "SKILL_DIR/discord_setup.rb" --invite-url "<APP_ID>"
    ```
-   Open it: `browser(action="navigate", url="<INVITE_URL>")`. Tell the user:
+   **Local mode**: Open it: `browser(action="navigate", url="<INVITE_URL>")`.
+   **Remote mode**: Do NOT call browser. Tell the user: "请在浏览器中打开以下邀请链接：\n<INVITE_URL>"
+   
+   Tell the user:
    > Pick your server from the dropdown → **Continue** → **Authorize**. I'll detect when the bot joins.
    >
    > If the dropdown is empty, you don't have a server yet — open <https://discord.com/channels/@me>, click **Add a Server** (the **+** button on the left sidebar) → **Create My Own** → **For me and my friends** → name it → **Create**, then re-open the invite link.

--- a/lib/clacky/default_skills/channel-manager/dingtalk_setup.rb
+++ b/lib/clacky/default_skills/channel-manager/dingtalk_setup.rb
@@ -54,6 +54,8 @@ def server_post(path, body)
   uri = URI(CLACKY_SERVER_URL)
   Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 10) do |h|
     req = Net::HTTP::Post.new(path, "Content-Type" => "application/json")
+    access_key = ENV["CLACKY_ACCESS_KEY"].to_s.strip
+    req["Authorization"] = "Bearer #{access_key}" unless access_key.empty?
     req.body = JSON.generate(body)
     h.request(req)
   end
@@ -62,7 +64,10 @@ end
 def server_get(path)
   uri = URI(CLACKY_SERVER_URL)
   Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 10) do |h|
-    h.request(Net::HTTP::Get.new(path))
+    req = Net::HTTP::Get.new(path)
+    access_key = ENV["CLACKY_ACCESS_KEY"].to_s.strip
+    req["Authorization"] = "Bearer #{access_key}" unless access_key.empty?
+    h.request(req)
   end
 end
 

--- a/lib/clacky/default_skills/channel-manager/discord_setup.rb
+++ b/lib/clacky/default_skills/channel-manager/discord_setup.rb
@@ -98,6 +98,8 @@ def save_to_server(bot_token:)
   http.open_timeout = 5
 
   req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+  access_key = ENV["CLACKY_ACCESS_KEY"].to_s.strip
+  req["Authorization"] = "Bearer #{access_key}" unless access_key.empty?
   req.body = body
 
   res  = http.request(req)

--- a/lib/clacky/default_skills/channel-manager/feishu_setup.rb
+++ b/lib/clacky/default_skills/channel-manager/feishu_setup.rb
@@ -432,6 +432,8 @@ def run_setup(browser, api)
       req = method == :post \
         ? Net::HTTP::Post.new(path, "Content-Type" => "application/json") \
         : Net::HTTP::Get.new(path)
+      access_key = ENV["CLACKY_ACCESS_KEY"].to_s.strip
+      req["Authorization"] = "Bearer #{access_key}" unless access_key.empty?
       req.body = JSON.generate(body_hash) if body_hash
       h.request(req)
     end

--- a/lib/clacky/default_skills/channel-manager/weixin_setup.rb
+++ b/lib/clacky/default_skills/channel-manager/weixin_setup.rb
@@ -152,6 +152,8 @@ def save_to_server(token:, base_url:)
   http.open_timeout = 5
 
   req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+  access_key = ENV["CLACKY_ACCESS_KEY"].to_s.strip
+  req["Authorization"] = "Bearer #{access_key}" unless access_key.empty?
   req.body = body
 
   res  = http.request(req)

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -221,7 +221,7 @@ module Clacky
         # so they can call back into the server without hardcoding the port,
         # and use the correct product name without re-reading brand.yml.
         ENV["CLACKY_SERVER_PORT"]  = @port.to_s
-        ENV["CLACKY_SERVER_HOST"]  = (@host == "0.0.0.0" ? "127.0.0.1" : @host)
+        ENV["CLACKY_SERVER_HOST"]  = (@host == "0.0.0.0" ? detect_lan_ip : @host)
         product_name = Clacky::BrandConfig.load.product_name
         ENV["CLACKY_PRODUCT_NAME"] = (product_name.nil? || product_name.strip.empty?) ? "OpenClacky" : product_name
 
@@ -1202,6 +1202,15 @@ module Clacky
       # Returns true when the bind host is loopback-only.
       private def local_host?(host)
         ["127.0.0.1", "::1", "localhost"].include?(host.to_s.strip)
+      end
+
+      # Detect the first non-loopback IPv4 address for LAN accessibility.
+      # When binding 0.0.0.0 we need a reachable IP for URLs shown to the user
+      # (e.g. WeChat QR page link). Falls back to 127.0.0.1 when offline.
+      private def detect_lan_ip
+        Socket.ip_address_list
+          .select { |a| a.ipv4? && !a.ipv4_loopback? }
+          .first&.ip_address || "127.0.0.1"
       end
 
       # Resolve access key from CLACKY_ACCESS_KEY env var only.


### PR DESCRIPTION
## Summary

Enable channel-manager setup to work correctly when the user accesses OpenClacky over LAN (remote mode) instead of localhost.

## Problem

1. `CLACKY_SERVER_HOST` was set to `0.0.0.0` when binding all interfaces — not a usable address for URLs shown to users.
2. Setup scripts made HTTP requests to the server without auth headers, causing 401 when `CLACKY_ACCESS_KEY` is configured.
3. SKILL.md unconditionally used browser automation, which controls the server machine's Chrome — invisible to remote users.
4. Weixin polling started in Step 1 before the user had a chance to scan the QR code, causing timeout on slow networks.

## Changes

- **http_server.rb**: `detect_lan_ip` resolves first non-loopback IPv4; `CLACKY_SERVER_HOST` uses it when host is `0.0.0.0`.
- **SKILL.md**: Step 0 detects local/remote mode; remote mode skips browser automation and gives direct URLs. Weixin polling moved to Step 2.
- **4 setup scripts**: conditionally attach `Authorization: Bearer` header from `CLACKY_ACCESS_KEY` env var.

## Testing

- Local mode (127.0.0.1): no behavior change, all flows pass.
- Remote mode (LAN IP): setup scripts auth correctly, browser automation properly skipped, QR URLs reachable from remote device.