### PR TITLE
feat(providers): add MiniMax M3 with vision support and pricing

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -170,8 +170,8 @@ module Clacky
         "name" => "Minimax",
         "base_url" => "https://api.minimaxi.com/v1",
         "api" => "openai-completions",
-        "default_model" => "MiniMax-M2.7",
-        "models" => ["MiniMax-M2.5", "MiniMax-M2.7"],
+        "default_model" => "MiniMax-M3",
+        "models" => ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.5"],
         # MiniMax operates two regional endpoints with identical APIs & model
         # lineup — mainland China (.com) and international (.io). Listing both
         # lets find_by_base_url identify either one as provider "minimax",
@@ -182,7 +182,12 @@ module Clacky
           { "label" => "International",  "label_key" => "settings.models.baseurl.variant.international",  "base_url" => "https://api.minimax.io/v1",   "region" => "intl" }.freeze
         ].freeze,
         # MiniMax M2.x does not support multimodal/vision input on this endpoint.
+        # M3 (released 2026-06-01) is natively multimodal and accepts image
+        # input, so it overrides the provider-level vision=false below.
         "capabilities" => { "vision" => false }.freeze,
+        "model_capabilities" => {
+          "MiniMax-M3" => { "vision" => true }.freeze
+        }.freeze,
         "website_url" => "https://www.minimaxi.com/user-center/basic-information/interface-key"
       }.freeze,
 

--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -350,6 +350,19 @@ module Clacky
         cache:  { write: 0.30, read: 0.03 }
       },
 
+      # M3 (released 2026-06-01) is MiniMax's multimodal flagship. Official
+      # pricing is tiered by context length (≤512K vs 512K–1M); per the
+      # project's "displayed ≤ actual" convention we record only the lowest
+      # (≤512K) tier as a flat rate — the global TIERED_PRICING_THRESHOLD is
+      # 200K, so applying the 512K–1M rate to the 200K–512K band would over-
+      # charge. Listed at original (non-promotional) prices: input $0.60,
+      # output $2.40, cache read $0.12 per 1M tokens.
+      "minimax-m3" => {
+        input:  { default: 0.60, over_200k: 0.60 },
+        output: { default: 2.40, over_200k: 2.40 },
+        cache:  { write: 0.60, read: 0.12 }
+      },
+
       "minimax-m2.7" => {
         input:  { default: 0.30, over_200k: 0.30 },
         output: { default: 1.20, over_200k: 1.20 },
@@ -583,6 +596,8 @@ module Clacky
           "glm-4.7"
         # MiniMax — model ids in providers.rb use capitalised "MiniMax-M2.x"
         # but we match case-insensitively and map to the lowercased table key.
+        when /^minimax-m3$/i
+          "minimax-m3"
         when /^minimax-m2\.5$/i
           "minimax-m2.5"
         when /^minimax-m2\.7$/i

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -492,6 +492,32 @@ RSpec.describe Clacky::ModelPricing do
       )
       expect(result[:source]).to eq(:price)
     end
+
+    it "bills MiniMax-M3 at its flat ≤512K-tier rate" do
+      usage = {
+        prompt_tokens: 100_000,
+        completion_tokens: 50_000,
+        cache_read_input_tokens: 20_000
+      }
+      result = described_class.calculate_cost(model: "MiniMax-M3", usage: usage)
+      # Regular input: (100_000 - 20_000) / 1M * $0.60 = $0.048
+      # Cache read:     20_000 / 1M * $0.12            = $0.0024
+      # Output:         50_000 / 1M * $2.40            = $0.12
+      # Total: $0.1704
+      expect(result[:cost]).to be_within(0.0001).of(0.1704)
+      expect(result[:source]).to eq(:price)
+    end
+
+    it "keeps MiniMax-M3 flat above 200K (no tier bump)" do
+      # Records only the ≤512K tier; the global 200K threshold must NOT
+      # escalate it (would over-charge the 200K–512K band).
+      result = described_class.calculate_cost(
+        model: "MiniMax-M3",
+        usage: { prompt_tokens: 400_000, completion_tokens: 0 }
+      )
+      # 400_000 / 1M * $0.60 = $0.24 (flat, not the 512K–1M $1.20 rate)
+      expect(result[:cost]).to be_within(0.0001).of(0.24)
+    end
   end
 
   # Guards against accidentally billing unrelated model names at a


### PR DESCRIPTION
## Problem

MiniMax released **M3** on 2026-06-01, its first natively multimodal flagship (accepts image input — unlike the text-only M2.x line). The model wasn't selectable in Settings/Welcome, and had no pricing entry, so usage would show cost as N/A.

## Fix

- **`providers.rb`** — Set MiniMax's `default_model` to `MiniMax-M3` and prepend it to the model list (`M3 / M2.7 / M2.5`). The provider stays `vision: false` (M2.x is text-only); M3 overrides to `vision: true` via `model_capabilities` — the same per-model override pattern already used for MiMo (`mimo-v2-omni`) and GLM (`glm-5v-turbo`).
- **`model_pricing.rb`** — Add `minimax-m3` at list price: input **$0.60**, output **$2.40**, cache read **0.12∗∗per1Mtokens,plusthe‘ 
m
 inimax−m3` anchored normalize match.
  - M3's official pricing is tiered by context length (≤512K vs 512K–1M). Per the project's "displayed ≤ actual" convention, only the **lowest (≤512K) tier** is recorded as a flat rate — the global `TIERED_PRICING_THRESHOLD` is 200K, so applying the 512K–1M rate to the 200K–512K band would over-charge. Prices are the original (non-promotional) rates. This mirrors how other tiered models (e.g. `qwen3.6-plus`) are recorded.
- **Front-end**: zero changes — Settings and Welcome both pull the model list dynamically from `/api/providers`.

## Test

- `rspec spec/clacky/model_pricing_spec.rb` — 42 examples, 0 failures (incl. 2 new M3 cases: base billing + "stays flat above 200K, no tier bump").
- `rspec spec/clacky/providers_spec.rb` — 61 examples, 0 failures.
- Runtime check confirms: `supports?(minimax, vision, M3) == true`, `M2.7 == false`; M3 cost for 1M in + 1M out = **$3.00**.
- `ruby -c` clean on both lib files; `git diff --check` clean.