### PR TITLE
feat: improve billing session list display

### DIFF
--- a/lib/clacky/billing/billing_store.rb
+++ b/lib/clacky/billing/billing_store.rb
@@ -168,7 +168,7 @@ module Clacky
         if deleted_records.any?
           merged = {
             session_id: "_deleted_",
-            session_name: "已删除会话",
+            session_name: nil,
             is_deleted: true,
             total_cost: deleted_records.sum { |r| r[:total_cost] }.round(6),
             total_tokens: deleted_records.sum { |r| r[:total_tokens] },

--- a/lib/clacky/billing/billing_store.rb
+++ b/lib/clacky/billing/billing_store.rb
@@ -4,7 +4,7 @@ require "json"
 require "fileutils"
 require "securerandom"
 require_relative "billing_record"
-
+require_relative "../session_manager"
 module Clacky
   module Billing
     # Persistent storage for billing records using JSONL files
@@ -115,8 +115,112 @@ module Clacky
         }
       end
 
-      # Get daily cost breakdown for the last N days
-      # @param days [Integer] Number of days to include
+      # Get session-level summary statistics
+      # @param period [Symbol] :day, :week, :month, :year, or :all
+      # @param model [String, nil] Filter by model name
+      # @param limit [Integer] Maximum number of sessions to return
+      # @return [Array<Hash>] Session summaries sorted by cost descending
+      def session_summary(period: :month, model: nil, limit: 50)
+        from_time = period_start(period)
+        records = query(from: from_time, model: model)
+
+        # Load session names from session manager
+        session_names = load_session_names
+
+        # Group by session_id
+        by_session = records.group_by { |r| r.session_id || "unknown" }
+
+        active_sessions = []
+        deleted_records = []
+
+        by_session.each do |session_id, rs|
+          total_cost = rs.sum { |r| r.cost_usd || 0 }
+          total_prompt = rs.sum { |r| r.prompt_tokens || 0 }
+          total_completion = rs.sum { |r| r.completion_tokens || 0 }
+          total_cache_read = rs.sum { |r| r.cache_read_tokens || 0 }
+          total_cache_write = rs.sum { |r| r.cache_write_tokens || 0 }
+          first_record = rs.min_by { |r| r.timestamp }
+          last_record = rs.max_by { |r| r.timestamp }
+
+          entry = {
+            session_id: session_id,
+            session_name: session_names[session_id],
+            total_cost: total_cost.round(6),
+            total_tokens: total_prompt + total_completion,
+            prompt_tokens: total_prompt,
+            completion_tokens: total_completion,
+            cache_read_tokens: total_cache_read,
+            cache_write_tokens: total_cache_write,
+            requests: rs.size,
+            first_request: first_record&.timestamp&.iso8601,
+            last_request: last_record&.timestamp&.iso8601,
+            models: rs.map(&:model).uniq
+          }
+
+          if session_names[session_id]
+            active_sessions << entry
+          else
+            deleted_records << entry
+          end
+        end
+
+        # Merge all deleted sessions into a single row
+        if deleted_records.any?
+          merged = {
+            session_id: "_deleted_",
+            session_name: "已删除会话",
+            is_deleted: true,
+            total_cost: deleted_records.sum { |r| r[:total_cost] }.round(6),
+            total_tokens: deleted_records.sum { |r| r[:total_tokens] },
+            prompt_tokens: deleted_records.sum { |r| r[:prompt_tokens] },
+            completion_tokens: deleted_records.sum { |r| r[:completion_tokens] },
+            cache_read_tokens: deleted_records.sum { |r| r[:cache_read_tokens] },
+            cache_write_tokens: deleted_records.sum { |r| r[:cache_write_tokens] },
+            requests: deleted_records.sum { |r| r[:requests] },
+            first_request: deleted_records.map { |r| r[:first_request] }.compact.min,
+            last_request: deleted_records.map { |r| r[:last_request] }.compact.max,
+            models: deleted_records.flat_map { |r| r[:models] }.uniq
+          }
+          active_sessions << merged
+        end
+
+        # Sort by total cost descending
+        active_sessions.sort_by! { |s| -s[:total_cost] }
+
+        # Apply limit
+        limit ? active_sessions.first(limit) : active_sessions
+      end
+
+      # Load session names from session manager (including trashed sessions)
+      # Returns a hash mapping session_id to session name
+      def load_session_names
+        names = {}
+        begin
+          # Load from active sessions
+          manager = Clacky::SessionManager.new
+          manager.all_sessions.each do |session|
+            id = session[:session_id]
+            name = session[:name]
+            names[id] = name if id && name && !name.to_s.empty?
+          end
+
+          # Also load from trashed sessions
+          trash_dir = File.join(Dir.home, ".clacky", "trash", "sessions-trash")
+          if Dir.exist?(trash_dir)
+            Dir.glob(File.join(trash_dir, "*.json")).each do |filepath|
+              session = JSON.parse(File.read(filepath), symbolize_names: true) rescue next
+              id = session[:session_id]
+              name = session[:name]
+              names[id] = name if id && name && !name.to_s.empty?
+            end
+          end
+        rescue => e
+          # Silently fail if session manager is not available
+        end
+        names
+      end
+
+      # Get daily cost breakdown for the last N days      # @param days [Integer] Number of days to include
       # @param model [String, nil] Filter by model name
       # @return [Array<Hash>] Daily summaries with date and cost
       def daily_breakdown(days: 30, model: nil)

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -436,8 +436,8 @@ module Clacky
         when ["GET",    "/api/billing/summary"]   then api_billing_summary(req, res)
         when ["GET",    "/api/billing/daily"]     then api_billing_daily(req, res)
         when ["GET",    "/api/billing/records"]   then api_billing_records(req, res)
