### PR TITLE
feat(settings): add one-click exchange rate update

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -4,6 +4,7 @@ require "webrick"
 require "websocket"
 require "socket"
 require "json"
+require "net/http"
 require "thread"
 require "fileutils"
 require "tmpdir"
@@ -107,6 +108,8 @@ module Clacky
     #   GET  /**                     → static files served from lib/clacky/web/ directory
     class HttpServer
       WEB_ROOT = File.expand_path("../web", __dir__)
+      EXCHANGE_RATE_PRIMARY_BASE_URL = "https://open.er-api.com/v6/latest"
+      EXCHANGE_RATE_FALLBACK_URL = "https://api.frankfurter.app/latest"
 
       # Default SOUL.md written when the user skips the onboard conversation.
       # A richer version is created by the Agent during the soul_setup phase.
@@ -368,6 +371,8 @@ module Clacky
           90
         elsif path == "/api/tool/browser"
           30
+        elsif path == "/api/exchange-rate"
+          20
         elsif path.end_with?("/benchmark")
           20
         elsif path == "/api/media/image"
@@ -401,6 +406,7 @@ module Clacky
         when ["GET",    "/api/skills"]         then api_list_skills(res)
         when ["GET",    "/api/config"]        then api_get_config(res)
         when ["GET",    "/api/config/settings"]  then api_get_settings(res)
+        when ["GET",    "/api/exchange-rate"]    then api_exchange_rate(req, res)
         when ["PATCH",  "/api/config/settings"]  then api_update_settings(req, res)
         when ["POST",   "/api/config/models"] then api_add_model(req, res)
         when ["POST",   "/api/config/test"]   then api_test_config(req, res)
@@ -654,6 +660,103 @@ module Clacky
           FileUtils.mkdir_p(working_dir) unless Dir.exist?(working_dir)
           build_session(name: "Session 1", working_dir: working_dir)
         end
