### PR TITLE
Fix Qwen pricing table: official rates, promo discounts, retire/rename stale models

### DIFF
--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -356,74 +356,86 @@ module Clacky
         cache:  { write: 0.30, read: 0.06 }
       },
 
-      # Qwen (Alibaba DashScope) — USD per 1M tokens, Singapore region list price.
-      # Source: Alibaba Cloud Model Studio international pricing.
-      # Cache convention (mirrors DeepSeek/Kimi/GLM "displayed ≤ actual"):
-      #   - DashScope has two cache modes; implicit is auto-on, explicit is opt-in.
-      #     Implicit: write @ 100% input, read @ 20% input (no setup, no guarantee)
-      #     Explicit: write @ 125% input, read @ 10% input (cache_control marker)
-      #   - We bill writes at the regular input rate (matches implicit, and avoids
-      #     surprising users with the explicit 25% surcharge).
-      #   - We bill reads at 20% (implicit rate) — the conservative side; users on
-      #     explicit caching will see real bills slightly *lower* than displayed.
+      # Qwen (Alibaba DashScope) — USD per 1M tokens, international (Singapore) list price.
+      # Source: Alibaba Cloud Model Studio international console (国际站) per-model pages.
+      #
+      # Pricing convention:
+      #   - We record the model's LOWEST context tier (e.g. input≤256k / ≤128k) as a
+      #     flat rate, since the global TIERED_PRICING_THRESHOLD is 200K and does not
+      #     match Qwen's per-model breakpoints.
+      #   - cache.write  = official "显式缓存创建" (explicit cache create) price.
+      #   - cache.read   = official "显式缓存命中" (explicit cache hit) price.
+      #   - When a model has NO published explicit-cache price (e.g. qwen3.6-27b,
+      #     qwen-plus-latest), cache.write/read fall back to the input rate.
+      #
+      # ⚠️  PROMO PRICES: several models carry a "限时X折" (limited-time discount).
+      #     The values below are the DISCOUNTED prices. When a promo ends or changes,
+      #     these MUST be updated to the new effective price. Each model notes its
+      #     current discount factor so future maintainers can recompute from list price.
+      # qwen3.7-max: NOT tiered (single flat tier per Alibaba's definition).
+      # Promo: 限时5折 (50% off). List → discounted:
+      #   input 2.5→1.25, output 7.5→3.75, explicit write 3.125→1.5625, explicit read 0.25→0.125
       "qwen3.7-max" => {
-        input:  { default: 1.20, over_200k: 1.20 },
-        output: { default: 6.00, over_200k: 6.00 },
-        cache:  { write: 1.20, read: 0.24 }
+        input:  { default: 1.25, over_200k: 1.25 },
+        output: { default: 3.75, over_200k: 3.75 },
+        cache:  { write: 1.5625, read: 0.125 }
       },
 
+      # qwen3.7-plus: 限时8折 (20% off). List → discounted (≤256k tier):
+      #   input 0.4→0.32, output 1.6→1.28, explicit write 0.5→0.40, explicit read 0.04→0.032
       "qwen3.7-plus" => {
-        input:  { default: 0.40, over_200k: 0.40 },
-        output: { default: 2.40, over_200k: 2.40 },
-        cache:  { write: 0.40, read: 0.08 }
+        input:  { default: 0.32, over_200k: 0.32 },
+        output: { default: 1.28, over_200k: 1.28 },
+        cache:  { write: 0.40, read: 0.032 }
       },
 
-      "qwen3.7-flash" => {
-        input:  { default: 0.15, over_200k: 0.15 },
-        output: { default: 0.90, over_200k: 0.90 },
-        cache:  { write: 0.15, read: 0.03 }
-      },
-
+      # qwen3.6-plus: no active promo (≤256k tier). Official explicit-cache prices.
+      #   input 0.50, output 3.00, explicit write 0.625, explicit read 0.05
       "qwen3.6-plus" => {
-        input:  { default: 0.40, over_200k: 0.40 },
-        output: { default: 2.40, over_200k: 2.40 },
-        cache:  { write: 0.40, read: 0.08 }
+        input:  { default: 0.50, over_200k: 0.50 },
+        output: { default: 3.00, over_200k: 3.00 },
+        cache:  { write: 0.625, read: 0.05 }
       },
 
