### PR TITLE
fix(brand_config): allow built-in brand skills without MANIFEST.enc.json (C-5627)

### DIFF
--- a/lib/clacky/brand_config.rb
+++ b/lib/clacky/brand_config.rb
@@ -783,12 +783,6 @@ module Clacky
 
       FileUtils.rm_f(tmp_zip)
 
-      if encrypted
-        manifest_path = File.join(dest_dir, "MANIFEST.enc.json")
-        raise "MANIFEST.enc.json missing after extraction" unless File.exist?(manifest_path)
-        JSON.parse(File.read(manifest_path))
-      end
-
       record_installed_skill(slug, version, skill_info["description"],
                              encrypted: encrypted,
                              description_zh: skill_info["description_zh"],

--- a/spec/clacky/brand_config_install_integrity_spec.rb
+++ b/spec/clacky/brand_config_install_integrity_spec.rb
@@ -54,30 +54,17 @@ RSpec.describe Clacky::BrandConfig, "#install_brand_skill! integrity & cleanup" 
     expect(Dir.exist?(dest_dir)).to be false
   end
 
-  it "removes dest_dir when MANIFEST.enc.json is missing for encrypted skills" do
+  it "succeeds for built-in skills whose ZIP does not include MANIFEST.enc.json" do
+    # Platform built-in skills (added by creators via the creator center) are
+    # not packaged with MANIFEST.enc.json. The installer must not block on it.
     subject = make_subject_with_stubbed_download(->(dest) {
       build_zip(dest, "SKILL.md.enc" => "fake-encrypted")
     })
 
     result = subject.install_brand_skill!(skill_info(slug), encrypted: true)
 
-    expect(result[:success]).to be false
-    expect(result[:error]).to match(/MANIFEST.enc.json missing/)
-    expect(Dir.exist?(dest_dir)).to be false
-  end
-
-  it "removes dest_dir when MANIFEST.enc.json contains malformed JSON" do
-    subject = make_subject_with_stubbed_download(->(dest) {
-      build_zip(dest,
-                "SKILL.md.enc"      => "fake-encrypted",
-                "MANIFEST.enc.json" => "{not-valid-json")
-    })
-
-    result = subject.install_brand_skill!(skill_info(slug), encrypted: true)
-
-    expect(result[:success]).to be false
-    expect(result[:error]).to match(/unexpected token|JSON/)
-    expect(Dir.exist?(dest_dir)).to be false
+    expect(result[:success]).to be true
+    expect(Dir.exist?(dest_dir)).to be true
   end
 
   it "succeeds when ZIP and MANIFEST are valid" do


### PR DESCRIPTION
## Problem

In **Skill Management → Brand Skills**, installing a platform built-in skill (e.g. "Short Video Script Generator" added by the creator via the creator center) immediately fails with:

```
Install failed: MANIFEST.enc.json missing after extraction
```

Other private brand skills (uploaded by the creator) install fine. The bug is that platform-hosted built-in skills are **not encrypted** by the platform, so their ZIP archives do not contain `MANIFEST.enc.json`. The installer's post-extraction check assumed every `encrypted: true` install must carry that manifest, blocking download for the entire built-in-skill category.

## Fix

Drop the post-extraction `MANIFEST.enc.json` existence/JSON-parse check in `BrandConfig#install_brand_skill!`. The check was a defensive remnant whose return value was never consumed — the real consumers (`decrypt_skill_content` and friends) read the manifest on demand and have their own fallbacks when it is absent. Removing it unblocks built-in skills without affecting encrypted private skills, which still ship their manifest and continue to load normally.

Scope is intentionally minimal — no changes to extraction, recording, decryption, or call sites.

## Test

✅ `bundle exec rspec spec/clacky/brand_config_install_integrity_spec.rb spec/clacky/brand_skill_spec.rb` — 35 examples, 0 failures
✅ Replaced the two obsolete specs (`MANIFEST.enc.json missing` / malformed JSON should fail) with a regression spec: a built-in skill whose ZIP only contains `SKILL.md.enc` now installs successfully under `encrypted: true`.
✅ Manual verification on local server: Skill Management → Brand Skills → click **Install** on a platform built-in skill → installs successfully, skill becomes available to the agent immediately.