### PR TITLE
fix(terminal): isolate .exe stdin at command-wrap time on WSL

### DIFF
--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -340,12 +340,6 @@ module Clacky
           project_root: cwd || Dir.pwd
         )
 
-        # WSL interop fix: Windows .exe processes inherit the PTY's stdin fd
-        # and attempt to use it as a Windows Console, causing them to hang
-        # indefinitely. Redirect stdin from /dev/null for any .exe invocation
-        # that doesn't already have an explicit stdin redirect.
-        safe_command = redirect_exe_stdin(safe_command)
-
         # PowerShell 5 on Chinese Windows emits CP936/GBK by default; force
         # UTF-8 so our PTY (which decodes as UTF-8) doesn't see ??? bytes.
         safe_command = force_powershell_utf8(safe_command)
@@ -988,8 +982,29 @@ module Clacky
         # exit codes are also swallowed so the *user* command's $? is what
         # lands in `__clacky_ec`.
         hooks_line = with_hooks ? hooks_prefix_for(session) : ""
-        line   = %Q|#{hooks_line}{ #{command}\n}; __clacky_ec=$?; printf "\n__CLACKY_DONE_#{token}_%s__\n" "$__clacky_ec"\n|
+        # WSL interop fix: Windows .exe processes inherit the PTY slave fd
+        # as their stdin and treat it like a Windows Console — they sit
+        # there waiting for input nobody will ever send, hanging the whole
+        # session. Wrapping the user command's group with `</dev/null` gives
+        # every process inside it (including .exe interop children) an
+        # immediate EOF on stdin, so they exit cleanly.
+        #
+        # We only do this on WSL when the command actually mentions `.exe`,
+        # so Linux interactive commands like `read -p` / `python` REPL on
+        # non-WSL hosts (and on WSL when not invoking Windows binaries)
+        # keep their PTY stdin and continue to behave as before.
+        stdin_redirect = exe_needs_stdin_isolation?(command) ? " </dev/null" : ""
+        line   = %Q|#{hooks_line}{ #{command}\n}#{stdin_redirect}; __clacky_ec=$?; printf "\n__CLACKY_DONE_#{token}_%s__\n" "$__clacky_ec"\n|
         session.mutex.synchronize { session.writer.write(line) }
+      end
+
+      # True when the command should run with stdin redirected from
+      # /dev/null. Currently only triggers on WSL when the command string
+      # mentions a Windows `.exe` binary — see write_user_command for the
+      # full rationale.
+      private def exe_needs_stdin_isolation?(command)
+        return false unless Clacky::Utils::EnvironmentDetector.wsl?
+        command.to_s =~ /\.exe\b/i ? true : false
       end
 
       # Build the "run hooks" prefix line. Empty string for shells where
@@ -1506,25 +1521,6 @@ module Clacky
         lines = text.split(/\r?\n/).reject { |l| l.strip.empty? }
         return "" if lines.empty?
         lines.last(DISPLAY_TAIL_LINES).join("\n")
-      end
-
-      # WSL interop fix: Windows .exe processes inherit the PTY stdin fd
-      # and try to use it as a Windows Console, which hangs indefinitely.
-      # Detect .exe invocations and redirect stdin from /dev/null unless
-      # the command already has an explicit stdin redirect.
-      private def redirect_exe_stdin(command)
-        return command unless Clacky::Utils::EnvironmentDetector.wsl?
-        return command unless command =~ /\.exe\b/i
-        return command if command =~ /<\s*[^\s|&;]/
-
-        # If the command has a shell-level pipe, insert </dev/null before
-        # the first pipe so only the .exe segment gets its stdin redirected,
-        # rather than starving a downstream pipe reader (e.g. `tr`, `grep`).
-        if command =~ /\|/
-          command.sub(/\s*\|/, ' </dev/null |')
-        else
-          "#{command} </dev/null"
-        end
       end
 
       # PowerShell 5 on Chinese Windows defaults [Console]::OutputEncoding

--- a/spec/clacky/tools/terminal_spec.rb
+++ b/spec/clacky/tools/terminal_spec.rb
@@ -961,6 +961,79 @@ RSpec.describe Clacky::Tools::Terminal do
   end
 
   # ---------------------------------------------------------------------------