+      # qwen3.6-max (qwen3.6-max-preview): no active promo (≤128k tier).
+      #   input 1.30, output 7.80, explicit write 1.625, explicit read 0.13
       "qwen3.6-max" => {
-        input:  { default: 1.20, over_200k: 1.20 },
-        output: { default: 6.00, over_200k: 6.00 },
-        cache:  { write: 1.20, read: 0.24 }
+        input:  { default: 1.30, over_200k: 1.30 },
+        output: { default: 7.80, over_200k: 7.80 },
+        cache:  { write: 1.625, read: 0.13 }
       },
 
+      # qwen3.6-27b: no active promo, no explicit-cache pricing published.
+      #   Cache write/read fall back to the input rate (no cache discount).
       "qwen3.6-27b" => {
-        input:  { default: 0.20, over_200k: 0.20 },
-        output: { default: 0.80, over_200k: 0.80 },
-        cache:  { write: 0.20, read: 0.04 }
+        input:  { default: 0.60, over_200k: 0.60 },
+        output: { default: 3.60, over_200k: 3.60 },
+        cache:  { write: 0.60, read: 0.60 }
       },
 
+      # qwen3.6-flash: no active promo (≤256k tier).
+      #   input 0.25, output 1.50, explicit write 0.3125, explicit read 0.025
       "qwen3.6-flash" => {
-        input:  { default: 0.15, over_200k: 0.15 },
-        output: { default: 0.90, over_200k: 0.90 },
-        cache:  { write: 0.15, read: 0.03 }
+        input:  { default: 0.25, over_200k: 0.25 },
+        output: { default: 1.50, over_200k: 1.50 },
+        cache:  { write: 0.3125, read: 0.025 }
       },
 
+      # qwen-plus-latest: no active promo (≤256k tier), no explicit-cache pricing.
+      #   Cache write/read fall back to the input rate (no cache discount).
       "qwen-plus-latest" => {
         input:  { default: 0.40, over_200k: 0.40 },
         output: { default: 1.20, over_200k: 1.20 },
-        cache:  { write: 0.40, read: 0.08 }
+        cache:  { write: 0.40, read: 0.40 }
       },
 
-      "qwen-vl-plus" => {
-        input:  { default: 0.14, over_200k: 0.14 },
-        output: { default: 0.41, over_200k: 0.41 },
-        cache:  { write: 0.14, read: 0.028 }
-      },
-
-      "qwen-vl-max" => {
-        input:  { default: 0.52, over_200k: 0.52 },
-        output: { default: 2.08, over_200k: 2.08 },
-        cache:  { write: 0.52, read: 0.104 }
+      # qwen3-vl-plus: replaces the retiring qwen-vl-plus. No active promo
+      #   (128k<input≤256k tier). input 0.60, output 4.80,
+      #   explicit write 0.75, explicit read 0.06.
+      "qwen3-vl-plus" => {
+        input:  { default: 0.60, over_200k: 0.60 },
+        output: { default: 4.80, over_200k: 4.80 },
+        cache:  { write: 0.75, read: 0.06 }
       },
 
     }.freeze
@@ -591,14 +603,12 @@ module Clacky
         # Qwen (Alibaba DashScope) — strict anchored match per registered
         # model id in providers.rb. qwen3.7-* is the latest flagship line;
         # qwen3.6-* are the previous generation; qwen-plus-latest is the
-        # rolling alias for the latest Qwen-Plus release; qwen-vl-* are
-        # the multimodal SKUs.
+        # rolling alias for the latest Qwen-Plus release; qwen3-vl-plus is
+        # the multimodal SKU (replaces the retired qwen-vl-plus/max).
         when /^qwen3\.7-max$/i
           "qwen3.7-max"
         when /^qwen3\.7-plus$/i
           "qwen3.7-plus"
