### PR TITLE
fix(terminal): make WSL exe stdin redirect quote-aware

### DIFF
--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -1507,7 +1507,6 @@ module Clacky
         return "" if lines.empty?
         lines.last(DISPLAY_TAIL_LINES).join("\n")
       end
-
       # WSL interop fix: Windows .exe processes inherit the PTY stdin fd
       # and try to use it as a Windows Console, which hangs indefinitely.
       # Detect .exe invocations and redirect stdin from /dev/null unless
@@ -1515,16 +1514,61 @@ module Clacky
       private def redirect_exe_stdin(command)
         return command unless Clacky::Utils::EnvironmentDetector.wsl?
         return command unless command =~ /\.exe\b/i
-        return command if command =~ /<\s*[^\s|&;]/
+        return command if shell_level_stdin_redirect?(command)
 
         # If the command has a shell-level pipe, insert </dev/null before
         # the first pipe so only the .exe segment gets its stdin redirected,
         # rather than starving a downstream pipe reader (e.g. `tr`, `grep`).
-        if command =~ /\|/
-          command.sub(/\s*\|/, ' </dev/null |')
+        if (pipe_index = first_shell_level_pipe_index(command))
+          "#{command[0...pipe_index].rstrip} </dev/null #{command[pipe_index..]}"
         else
           "#{command} </dev/null"
         end
+      end
+
+      private def shell_level_stdin_redirect?(command)
+        shell_level_char_index(command, "<") do |cmd, index|
+          next false if cmd[index + 1] == "<"
+          next false if index.positive? && cmd[index - 1] == "<"
+          true
+        end
+      end
+
+      private def first_shell_level_pipe_index(command)
+        shell_level_char_index(command, "|")
+      end
+
+      private def shell_level_char_index(command, target)
+        quote = nil
+        escaped = false
+
+        command.each_char.with_index do |char, index|
+          if escaped
+            escaped = false
+            next
+          end
+
+          if char == "\\"
+            escaped = true
+            next
+          end
+
+          if quote
+            quote = nil if char == quote
+            next
+          end
+
+          if char == "'" || char == '"'
+            quote = char
+            next
+          end
+
+          next unless char == target
+          return index unless block_given?
+          return index if yield(command, index)
+        end
+
+        nil
       end
 
       # PowerShell 5 on Chinese Windows defaults [Console]::OutputEncoding

--- a/spec/clacky/tools/terminal_spec.rb
+++ b/spec/clacky/tools/terminal_spec.rb
@@ -897,6 +897,69 @@ RSpec.describe Clacky::Tools::Terminal do
     end
   end
 
+
+  describe "#redirect_exe_stdin" do
+    let(:terminal) { described_class.new }
+
+    def call(cmd)
+      terminal.send(:redirect_exe_stdin, cmd)
+    end
+
+    it "leaves commands unchanged outside WSL" do
+      allow(Clacky::Utils::EnvironmentDetector).to receive(:wsl?).and_return(false)
+
+      expect(call("cmd.exe /c dir")).to eq("cmd.exe /c dir")
+    end
+
+    context "on WSL" do
+      before do
+        allow(Clacky::Utils::EnvironmentDetector).to receive(:wsl?).and_return(true)
+      end
+
+      it "leaves non-.exe commands unchanged" do
+        expect(call("ls /tmp")).to eq("ls /tmp")
+      end
+
+      it "appends stdin redirect to a simple .exe command" do
+        expect(call("cmd.exe /c dir")).to eq("cmd.exe /c dir </dev/null")
+      end
+
+      it "inserts stdin redirect before a shell-level pipe" do
+        expect(call("foo.exe | grep bar")).to eq("foo.exe </dev/null | grep bar")
+      end
+
+      it "ignores pipes inside double-quoted PowerShell commands" do
+        cmd = %q{powershell.exe -Command "Get-ChildItem C:\Windows\System32 -File | Select-Object -First 3 Name"}
+        expect(call(cmd)).to eq(%q{powershell.exe -Command "Get-ChildItem C:\Windows\System32 -File | Select-Object -First 3 Name" </dev/null})
+      end
+
+      it "ignores pipes inside single quotes" do
+        cmd = %q{foo.exe 'left | right'}
+        expect(call(cmd)).to eq("foo.exe 'left | right' </dev/null")
+      end
+
+      it "ignores escaped pipes" do
+        cmd = %q{foo.exe left\|right}
+        expect(call(cmd)).to eq(%q{foo.exe left\|right} + " </dev/null")
+      end
+
+      it "does not inject when a shell-level stdin redirect already exists" do
+        cmd = "foo.exe < input.txt | grep bar"
+        expect(call(cmd)).to eq(cmd)
+      end
+
+      it "does not treat stdin-like text inside quotes as shell-level redirect" do
+        cmd = %q{foo.exe "left < right"}
+        expect(call(cmd)).to eq(%q{foo.exe "left < right" </dev/null})
+      end
+
+      it "keeps existing behaviour for shell-level || chains" do
+        expect(call("foo.exe || true")).to eq("foo.exe </dev/null || true")
+      end
+    end
+  end
+
+
   describe "#force_powershell_utf8" do
     let(:terminal) { described_class.new }
     def call(cmd)


### PR DESCRIPTION
## Problem
- WSL `.exe` commands automatically receive `</dev/null` to avoid hanging on inherited PTY stdin.
- The previous implementation detected pipes with a simple regex, so a pipe inside a quoted PowerShell `-Command` string could be treated as a shell-level pipe.
- This caused `</dev/null` to be injected into the PowerShell script body, resulting in parser errors such as `The '<' operator is reserved for future use`.

## Fix
- Keep the existing WSL + `.exe` injection behavior unchanged.
- Replace regex-based pipe/stdin detection with a quote-aware scanner that ignores pipes and stdin-like redirects inside single quotes, double quotes, and escaped characters.
- Insert `</dev/null` before the first shell-level pipe only, otherwise append it to the command.

## Test
- Added coverage for `redirect_exe_stdin` including simple `.exe` commands, shell-level pipes, quoted pipes, escaped pipes, existing stdin redirects, and PowerShell `-Command` pipelines.
- Ran `bundle exec rspec spec/clacky/tools/terminal_spec.rb`.
- Result: `113 examples, 0 failures`.