-        when ["DELETE", "/api/billing/clear"]     then api_billing_clear(req, res)
-        when ["PATCH",  "/api/sessions/:id/model"] then api_switch_session_model(req, res)
+        when ["GET",    "/api/billing/sessions"]  then api_billing_sessions(req, res)
+        when ["DELETE", "/api/billing/clear"]     then api_billing_clear(req, res)        when ["PATCH",  "/api/sessions/:id/model"] then api_switch_session_model(req, res)
         when ["PATCH",  "/api/sessions/:id/working_dir"] then api_change_session_working_dir(req, res)
         else
           if method == "POST" && path.match?(%r{^/api/channels/[^/]+/send$})
@@ -1170,8 +1170,27 @@ module Clacky
         })
       end
 
-      # DELETE /api/billing/clear
-      # Clears billing records
+      # GET /api/billing/sessions
+      # Returns session-level billing summary
+      # Query params: period (day|week|month|year|all, default: month), model, limit
+      def api_billing_sessions(req, res)
+        require_relative "../billing/billing_store"
+
+        query = URI.decode_www_form(req.query_string.to_s).to_h
+        period = (query["period"] || "month").to_sym
+        model = query["model"]
+        limit = [(query["limit"] || "50").to_i, 200].min
+
+        store = Clacky::Billing::BillingStore.new
+        sessions = store.session_summary(period: period, model: model, limit: limit)
+
+        json_response(res, 200, {
+          sessions: sessions,
+          count: sessions.size
+        })
+      end
+
+      # DELETE /api/billing/clear      # Clears billing records
       # Query params: scope (today|all, default: today)
       def api_billing_clear(req, res)
         require_relative "../billing/billing_store"

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -9018,11 +9018,10 @@ body.setup-mode[data-theme="dark"] {
   transition: height 0.2s ease;
 }
 .billing-cache-miss {
-  background: #3b82f6;
+  background: #f59e0b;
   width: 100%;
   transition: height 0.2s ease;
-}
-.billing-output-bar {
+}.billing-output-bar {
   width: 12px;
   background: #10b981;
   border-radius: 2px 2px 0 0;
@@ -9038,10 +9037,10 @@ body.setup-mode[data-theme="dark"] {
 }
 
 /* Legend colors */
+.billing-legend-total { background: #6366f1; }
 .billing-legend-cache-hit { background: #93c5fd; }
-.billing-legend-cache-miss { background: #3b82f6; }
+.billing-legend-cache-miss { background: #f59e0b; }
 .billing-legend-output { background: #10b981; }
-
 /* ── Chart Tooltip ───────────────────────────────────────────────────── */
 .billing-chart-tooltip {
   display: none;
@@ -9085,10 +9084,10 @@ body.setup-mode[data-theme="dark"] {
   border-radius: 50%;
   flex-shrink: 0;
 }
+.tooltip-total { background: #6366f1; }
 .tooltip-cache-hit { background: #93c5fd; }
-.tooltip-cache-miss { background: #3b82f6; }
-.tooltip-output { background: #10b981; }
-.tooltip-label {
+.tooltip-cache-miss { background: #f59e0b; }
+.tooltip-output { background: #10b981; }.tooltip-label {
   flex: 1;
   color: var(--color-text-secondary);
 }
@@ -9155,8 +9154,8 @@ body.setup-mode[data-theme="dark"] {
   border-radius: 3px;
   transition: width 0.3s ease;
 }
-.billing-bar-prompt {
-  background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
+.billing-bar-total {
+  background: linear-gradient(90deg, #6366f1 0%, #818cf8 100%);
 }
 .billing-bar-completion {
   background: linear-gradient(90deg, #10b981 0%, #34d399 100%);
@@ -9164,10 +9163,9 @@ body.setup-mode[data-theme="dark"] {
 .billing-bar-cache-read {
   background: linear-gradient(90deg, #93c5fd 0%, #bfdbfe 100%);
 }
-.billing-bar-cache-write {
-  background: linear-gradient(90deg, #6366f1 0%, #818cf8 100%);
+.billing-bar-cache-miss {
+  background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%);
 }
-
 /* ── Model List ──────────────────────────────────────────────────────── */
 .billing-model-list {
   display: flex;
@@ -9568,4 +9566,148 @@ body.setup-mode[data-theme="dark"] {
   font-size: 0.875rem;
   color: var(--color-text-secondary);
   font-weight: 500;
+}
+
+/* ── Sessions List ───────────────────────────────────────────────────── */
+.billing-sessions-row {
+  margin-top: 1rem;
+}
+.billing-sessions-section {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+.billing-sessions-section h3 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 1rem 0;
+}
+.billing-sessions-empty {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+.billing-sessions-header {
+  display: grid;
+  grid-template-columns: 36px 1.5fr 0.8fr 0.8fr 0.8fr 0.8fr 0.8fr 1fr;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-tertiary);
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+.billing-sessions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.billing-session-row {
+  display: grid;
+  grid-template-columns: 36px 1.5fr 0.8fr 0.8fr 0.8fr 0.8fr 0.8fr 1fr;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  transition: background 0.15s;
+  align-items: center;
+}
+.billing-session-row:hover {
+  background: var(--color-bg-tertiary);
+}
+.billing-session-deleted {
+  opacity: 0.7;
+  border-left: 3px solid var(--color-warning);
+}
+.billing-session-deleted .billing-cell-main {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+.billing-cell {
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.billing-cell-index {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+.billing-cell-session {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+.billing-cell-main {
+  font-weight: 500;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.billing-cell-sub {
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.billing-cell-number {
+  font-family: var(--font-mono);
+  text-align: right;
+  color: var(--color-text-primary);
+}
+.billing-cell-hit {
+  color: #3b82f6;
+}
+.billing-cell-miss {
+  color: #f59e0b;
+}
+.billing-cell-cost {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--color-accent);
+  text-align: right;
+}
+.billing-cell-time {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+}
+@media (max-width: 768px) {
+  .billing-sessions-header {
+    display: none;
+  }
+  .billing-session-row {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 1rem;
+  }
+  .billing-cell-index {
+    display: none;
+  }
+  .billing-cell-session {
+    grid-column: 1 / -1;
+  }
+  .billing-cell-number {
+    text-align: left;
+  }
+  .billing-cell-number::before {
+    font-size: 0.625rem;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    display: block;
+  }
+  .billing-cell-time {
+    grid-column: 1 / -1;
+    text-align: right;
+  }
 }

--- a/lib/clacky/web/billing.js
+++ b/lib/clacky/web/billing.js
@@ -4,6 +4,7 @@
 const Billing = (() => {
   let _summary = null;
   let _daily = [];
+  let _sessions = []; // 会话列表
   let _allModels = []; // 保存完整的模型列表
   let _currentPeriod = "day";
   let _currentModel = "all";
@@ -73,14 +74,18 @@ const Billing = (() => {
 
     try {
       const modelParam = (_currentModel && _currentModel !== "all") ? `&model=${encodeURIComponent(_currentModel)}` : "";
-      const [summaryRes, dailyRes] = await Promise.all([
+      const [summaryRes, dailyRes, sessionsRes] = await Promise.all([
         fetch(`/api/billing/summary?period=${_currentPeriod}${modelParam}`),
-        fetch(`/api/billing/daily?days=30${modelParam}`)
+        fetch(`/api/billing/daily?days=30${modelParam}`),
+        fetch(`/api/billing/sessions?period=${_currentPeriod}${modelParam}&limit=100`)
       ]);
 
       _summary = await summaryRes.json();
       const dailyData = await dailyRes.json();
       _daily = dailyData.days || [];
+
+      const sessionsData = await sessionsRes.json();
+      _sessions = sessionsData.sessions || [];
 
       // 保存完整模型列表（仅在未筛选时更新）
       if (!_currentModel || _currentModel === "all") {
@@ -172,6 +177,10 @@ const Billing = (() => {
         <div class="billing-chart-row">
           ${_renderCombinedChart()}
         </div>
+
+        <div class="billing-sessions-row">
+          ${_renderSessionList()}
+        </div>
       </div>
     `;
 
@@ -220,13 +229,18 @@ const Billing = (() => {
           <span class="tooltip-total">${total} tokens</span>
         </div>
         <div class="tooltip-row">
+          <span class="tooltip-dot tooltip-total"></span>
+          <span class="tooltip-label">${I18n.t("billing.totalTokens") || "Total Tokens"}</span>
+          <span class="tooltip-value">${total}</span>
+        </div>
+        <div class="tooltip-row">
           <span class="tooltip-dot tooltip-cache-hit"></span>
-          <span class="tooltip-label">${I18n.t("billing.inputCacheHit") || "Input (Cache Hit)"}</span>
+          <span class="tooltip-label">${I18n.t("billing.inputCacheHit") || "Input (Hit)"}</span>
           <span class="tooltip-value">${cacheHit}</span>
         </div>
         <div class="tooltip-row">
           <span class="tooltip-dot tooltip-cache-miss"></span>
-          <span class="tooltip-label">${I18n.t("billing.inputCacheMiss") || "Input (Cache Miss)"}</span>
+          <span class="tooltip-label">${I18n.t("billing.inputCacheMiss") || "Input (Miss)"}</span>
           <span class="tooltip-value">${cacheMiss}</span>
         </div>
         <div class="tooltip-row">
@@ -333,35 +347,50 @@ const Billing = (() => {
   }
 
   function _renderTokenBreakdown() {
+    const totalTokens = _summary.total_tokens || 0;
+    const promptTokens = _summary.prompt_tokens || 0;
+    const completionTokens = _summary.completion_tokens || 0;
+    const cacheReadTokens = _summary.cache_read_tokens || 0;
+    const cacheMissTokens = promptTokens - cacheReadTokens;
+
     return `
       <div class="billing-section billing-token-section">
         <h3>${I18n.t("billing.tokenBreakdown") || "Token Breakdown"}</h3>
         <div class="billing-token-bars">
           <div class="billing-token-bar-item">
             <div class="billing-token-bar-header">
-              <span class="billing-token-bar-label">${I18n.t("billing.inputCacheHit") || "Input (Cache Hit)"}</span>
-              <span class="billing-token-bar-value">${_formatCompact(_summary.cache_read_tokens)}</span>
+              <span class="billing-token-bar-label">${I18n.t("billing.totalTokens") || "Total Tokens"}</span>
+              <span class="billing-token-bar-value">${_formatCompact(totalTokens)}</span>
             </div>
             <div class="billing-token-bar-track">
-              <div class="billing-token-bar-fill billing-bar-cache-read" style="width: ${_getTokenPercent('cache_read')}%"></div>
+              <div class="billing-token-bar-fill billing-bar-total" style="width: 100%"></div>
             </div>
           </div>
           <div class="billing-token-bar-item">
             <div class="billing-token-bar-header">
-              <span class="billing-token-bar-label">${I18n.t("billing.inputCacheMiss") || "Input (Cache Miss)"}</span>
-              <span class="billing-token-bar-value">${_formatCompact(_summary.prompt_tokens)}</span>
+              <span class="billing-token-bar-label">${I18n.t("billing.inputCacheHit") || "Input (Hit)"}</span>
+              <span class="billing-token-bar-value">${_formatCompact(cacheReadTokens)}</span>
             </div>
             <div class="billing-token-bar-track">
-              <div class="billing-token-bar-fill billing-bar-prompt" style="width: ${_getTokenPercent('prompt')}%"></div>
+              <div class="billing-token-bar-fill billing-bar-cache-read" style="width: ${_getTokenPercent(cacheReadTokens, totalTokens)}%"></div>
+            </div>
+          </div>
+          <div class="billing-token-bar-item">
+            <div class="billing-token-bar-header">
+              <span class="billing-token-bar-label">${I18n.t("billing.inputCacheMiss") || "Input (Miss)"}</span>
+              <span class="billing-token-bar-value">${_formatCompact(cacheMissTokens)}</span>
+            </div>
+            <div class="billing-token-bar-track">
+              <div class="billing-token-bar-fill billing-bar-cache-miss" style="width: ${_getTokenPercent(cacheMissTokens, totalTokens)}%"></div>
             </div>
           </div>
           <div class="billing-token-bar-item">
             <div class="billing-token-bar-header">
               <span class="billing-token-bar-label">${I18n.t("billing.output") || "Output"}</span>
-              <span class="billing-token-bar-value">${_formatCompact(_summary.completion_tokens)}</span>
+              <span class="billing-token-bar-value">${_formatCompact(completionTokens)}</span>
             </div>
             <div class="billing-token-bar-track">
-              <div class="billing-token-bar-fill billing-bar-completion" style="width: ${_getTokenPercent('completion')}%"></div>
+              <div class="billing-token-bar-fill billing-bar-completion" style="width: ${_getTokenPercent(completionTokens, totalTokens)}%"></div>
             </div>
           </div>
         </div>
@@ -369,9 +398,8 @@ const Billing = (() => {
     `;
   }
 
-  function _getTokenPercent(type) {
-    const total = _summary.total_tokens || 1;
-    const value = _summary[type + '_tokens'] || 0;
+  function _getTokenPercent(value, total) {
+    if (!total || total === 0) return 0;
     return Math.min((value / total) * 100, 100).toFixed(1);
   }
 
@@ -427,9 +455,8 @@ const Billing = (() => {
 
     const recentDays = _daily.slice(-14);
     // Max values for scaling
-    const maxInput = Math.max(...recentDays.map(d => (d.prompt_tokens || 0) + (d.cache_read_tokens || 0)), 1);
-    const maxOutput = Math.max(...recentDays.map(d => d.completion_tokens || 0), 1);
-    const maxVal = Math.max(maxInput, maxOutput);
+    const maxInput = Math.max(...recentDays.map(d => d.prompt_tokens || 0), 1);
+    const maxOutput = Math.max(...recentDays.map(d => d.completion_tokens || 0), 1);    const maxVal = Math.max(maxInput, maxOutput);
 
     // Chart height in pixels
     const chartHeight = 120;
@@ -437,9 +464,10 @@ const Billing = (() => {
     // Generate bars: each date has Input (stacked: cache hit + cache miss) and Output
     const chartBars = recentDays.map((d, i) => {
       const cacheHit = d.cache_read_tokens || 0;        // 命中缓存
-      const cacheMiss = d.prompt_tokens || 0;           // 未命中缓存（实际发送的prompt）
+      const totalPrompt = d.prompt_tokens || 0;         // 全部输入token
+      const cacheMiss = totalPrompt - cacheHit;         // 未命中缓存 = 全部输入 - 命中
       const output = d.completion_tokens || 0;
-      const totalInput = cacheHit + cacheMiss;
+      const totalInput = totalPrompt;
       const totalTokens = totalInput + output;
 
       // Calculate heights in pixels
@@ -472,12 +500,16 @@ const Billing = (() => {
           <h4>${I18n.t("billing.dailyUsage") || "Usage Details"}</h4>
           <div class="billing-chart-legends">
             <span class="billing-chart-legend">
+              <span class="billing-legend-dot billing-legend-total"></span>
+              ${I18n.t("billing.totalTokens") || "Total Tokens"}
+            </span>
+            <span class="billing-chart-legend">
               <span class="billing-legend-dot billing-legend-cache-hit"></span>
-              ${I18n.t("billing.inputCacheHit") || "Input (Cache Hit)"}
+              ${I18n.t("billing.inputCacheHit") || "Input (Hit)"}
             </span>
             <span class="billing-chart-legend">
               <span class="billing-legend-dot billing-legend-cache-miss"></span>
-              ${I18n.t("billing.inputCacheMiss") || "Input (Cache Miss)"}
+              ${I18n.t("billing.inputCacheMiss") || "Input (Miss)"}
             </span>
             <span class="billing-chart-legend">
               <span class="billing-legend-dot billing-legend-output"></span>
@@ -490,6 +522,69 @@ const Billing = (() => {
         </div>
       </div>
       <div class="billing-chart-tooltip" id="billing-tooltip"></div>
+    `;
+  }
+
+  function _renderSessionList() {
+    if (!_sessions || _sessions.length === 0) {
+      return `
+        <div class="billing-section billing-sessions-section">
+          <h3>${I18n.t("billing.sessions") || "Sessions"}</h3>
+          <div class="billing-sessions-empty">${I18n.t("billing.noSessions") || "No session data"}</div>
+        </div>
+      `;
+    }
+
+    const rows = _sessions.map((s, index) => {
+      const sessionId = s.session_id || "unknown";
+      const isDeleted = s.is_deleted;
+      const sessionName = s.session_name || sessionId;
+      const displayName = isDeleted ? (I18n.t("billing.deletedSessions") || "已删除会话") : (sessionName.length > 25 ? sessionName.slice(0, 25) + "..." : sessionName);
+      const totalCost = _convertCost(s.total_cost || 0);
+      const totalTokens = s.total_tokens || 0;
+      const promptTokens = s.prompt_tokens || 0;
+      const cacheHit = s.cache_read_tokens || 0;
+      const cacheMiss = promptTokens - cacheHit;
+      const completionTokens = s.completion_tokens || 0;
+      const requests = s.requests || 0;
+      const models = (s.models || []).join(", ");
+      const lastRequest = s.last_request ? new Date(s.last_request).toLocaleString() : "-";
+      const rowClass = isDeleted ? "billing-session-row billing-session-deleted" : "billing-session-row";
+
+      return `
+        <div class="${rowClass}" data-session-id="${_esc(sessionId)}">
+          <div class="billing-cell billing-cell-index">${index + 1}</div>
+          <div class="billing-cell billing-cell-session" title="${_esc(sessionName)}">
+            <span class="billing-cell-main">${_esc(displayName)}</span>
+            <span class="billing-cell-sub">${requests} ${I18n.t("billing.requests") || "req"} · ${_esc(models)}</span>
+          </div>
+          <div class="billing-cell billing-cell-number">${_formatCompact(totalTokens)}</div>
+          <div class="billing-cell billing-cell-number billing-cell-hit">${_formatCompact(cacheHit)}</div>
+          <div class="billing-cell billing-cell-number billing-cell-miss">${_formatCompact(cacheMiss)}</div>
+          <div class="billing-cell billing-cell-number">${_formatCompact(completionTokens)}</div>
+          <div class="billing-cell billing-cell-cost">${_getCurrencySymbol()}${_formatCost(totalCost)}</div>
+          <div class="billing-cell billing-cell-time">${lastRequest}</div>
+        </div>
+      `;
+    }).join("");
+
+    return `
+      <div class="billing-section billing-sessions-section">
+        <h3>${I18n.t("billing.sessions") || "Sessions"}</h3>
+        <div class="billing-sessions-header">
+          <span class="billing-cell billing-cell-index">#</span>
+          <span class="billing-cell billing-cell-session">${I18n.t("billing.sessionId") || "Session"}</span>
+          <span class="billing-cell billing-cell-number">${I18n.t("billing.headerTotal") || "总消耗"}</span>
+          <span class="billing-cell billing-cell-number">${I18n.t("billing.headerHit") || "命中"}</span>
+          <span class="billing-cell billing-cell-number">${I18n.t("billing.headerMiss") || "未命中"}</span>
+          <span class="billing-cell billing-cell-number">${I18n.t("billing.headerOutput") || "输出"}</span>
+          <span class="billing-cell billing-cell-cost">${I18n.t("billing.cost") || "Cost"}</span>
+          <span class="billing-cell billing-cell-time">${I18n.t("billing.lastRequest") || "Time"}</span>
+        </div>
+        <div class="billing-sessions-list">
+          ${rows}
+        </div>
+      </div>
     `;
   }
 

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -686,15 +686,25 @@ const I18n = (() => {
       "billing.cacheHit":        "Cache Hit",
       "billing.inputCacheHit":   "Input (Cache Hit)",
       "billing.inputCacheMiss":  "Input (Cache Miss)",
-      "billing.output":          "Output",
-      "billing.tokenUsage":      "Token Usage",
+      "billing.totalInput":      "Total Input",
+      "billing.output":          "Output",      "billing.tokenUsage":      "Token Usage",
       "billing.costTrend":       "Cost Trend",
       "billing.noData":          "No data available",
 
       "error.insufficient_credit": "Insufficient LLM credit. Please top up your account to continue.",
       "error.insufficient_credit.action": "Top up",
-    },
 
+      "billing.sessions":        "Sessions",
+      "billing.sessionId":       "Session",
+      "billing.tokens":          "Tokens",
+      "billing.lastRequest":     "Last Request",
+      "billing.noSessions":      "No session data",
+      "billing.deletedSessions": "Deleted Sessions",
+      "billing.headerTotal":     "Total",
+      "billing.headerHit":       "Hit",
+      "billing.headerMiss":      "Miss",
+      "billing.headerOutput":    "Output",
+    },
     zh: {
       // ── Sidebar ──
       "sidebar.chat":     "会话",
@@ -1366,16 +1376,26 @@ const I18n = (() => {
       "billing.cacheHit":        "缓存命中",
       "billing.inputCacheHit":   "输入（命中缓存）",
       "billing.inputCacheMiss":  "输入（未命中缓存）",
-      "billing.output":          "输出",
-      "billing.tokenUsage":      "Token 用量",
+      "billing.totalTokens":     "Token 总消耗",
+      "billing.totalInput":      "总输入",
+      "billing.output":          "输出",      "billing.tokenUsage":      "Token 用量",
       "billing.costTrend":       "费用趋势",
       "billing.noData":          "暂无数据",
 
       "error.insufficient_credit": "LLM（大模型）余额不足，请充值后继续使用。",
       "error.insufficient_credit.action": "去充值",
+      "billing.sessions":        "会话消耗",
+      "billing.sessionId":       "会话",
+      "billing.tokens":          "Token",
+      "billing.lastRequest":     "最后请求",
+      "billing.noSessions":      "暂无会话数据",
+      "billing.deletedSessions": "已删除会话",
+      "billing.headerTotal":     "总消耗",
+      "billing.headerHit":       "命中",
+      "billing.headerMiss":      "未命中",
+      "billing.headerOutput":    "输出",
     }
   };
-
   // ── State ──────────────────────────────────────────────────────────────────
   let _lang = localStorage.getItem(STORAGE_KEY) || DEFAULT_LANG;
 


### PR DESCRIPTION
- Add session names instead of session IDs
- Merge deleted sessions into single row
- Standardize token breakdown table with headers: Total, Hit, Miss, Output
- Add color coding for cache hit (blue) and miss (orange)
- Support responsive layout for mobile

Billing UI improvements:
- Show session names from SessionManager
- Combine all deleted sessions into one row with special styling
- Standard table layout with token params in header rows
- Consistent 4-token display: Total, Input (Hit), Input (Miss), Output
- Color-coded cache hit/miss for better visibility