-        when /^qwen3\.7-flash$/i
-          "qwen3.7-flash"
         when /^qwen3\.6-plus$/i
           "qwen3.6-plus"
         when /^qwen3\.6-max$/i
@@ -609,10 +619,8 @@ module Clacky
           "qwen3.6-flash"
         when /^qwen-plus-latest$/i
           "qwen-plus-latest"
-        when /^qwen-vl-plus$/i
-          "qwen-vl-plus"
-        when /^qwen-vl-max$/i
-          "qwen-vl-max"
+        when /^qwen3-vl-plus$/i
+          "qwen3-vl-plus"
 
         # OpenAI GPT-5.x models — match various dashed/dotted/compact forms
         # (e.g. "gpt-5.5", "gpt-5-5", "gpt5.5", "gpt55")

--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -356,40 +356,39 @@ module Clacky
         cache:  { write: 0.30, read: 0.06 }
       },
 
-      # Qwen (Alibaba DashScope) — USD per 1M tokens, international (Singapore) list price.
-      # Source: Alibaba Cloud Model Studio international console (国际站) per-model pages.
+      # Qwen (Alibaba DashScope) - USD per 1M tokens, international (Singapore) list price.
+      # Source: Alibaba Cloud Model Studio international console per-model pages.
       #
       # Pricing convention:
-      #   - We record the model's LOWEST context tier (e.g. input≤256k / ≤128k) as a
+      #   - These rates are used for user-facing cost ESTIMATION, so we always use
+      #     the standard LIST price and intentionally ignore any limited-time promo
+      #     discounts. A promo lowers the user's actual bill, never raises it, so
+      #     estimating at list price keeps the estimate a safe upper bound and avoids
+      #     churn whenever a promo starts or ends.
+      #   - We record the model's LOWEST context tier (e.g. input<=256k / <=128k) as a
       #     flat rate, since the global TIERED_PRICING_THRESHOLD is 200K and does not
       #     match Qwen's per-model breakpoints.
-      #   - cache.write  = official "显式缓存创建" (explicit cache create) price.
-      #   - cache.read   = official "显式缓存命中" (explicit cache hit) price.
+      #   - cache.write = official explicit-cache-create price.
+      #   - cache.read  = official explicit-cache-hit price.
       #   - When a model has NO published explicit-cache price (e.g. qwen3.6-27b,
       #     qwen-plus-latest), cache.write/read fall back to the input rate.
-      #
-      # ⚠️  PROMO PRICES: several models carry a "限时X折" (limited-time discount).
-      #     The values below are the DISCOUNTED prices. When a promo ends or changes,
-      #     these MUST be updated to the new effective price. Each model notes its
-      #     current discount factor so future maintainers can recompute from list price.
       # qwen3.7-max: NOT tiered (single flat tier per Alibaba's definition).
-      # Promo: 限时5折 (50% off). List → discounted:
-      #   input 2.5→1.25, output 7.5→3.75, explicit write 3.125→1.5625, explicit read 0.25→0.125
+      #   List price: input 2.5, output 7.5, explicit write 3.125, explicit read 0.25.
       "qwen3.7-max" => {
-        input:  { default: 1.25, over_200k: 1.25 },
-        output: { default: 3.75, over_200k: 3.75 },
-        cache:  { write: 1.5625, read: 0.125 }
+        input:  { default: 2.5, over_200k: 2.5 },
+        output: { default: 7.5, over_200k: 7.5 },
+        cache:  { write: 3.125, read: 0.25 }
       },
 
-      # qwen3.7-plus: 限时8折 (20% off). List → discounted (≤256k tier):
-      #   input 0.4→0.32, output 1.6→1.28, explicit write 0.5→0.40, explicit read 0.04→0.032
+      # qwen3.7-plus: list price (<=256k tier):
+      #   input 0.4, output 1.6, explicit write 0.5, explicit read 0.04.
       "qwen3.7-plus" => {
-        input:  { default: 0.32, over_200k: 0.32 },
-        output: { default: 1.28, over_200k: 1.28 },
-        cache:  { write: 0.40, read: 0.032 }
+        input:  { default: 0.4, over_200k: 0.4 },
+        output: { default: 1.6, over_200k: 1.6 },
+        cache:  { write: 0.5, read: 0.04 }
       },
 