+      end
+
+      # GET /api/exchange-rate?from=USD&to=CNY
+      # Fetches the latest exchange rate on demand. The browser still owns the
+      # saved preference in localStorage; this API is only a lightweight proxy
+      # that avoids CORS issues and normalizes provider responses.
+      def api_exchange_rate(req, res)
+        query = URI.decode_www_form(req.query_string.to_s).to_h
+        from  = normalize_currency_code(query["from"], fallback: "USD")
+        to    = normalize_currency_code(query["to"], fallback: "CNY")
+
+        unless from && to
+          return json_response(res, 400, { error: "from and to must be 3-letter currency codes" })
+        end
+
+        data = fetch_exchange_rate(from, to)
+        json_response(res, 200, data)
+      rescue StandardError => e
+        Clacky::Logger.warn("[ExchangeRate] failed: #{e.class}: #{e.message}")
+        json_response(res, 502, { error: "Failed to fetch exchange rate" })
+      end
+
+      def normalize_currency_code(value, fallback:)
+        code = value.to_s.strip.upcase
+        code = fallback if code.empty?
+        code.match?(/\A[A-Z]{3}\z/) ? code : nil
+      end
+
+      def fetch_exchange_rate(from, to)
+        fetch_open_exchange_rate(from, to)
+      rescue StandardError => primary_error
+        Clacky::Logger.warn("[ExchangeRate] primary source failed: #{primary_error.message}")
+        fetch_frankfurter_exchange_rate(from, to)
+      end
+
+      def fetch_open_exchange_rate(from, to)
+        data = fetch_exchange_rate_json("#{EXCHANGE_RATE_PRIMARY_BASE_URL}/#{URI.encode_www_form_component(from)}")
+        raise "open.er-api.com returned #{data["result"] || "unknown"}" unless data["result"] == "success"
+
+        rate = positive_float(data.dig("rates", to))
+        raise "open.er-api.com missing #{to} rate" unless rate
+
+        updated_at = data["time_last_update_utc"].to_s
+        {
+          from: from,
+          to: to,
+          rate: rate,
+          date: parse_exchange_rate_date(updated_at),
+          updated_at: updated_at,
+          source: "open.er-api.com"
+        }
+      end
+
+      def fetch_frankfurter_exchange_rate(from, to)
+        query = URI.encode_www_form("from" => from, "to" => to)
+        data  = fetch_exchange_rate_json("#{EXCHANGE_RATE_FALLBACK_URL}?#{query}")
+
+        rate = positive_float(data.dig("rates", to))
+        raise "frankfurter.app missing #{to} rate" unless rate
+
+        {
+          from: from,
+          to: to,
+          rate: rate,
+          date: data["date"].to_s,
+          updated_at: data["date"].to_s,
+          source: "frankfurter.app"
+        }
+      end
+
+      def fetch_exchange_rate_json(url)
+        uri = URI(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.open_timeout = 5
+        http.read_timeout = 8
+
+        req = Net::HTTP::Get.new(uri.request_uri, "Accept" => "application/json")
+        response = http.request(req)
+        raise "HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+        JSON.parse(response.body.to_s)
+      end
+
+      def positive_float(value)
+        rate = Float(value)
+        rate.positive? ? rate : nil
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def parse_exchange_rate_date(value)
+        return "" if value.to_s.strip.empty?
+
+        Date.parse(value.to_s).iso8601
+      rescue ArgumentError
+        ""
       end
 
       # ── Onboard API ───────────────────────────────────────────────────────────

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -9571,6 +9571,53 @@ body.setup-mode[data-theme="dark"] {
   color: var(--color-text-secondary);
   font-weight: 500;
 }
+.settings-exchange-rate-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 34px;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--color-accent-primary) 28%, var(--color-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-accent-primary) 8%, var(--color-bg-secondary));
+  color: var(--color-accent-primary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+.settings-exchange-rate-refresh svg {
+  flex: 0 0 auto;
+}
+.settings-exchange-rate-refresh:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--color-accent-primary) 52%, var(--color-border));
+  background: color-mix(in srgb, var(--color-accent-primary) 12%, var(--color-bg-secondary));
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--color-accent-primary) 16%, transparent);
+  transform: translateY(-1px);
+}
+.settings-exchange-rate-refresh:active:not(:disabled) {
+  transform: translateY(0);
+}
+.settings-exchange-rate-refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+.settings-exchange-rate-status {
+  min-height: 1.1rem;
+  margin-top: 0.4rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+.settings-exchange-rate-status.success {
+  color: var(--color-success, #2e7d32);
+}
+.settings-exchange-rate-status.error {
+  color: var(--color-error, #d33);
+}
 
 /* ── Sessions List ───────────────────────────────────────────────────── */
 .billing-sessions-row {

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -624,6 +624,10 @@ const I18n = (() => {
       "settings.currency.usd":             "$ USD",
       "settings.currency.cny":             "¥ CNY",
       "settings.currency.exchangeRate":    "Exchange Rate (1 USD =)",
+      "settings.currency.updateLatest":    "Update latest",
+      "settings.currency.updating":        "Updating…",
+      "settings.currency.updated":         "Updated from {{source}} on {{date}}",
+      "settings.currency.updateFailed":    "Failed to fetch the latest rate. You can still enter it manually.",
 
       // ── Onboard ──
       "onboard.title":              "Welcome to {{brand}}",
@@ -1343,6 +1347,10 @@ const I18n = (() => {
       "settings.currency.usd":             "$ 美元",
       "settings.currency.cny":             "¥ 人民币",
       "settings.currency.exchangeRate":    "汇率 (1 美元 =)",
+      "settings.currency.updateLatest":    "获取最新汇率",
+      "settings.currency.updating":        "获取中…",
+      "settings.currency.updated":         "已从 {{source}} 更新，日期 {{date}}",
+      "settings.currency.updateFailed":    "获取最新汇率失败，仍可手动输入。",
 
       // ── Onboard ──
       "onboard.title":              "欢迎使用 {{brand}}",

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -824,7 +824,15 @@
                 <div class="settings-exchange-rate-input-wrapper">
                   <input type="number" id="settings-exchange-rate" class="settings-exchange-rate-input" step="0.0001" min="0.0001" placeholder="6.7944">
                   <span class="settings-exchange-rate-unit">CNY</span>
+                  <button type="button" id="btn-update-exchange-rate" class="settings-exchange-rate-refresh">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/>
+                      <path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>
+                    </svg>
+                    <span data-i18n="settings.currency.updateLatest">Update latest</span>
+                  </button>
                 </div>
+                <div id="settings-exchange-rate-status" class="settings-exchange-rate-status"></div>
               </label>
             </div>
           </section>

--- a/lib/clacky/web/settings.js
+++ b/lib/clacky/web/settings.js
@@ -1914,6 +1914,7 @@ const Settings = (() => {
     // Initialize exchange rate input
     const exchangeRateInput = document.getElementById("settings-exchange-rate");
     const exchangeRateSection = document.getElementById("exchange-rate-section");
+    const updateRateBtn = document.getElementById("btn-update-exchange-rate");
     if (exchangeRateInput && exchangeRateSection) {
       // Set initial value
       exchangeRateInput.value = _getExchangeRate();
@@ -1928,7 +1929,56 @@ const Settings = (() => {
           exchangeRateInput.value = _getExchangeRate();
         }
       });
+
+      if (updateRateBtn && !updateRateBtn.dataset.bound) {
+        updateRateBtn.dataset.bound = "1";
+        updateRateBtn.addEventListener("click", () => _updateLatestExchangeRate());
+      }
     }
+  }
+
+  async function _updateLatestExchangeRate() {
+    const input = document.getElementById("settings-exchange-rate");
+    const btn = document.getElementById("btn-update-exchange-rate");
+    if (!input || !btn) return;
+
+    const label = btn.querySelector("span");
+    const originalText = label ? label.textContent : btn.textContent;
+    btn.disabled = true;
+    if (label) label.textContent = I18n.t("settings.currency.updating");
+    else btn.textContent = I18n.t("settings.currency.updating");
+    _setExchangeRateStatus("", "");
+
+    try {
+      const res = await fetch("/api/exchange-rate?from=USD&to=CNY");
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(I18n.t("settings.currency.updateFailed"));
+
+      const rate = parseFloat(data.rate);
+      if (isNaN(rate) || rate <= 0) throw new Error(I18n.t("settings.currency.updateFailed"));
+
+      input.value = rate.toString();
+      _setExchangeRate(rate);
+      _setExchangeRateStatus(
+        I18n.t("settings.currency.updated", { source: data.source || "", date: data.date || "" }),
+        "success"
+      );
+    } catch (e) {
+      _setExchangeRateStatus(e.message || I18n.t("settings.currency.updateFailed"), "error");
+    } finally {
+      btn.disabled = false;
+      if (label) label.textContent = originalText || I18n.t("settings.currency.updateLatest");
+      else btn.textContent = originalText || I18n.t("settings.currency.updateLatest");
+    }
+  }
+
+  function _setExchangeRateStatus(message, type) {
+    const status = document.getElementById("settings-exchange-rate-status");
+    if (!status) return;
+
+    status.textContent = message || "";
+    status.classList.toggle("success", type === "success");
+    status.classList.toggle("error", type === "error");
   }
 
   // ── Font Size ──────────────────────────────────────────────────────────

--- a/spec/clacky/server/http_server_spec.rb
+++ b/spec/clacky/server/http_server_spec.rb
@@ -118,6 +118,60 @@ RSpec.describe Clacky::Server::HttpServer do
     end
   end
 
+  # ── GET /api/exchange-rate ─────────────────────────────────────────────────
+
+  describe "GET /api/exchange-rate" do
+    it "returns normalized exchange rate data from the primary source" do
+      with_server(agent_config: agent_config) do |server|
+        allow(server).to receive(:fetch_open_exchange_rate).with("USD", "CNY").and_return({
+          from: "USD", to: "CNY", rate: 6.772555, date: "2026-06-01",
+          updated_at: "Mon, 01 Jun 2026 00:02:31 +0000", source: "open.er-api.com"
+        })
+
+        req = fake_req(method: "GET", path: "/api/exchange-rate", query_string: "from=usd&to=cny")
+        res = fake_res
+        dispatch(server, req, res)
+
+        body = parsed_body(res)
+        expect(res.status).to eq(200)
+        expect(body["from"]).to eq("USD")
+        expect(body["to"]).to eq("CNY")
+        expect(body["rate"]).to eq(6.772555)
+        expect(body["source"]).to eq("open.er-api.com")
+      end
+    end
+
+    it "falls back when the primary source fails" do
+      with_server(agent_config: agent_config) do |server|
+        allow(server).to receive(:fetch_open_exchange_rate).and_raise(StandardError, "primary down")
+        allow(server).to receive(:fetch_frankfurter_exchange_rate).with("USD", "CNY").and_return({
+          from: "USD", to: "CNY", rate: 6.7668, date: "2026-05-29",
+          updated_at: "2026-05-29", source: "frankfurter.app"
+        })
+
+        req = fake_req(method: "GET", path: "/api/exchange-rate")
+        res = fake_res
+        dispatch(server, req, res)
+
+        body = parsed_body(res)
+        expect(res.status).to eq(200)
+        expect(body["rate"]).to eq(6.7668)
+        expect(body["source"]).to eq("frankfurter.app")
+      end
+    end
+
+    it "rejects invalid currency codes" do
+      with_server(agent_config: agent_config) do |server|
+        req = fake_req(method: "GET", path: "/api/exchange-rate", query_string: "from=USDD&to=CNY")
+        res = fake_res
+        dispatch(server, req, res)
+
+        expect(res.status).to eq(400)
+        expect(parsed_body(res)["error"]).to include("3-letter")
+      end
+    end
+  end
+
   # ── GET /api/sessions ─────────────────────────────────────────────────────
 
   describe "GET /api/sessions" do


### PR DESCRIPTION
## Problem

Users need to keep the USD-to-CNY exchange rate up to date for accurate cost statistics, but the settings page only supported manual input.

## Fix

- Added a one-click "Update latest" button next to the exchange rate input.
- Added a lightweight backend proxy endpoint at `GET /api/exchange-rate?from=USD&to=CNY`.
- Fetches rates from `open.er-api.com` with `frankfurter.app` as fallback.
- Saves the fetched rate to the existing `clacky-exchange-rate` localStorage key.
- Keeps manual exchange rate input unchanged as an always-available option.
- Added localized status messages and a button style consistent with existing UI patterns.

## Test

- ✅ `ruby -c lib/clacky/server/http_server.rb`
- ✅ `bundle exec rspec spec/clacky/server/http_server_spec.rb`
- ✅ `git diff --check`
- ✅ Manual smoke test against the live exchange rate source