+  # #exe_needs_stdin_isolation? — decides whether the user-command wrapper
+  # should append `</dev/null` so Windows .exe interop children don't inherit
+  # the PTY slave fd as their Console (and hang forever waiting for input).
+  # ---------------------------------------------------------------------------
+  describe "#exe_needs_stdin_isolation?" do
+    let(:terminal) { described_class.new }
+    def call(cmd)
+      terminal.send(:exe_needs_stdin_isolation?, cmd)
+    end
+
+    context "when running on WSL" do
+      before do
+        allow(Clacky::Utils::EnvironmentDetector).to receive(:wsl?).and_return(true)
+      end
+
+      it "returns true for plain .exe invocations" do
+        expect(call("whoami.exe")).to be true
+        expect(call("ipconfig.exe")).to be true
+        expect(call("powershell.exe -Command Get-Date")).to be true
+      end
+
+      it "returns true even when .exe is in the middle of a pipeline" do
+        expect(call("ipconfig.exe | grep IPv4")).to be true
+        expect(call("ls | findstr.exe foo")).to be true
+      end
+
+      it "returns true for .exe inside a quoted PowerShell -Command body" do
+        # The whole user command still mentions powershell.exe, so we wrap
+        # the entire group with </dev/null. The pipe inside the quoted
+        # string is PS-internal, but that's irrelevant — we no longer
+        # splice into the command body, only around it.
+        cmd = %q{powershell.exe -Command "Get-NetIPAddress | Select-Object InterfaceAlias"}
+        expect(call(cmd)).to be true
+      end
+
+      it "returns true for case-insensitive .EXE matches" do
+        expect(call("WHOAMI.EXE")).to be true
+        expect(call("Notepad.Exe")).to be true
+      end
+
+      it "returns false for plain Linux commands" do
+        expect(call("ls /tmp")).to be false
+        expect(call("echo hi")).to be false
+        expect(call("cat foo | grep bar")).to be false
+        expect(call("read -p 'Name: ' name && echo $name")).to be false
+      end
+
+      it "treats .exe as a word boundary, not a substring match" do
+        # `.exec` / `.execute` shouldn't trigger — only a literal `.exe`
+        # followed by a non-word char (or end of string).
+        expect(call("ruby foo.execute")).to be false
+        expect(call("./foo.exec")).to be false
+      end
+    end
+
+    context "when not running on WSL" do
+      before do
+        allow(Clacky::Utils::EnvironmentDetector).to receive(:wsl?).and_return(false)
+      end
+
+      it "returns false even for commands that mention .exe" do
+        # On non-WSL hosts there is no Windows interop layer, so we must
+        # never silently swallow stdin — a Linux user might genuinely
+        # have a file called `foo.exe`, or pipe into a cross-compile
+        # tool that happens to include `.exe` in its args.
+        expect(call("whoami.exe")).to be false
+        expect(call("powershell.exe -Command Get-Date")).to be false
+        expect(call("ls /tmp")).to be false
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # .run_sync — internal Ruby synchronous-capture API
   # ---------------------------------------------------------------------------
   describe ".run_sync" do


### PR DESCRIPTION
## Problem

On WSL, Windows `.exe` processes invoked from our PTY inherit the slave fd as their stdin and treat it like a Windows Console, sitting forever waiting for input that never arrives — the whole terminal session hangs.

The previous fix (`redirect_exe_stdin`) addressed this by scanning the command string and surgically inserting `</dev/null` around `.exe` segments. It worked for the common case but kept growing in complexity to handle pipes, quoted PowerShell `-Command` strings, and `<` parser-error edge cases — a symptom-level patch fighting shell-string parsing.

## Fix

Move stdin isolation up to the command-wrapper layer. In `write_user_command`, when the command runs on WSL **and** mentions `.exe`, wrap the user's command group with `</dev/null`:

```sh
{ <user command>
} </dev/null; __clacky_ec=$?; ...
```

This gives every process inside the group (including any Windows interop children) an immediate EOF on stdin, regardless of pipe layout, quoting, or shell metacharacters. We no longer need to parse the command string.

Scope is intentionally narrow:
- Only triggers on WSL.
- Only triggers when the command mentions `.exe`.
- Linux interactive commands (`read -p`, `python` REPL, etc.) and non-WSL hosts keep their PTY stdin untouched.

The old `redirect_exe_stdin` method and its caller in `do_start` are removed. `force_powershell_utf8` is preserved — it is orthogonal to this fix.

## Test

✅ `bundle exec rspec spec/clacky/tools/terminal_spec.rb` — 110 examples, 0 failures
✅ New `#exe_needs_stdin_isolation?` describe block (7 cases): WSL + plain `.exe` / pipe / quoted PowerShell `-Command` / mixed case / word boundary (`.exec`, `.execute`) / non-`.exe` Linux command, plus non-WSL reference case.
✅ Manual WSL verification:
  - `whoami.exe`, `ipconfig.exe`, `cmd.exe /c dir`, `powershell.exe -Command "..."` — return immediately, no hang.
  - `ipconfig.exe | grep -i ipv4`, `echo hello | clip.exe`, `cmd.exe /c dir && echo ok` — pipes and chains work.
  - `powershell.exe -Command "Write-Host '你好'"` — UTF-8 output preserved.
  - `bash -c 'read -p "Name: " n && echo hi $n'`, `python3` REPL — interactive prompts still work.
  - `ls /tmp`, `echo hi`, `echo "test.exe"` — Linux commands and incidental `.exe` strings unaffected.
  - PowerShell `<` parser-error regression no longer reproduces.