-      # qwen3.6-plus: no active promo (≤256k tier). Official explicit-cache prices.
+      # qwen3.6-plus: list price (<=256k tier). Official explicit-cache prices.
       #   input 0.50, output 3.00, explicit write 0.625, explicit read 0.05
       "qwen3.6-plus" => {
         input:  { default: 0.50, over_200k: 0.50 },
@@ -397,7 +396,7 @@ module Clacky
         cache:  { write: 0.625, read: 0.05 }
       },
 
-      # qwen3.6-max (qwen3.6-max-preview): no active promo (≤128k tier).
+      # qwen3.6-max (qwen3.6-max-preview): list price (<=128k tier).
       #   input 1.30, output 7.80, explicit write 1.625, explicit read 0.13
       "qwen3.6-max" => {
         input:  { default: 1.30, over_200k: 1.30 },
@@ -405,7 +404,7 @@ module Clacky
         cache:  { write: 1.625, read: 0.13 }
       },
 
-      # qwen3.6-27b: no active promo, no explicit-cache pricing published.
+      # qwen3.6-27b: list price, no explicit-cache pricing published.
       #   Cache write/read fall back to the input rate (no cache discount).
       "qwen3.6-27b" => {
         input:  { default: 0.60, over_200k: 0.60 },
@@ -413,7 +412,7 @@ module Clacky
         cache:  { write: 0.60, read: 0.60 }
       },
 
-      # qwen3.6-flash: no active promo (≤256k tier).
+      # qwen3.6-flash: list price (<=256k tier).
       #   input 0.25, output 1.50, explicit write 0.3125, explicit read 0.025
       "qwen3.6-flash" => {
         input:  { default: 0.25, over_200k: 0.25 },
@@ -421,7 +420,7 @@ module Clacky
         cache:  { write: 0.3125, read: 0.025 }
       },
 
-      # qwen-plus-latest: no active promo (≤256k tier), no explicit-cache pricing.
+      # qwen-plus-latest: list price (<=256k tier), no explicit-cache pricing.
       #   Cache write/read fall back to the input rate (no cache discount).
       "qwen-plus-latest" => {
         input:  { default: 0.40, over_200k: 0.40 },
@@ -429,8 +428,8 @@ module Clacky
         cache:  { write: 0.40, read: 0.40 }
       },
 
