### PR TITLE
Fix duplicate subagent UI output

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -463,7 +463,7 @@ module Clacky
               tool_calls_count: (response[:tool_calls] || []).size
             )
             if response[:content] && !response[:content].empty?
-              emit_assistant_message(response[:content], reasoning_content: response[:reasoning_content])
+              emit_assistant_message(response[:content], reasoning_content: response[:reasoning_content], final: true)
             end
 
             # Show token usage after the assistant message so WebUI renders it below the bubble
@@ -1591,7 +1591,7 @@ module Clacky
     # and cannot load file:// directly) and must stay scoped to the Web UI
     # controller. IM channel subscribers need the original file:// markdown so
     # parse_file_links can extract paths and deliver images as native attachments.
-    private def emit_assistant_message(content, reasoning_content: nil)
+    private def emit_assistant_message(content, reasoning_content: nil, final: false)
       # Prepend reasoning/thinking content (from thinking-mode providers like
       # DeepSeek V4, Kimi K2) wrapped in <think> tags so the Web UI renders it
       # as a collapsible thinking block (see sessions.js _renderMarkdown).
@@ -1602,6 +1602,12 @@ module Clacky
       end
 
       return if full_content.nil? || full_content.to_s.strip.empty?
+
+      # Subagents can stream useful intermediate assistant messages before tool
+      # calls. Only their terminal answer is summarized back into the parent, so
+      # suppress that final UI emission to avoid showing the user a near-duplicate
+      # subagent answer followed by the parent's summary/response.
+      return if @is_subagent && final
 
       parsed = parse_file_links(content)
       @ui&.show_assistant_message(full_content, files: parsed[:files])

--- a/spec/clacky/agent_subagent_spec.rb
+++ b/spec/clacky/agent_subagent_spec.rb
@@ -258,6 +258,50 @@ RSpec.describe Clacky::Agent, "#fork_subagent" do
     end
   end
 
+  describe "subagent UI output" do
+    it "does not emit the final subagent assistant response directly to the shared UI" do
+      ui = instance_double("UI")
+      allow(ui).to receive(:show_progress)
+      allow(ui).to receive(:show_token_usage)
+
+      subagent = described_class.new(
+        client,
+        config,
+        working_dir: Dir.pwd,
+        ui: ui,
+        profile: "coding",
+        session_id: Clacky::SessionManager.generate_id,
+        source: :manual
+      )
+      subagent.instance_variable_set(:@is_subagent, true)
+
+      expect(ui).not_to receive(:show_assistant_message)
+
+      subagent.send(:emit_assistant_message, "Internal subagent result", final: true)
+    end
+
+    it "still emits intermediate subagent assistant responses" do
+      ui = instance_double("UI")
+      allow(ui).to receive(:show_progress)
+      allow(ui).to receive(:show_token_usage)
+
+      subagent = described_class.new(
+        client,
+        config,
+        working_dir: Dir.pwd,
+        ui: ui,
+        profile: "coding",
+        session_id: Clacky::SessionManager.generate_id,
+        source: :manual
+      )
+      subagent.instance_variable_set(:@is_subagent, true)
+
+      expect(ui).to receive(:show_assistant_message).with("Intermediate update", files: [])
+
+      subagent.send(:emit_assistant_message, "Intermediate update")
+    end
+  end
+
   describe "#deep_clone" do
     it "creates a deep copy of objects" do
       original = {


### PR DESCRIPTION
Fixes #183.

This prevents forked subagents from emitting their final assistant message directly to the shared UI. The subagent response is still kept in message history, so the parent can continue to summarize it through `generate_subagent_summary`, but users no longer see the subagent output followed by a near-duplicate parent response.

Validation:
- `bundle exec rspec spec/clacky/agent_subagent_spec.rb`
- Full test suite in Docker with Ruby 3.4.4 + Node installed: 2132 examples, 0 failures
- `git diff --check`