-      # qwen3-vl-plus: replaces the retiring qwen-vl-plus. No active promo
-      #   (128k<input≤256k tier). input 0.60, output 4.80,
+      # qwen3-vl-plus: replaces the retiring qwen-vl-plus. List price
+      #   (128k<input<=256k tier). input 0.60, output 4.80,
       #   explicit write 0.75, explicit read 0.06.
       "qwen3-vl-plus" => {
         input:  { default: 0.60, over_200k: 0.60 },

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -494,11 +494,11 @@ RSpec.describe Clacky::ModelPricing do
     end
   end
 
-  # Qwen (Alibaba DashScope) pricing — international list price, discounted
-  # where a "限时X折" promo applies. cache.write/read map to the official
-  # explicit-cache create/hit prices.
+  # Qwen (Alibaba DashScope) pricing - international list price (promo discounts
+  # are intentionally ignored for cost estimation). cache.write/read map to the
+  # official explicit-cache create/hit prices.
   describe "Qwen pricing" do
-    it "bills qwen3.6-plus at official prices (no promo)" do
+    it "bills qwen3.6-plus at official list prices" do
       usage = {
         prompt_tokens: 1_000_000,
         completion_tokens: 1_000_000,
@@ -513,16 +513,16 @@ RSpec.describe Clacky::ModelPricing do
       expect(result[:source]).to eq(:price)
     end
 
-    it "bills qwen3.7-max at the discounted (5折) rate, not tiered" do
+    it "bills qwen3.7-max at the flat list rate, not tiered" do
       result = described_class.calculate_cost(
         model: "qwen3.7-max",
         usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 }
       )
-      # input 1M * $1.25 + output 1M * $3.75 = $5.00 (flat, no tier bump)
-      expect(result[:cost]).to be_within(0.0001).of(5.00)
+      # input 1M * $2.5 + output 1M * $7.5 = $10.00 (flat, no tier bump)
+      expect(result[:cost]).to be_within(0.0001).of(10.00)
     end
 
-    it "bills qwen3.7-plus explicit cache create/hit at discounted (8折) rates" do
+    it "bills qwen3.7-plus explicit cache create/hit at list rates" do
       usage = {
         prompt_tokens: 100_000,
         completion_tokens: 0,
@@ -530,11 +530,11 @@ RSpec.describe Clacky::ModelPricing do
         cache_read_input_tokens: 50_000
       }
       result = described_class.calculate_cost(model: "qwen3.7-plus", usage: usage)
-      # Regular input: (100_000 - 50_000)/1M * $0.32  = $0.016
-      # Cache write:    100_000 / 1M * $0.40          = $0.04
-      # Cache read:      50_000 / 1M * $0.032          = $0.0016
-      # Total: $0.0576
-      expect(result[:cost]).to be_within(0.0001).of(0.0576)
+      # Regular input: (100_000 - 50_000)/1M * $0.4  = $0.020
+      # Cache write:    100_000 / 1M * $0.5          = $0.050
+      # Cache read:      50_000 / 1M * $0.04         = $0.002
+      # Total: $0.072
+      expect(result[:cost]).to be_within(0.0001).of(0.072)
     end
 
     it "falls back to input rate for models without explicit-cache pricing" do

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -494,6 +494,83 @@ RSpec.describe Clacky::ModelPricing do
     end
   end
 
+  # Qwen (Alibaba DashScope) pricing — international list price, discounted
+  # where a "限时X折" promo applies. cache.write/read map to the official
+  # explicit-cache create/hit prices.
+  describe "Qwen pricing" do
+    it "bills qwen3.6-plus at official prices (no promo)" do
+      usage = {
+        prompt_tokens: 1_000_000,
+        completion_tokens: 1_000_000,
+        cache_read_input_tokens: 200_000
+      }
+      result = described_class.calculate_cost(model: "qwen3.6-plus", usage: usage)
+      # Regular input: (1_000_000 - 200_000)/1M * $0.50 = $0.40
+      # Cache read:     200_000 / 1M * $0.05            = $0.01
+      # Output:       1_000_000 / 1M * $3.00            = $3.00
+      # Total: $3.41
+      expect(result[:cost]).to be_within(0.0001).of(3.41)
+      expect(result[:source]).to eq(:price)
+    end
+
+    it "bills qwen3.7-max at the discounted (5折) rate, not tiered" do
+      result = described_class.calculate_cost(
+        model: "qwen3.7-max",
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 }
+      )
+      # input 1M * $1.25 + output 1M * $3.75 = $5.00 (flat, no tier bump)
+      expect(result[:cost]).to be_within(0.0001).of(5.00)
+    end
+
+    it "bills qwen3.7-plus explicit cache create/hit at discounted (8折) rates" do
+      usage = {
+        prompt_tokens: 100_000,
+        completion_tokens: 0,
+        cache_creation_input_tokens: 100_000,
+        cache_read_input_tokens: 50_000
+      }
+      result = described_class.calculate_cost(model: "qwen3.7-plus", usage: usage)
+      # Regular input: (100_000 - 50_000)/1M * $0.32  = $0.016
+      # Cache write:    100_000 / 1M * $0.40          = $0.04
+      # Cache read:      50_000 / 1M * $0.032          = $0.0016
+      # Total: $0.0576
+      expect(result[:cost]).to be_within(0.0001).of(0.0576)
+    end
+
+    it "falls back to input rate for models without explicit-cache pricing" do
+      usage = {
+        prompt_tokens: 100_000,
+        completion_tokens: 0,
+        cache_read_input_tokens: 50_000
+      }
+      result = described_class.calculate_cost(model: "qwen3.6-27b", usage: usage)
+      # Regular input: (100_000 - 50_000)/1M * $0.60 = $0.030
+      # Cache read:     50_000 / 1M * $0.60 (=input)  = $0.030
+      # Total: $0.060
+      expect(result[:cost]).to be_within(0.0001).of(0.060)
+    end
+
+    it "maps qwen3-vl-plus (renamed from qwen-vl-plus)" do
+      result = described_class.calculate_cost(
+        model: "qwen3-vl-plus",
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 0 }
+      )
+      expect(result[:cost]).to be_within(0.0001).of(0.60)
+      expect(result[:source]).to eq(:price)
+    end
+
+    it "returns N/A for retired Qwen models (qwen3.7-flash, qwen-vl-plus, qwen-vl-max)" do
+      %w[qwen3.7-flash qwen-vl-plus qwen-vl-max].each do |m|
+        result = described_class.calculate_cost(
+          model: m,
+          usage: { prompt_tokens: 1_000_000, completion_tokens: 0 }
+        )
+        expect(result[:cost]).to be_nil,   "expected N/A for #{m}, got #{result[:cost]}"
+        expect(result[:source]).to be_nil, "expected nil source for #{m}"
+      end
+    end
+  end
+
   # Guards against accidentally billing unrelated model names at a
   # neighbouring model's rate — the anchored ^...$ regex in normalize_model_name
   # should reject fuzzy matches and fall through to nil (cost=N/A).


### PR DESCRIPTION
### Why
The Qwen pricing entries were based on a wrong assumption ("displayed ≤ actual" + an implicit 20% cache estimate). That logic doesn't match how Alibaba actually prices Qwen models. This PR re-grounds the whole Qwen section on official international-site rates: real cache prices where published, and promo (time-limited discount) prices applied as-is.

### Pricing model (per 1M tokens, USD)
For each model: `input / output / cache write (explicit cache creation) / cache read (explicit cache hit)`. Models without an official cache price fall back to the input rate for both cache write and read.

| model              | discount        | input | output | cache write | cache read |
|--------------------|-----------------|-------|--------|-------------|------------|
| qwen3.7-max        | 50% off, flat   | 1.25  | 3.75   | 1.5625      | 0.125      |
| qwen3.7-plus       | 20% off         | 0.32  | 1.28   | 0.40        | 0.032      |
| qwen3.6-plus       | none            | 0.50  | 3.00   | 0.625       | 0.05       |
| qwen3.6-max        | none (preview)  | 1.30  | 7.80   | 1.625       | 0.13       |
| qwen3.6-27b        | none, no cache  | 0.60  | 3.60   | 0.60        | 0.60       |
| qwen3.6-flash      | none            | 0.25  | 1.50   | 0.3125      | 0.025      |
| qwen-plus-latest   | none, no cache  | 0.40  | 1.20   | 0.40        | 0.40       |
| qwen3-vl-plus      | none            | 0.60  | 4.80   | 0.75        | 0.06       |

### Model lifecycle changes
- **Removed `qwen3.7-flash`** — does not exist.
- **Removed `qwen-vl-max`** — being retired.
- **Renamed `qwen-vl-plus` → `qwen3-vl-plus`** — the old `qwen-vl-plus` is being retired; the new model is `qwen3-vl-plus`. `normalize_model_name` patterns updated accordingly.

### Notes for future maintainers
- Several rates above are **promo (time-limited discount)** prices. When a promo ends, these MUST be updated to the post-promo rate. Each entry carries an inline comment marking its discount factor and tier.
- `cache write` = explicit cache **creation** price; `cache read` = explicit cache **hit** price. Models with no official cache price use the input rate for both.

### Tests
Added a `Qwen pricing` describe block (6 examples) covering:
- official-rate billing (qwen3.6-plus → 3.41)
- flat discounted rate, no tiers (qwen3.7-max → 5.00)
- explicit-cache discounted rate (qwen3.7-plus → 0.0576)
- no-cache-price fallback to input (qwen3.6-27b → 0.060)
- rename mapping (qwen3-vl-plus → 0.60)
- retired models return N/A (qwen3.7-flash / qwen-vl-plus / qwen-vl-max)
