### PR TITLE
fix(web): hot-reload workspace file list on file changes (C-5638)

### DIFF
--- a/lib/clacky/web/workspace.js
+++ b/lib/clacky/web/workspace.js
@@ -10,6 +10,8 @@ const Workspace = (() => {
   let _sessionId   = null;
   let _workingDir  = null;
   let _open        = false;
+  let _refreshTimer = null;          // debounce timer for hot-reload refresh
+  const REFRESH_DEBOUNCE_MS = 600;
 
   const $ = (id) => document.getElementById(id);
   const t = (key) => (typeof I18n !== "undefined" ? I18n.t(key) : key);
@@ -84,11 +86,12 @@ const Workspace = (() => {
     node.appendChild(row);
 
     if (entry.type === "dir") {
+      node.dataset.dirPath = entry.path;
       const children = document.createElement("div");
       children.className = "wt-children";
       children.style.display = "none";
       node.appendChild(children);
-      row.addEventListener("click", () => toggleDir(entry, caret, children));
+      row.addEventListener("click", () => toggleDir(entry, caret, children, node));
     } else {
       row.addEventListener("click", () => downloadFile(entry));
     }
@@ -96,15 +99,17 @@ const Workspace = (() => {
     return node;
   }
 
-  async function toggleDir(entry, caret, children) {
+  async function toggleDir(entry, caret, children, node) {
     const isOpen = caret.classList.contains("open");
     if (isOpen) {
       caret.classList.remove("open");
       children.style.display = "none";
+      if (node) delete node.dataset.expanded;
       return;
     }
     caret.classList.add("open");
     children.style.display = "";
+    if (node) node.dataset.expanded = "1";
     if (children.dataset.loaded === "1") return;
 
     children.innerHTML = `<div class="wt-loading">${t("workspace.loading")}</div>`;
@@ -143,18 +148,82 @@ const Workspace = (() => {
     }
   }
 
-  async function loadRoot() {
+  // Collect the relative paths of all currently-expanded directories,
+  // so a hot-reload refresh can restore the same expand state.
+  function collectExpandedPaths() {
+    const tree = $("workspace-tree");
+    if (!tree) return [];
+    return Array.from(tree.querySelectorAll('.wt-node[data-expanded="1"]'))
+      .map((n) => n.dataset.dirPath)
+      .filter((p) => p != null);
+  }
+
+  // Expand a directory node programmatically (no user click), loading its
+  // children if not already loaded. Returns once children are in the DOM.
+  async function expandNode(node) {
+    if (!node || node.dataset.dirPath == null) return;
+    const caret    = node.querySelector(":scope > .wt-row > .wt-caret");
+    const children = node.querySelector(":scope > .wt-children");
+    if (!caret || !children) return;
+    caret.classList.add("open");
+    children.style.display = "";
+    node.dataset.expanded = "1";
+    if (children.dataset.loaded === "1") return;
+    children.innerHTML = `<div class="wt-loading">${t("workspace.loading")}</div>`;
+    try {
+      const entries = await fetchEntries(node.dataset.dirPath);
+      children.innerHTML = "";
+      children.appendChild(renderEntries(entries));
+      children.dataset.loaded = "1";
+    } catch (err) {
+      console.error("workspace load failed:", err);
+      children.innerHTML = `<div class="wt-error">${t("workspace.error")}</div>`;
+    }
+  }
+
+  // Re-expand the given relative paths, shallowest first, so parents are
+  // loaded before their children. Paths that no longer exist are skipped.
+  async function restoreExpandedPaths(paths) {
+    if (!paths || !paths.length) return;
+    const tree = $("workspace-tree");
+    if (!tree) return;
+    const ordered = paths.slice().sort((a, b) => a.split("/").length - b.split("/").length);
+    for (const p of ordered) {
+      const node = tree.querySelector(`.wt-node[data-dir-path="${CSS.escape(p)}"]`);
+      if (node) await expandNode(node);
+    }
+  }
+
+  async function loadRoot({ preserveExpanded = false } = {}) {
     const tree = $("workspace-tree");
     if (!tree || !_sessionId) return;
-    tree.innerHTML = `<div class="wt-loading">${t("workspace.loading")}</div>`;
+    const expanded = preserveExpanded ? collectExpandedPaths() : [];
+    // Silent refresh keeps the current tree visible; only the initial / manual
+    // load shows the loading placeholder to avoid a flicker on every reload.
+    if (!preserveExpanded) {
+      tree.innerHTML = `<div class="wt-loading">${t("workspace.loading")}</div>`;
+    }
     try {
       const entries = await fetchEntries("");
       tree.innerHTML = "";
       tree.appendChild(renderEntries(entries));
+      if (expanded.length) await restoreExpandedPaths(expanded);
     } catch (err) {
       console.error("workspace load failed:", err);
       tree.innerHTML = `<div class="wt-error">${t("workspace.error")}</div>`;
     }
+  }
+
+  // Debounced hot-reload entry point. Called on WS tool_result / complete
+  // events. No-ops when the panel is closed or there is no session, so it
+  // costs nothing when not visible.
+  function refreshIfOpen() {
+    if (!_open || !_sessionId) return;
+    if (_refreshTimer) clearTimeout(_refreshTimer);
+    _refreshTimer = setTimeout(() => {
+      _refreshTimer = null;
+      loadRoot({ preserveExpanded: true });
+    }, REFRESH_DEBOUNCE_MS);
   }
 
   function applyOpenState() {
@@ -196,7 +265,11 @@ const Workspace = (() => {
       _workingDir = newDir;
       applyOpenState();
       if (changed && _open && _sessionId) loadRoot();
-    }
+    },
+
+    // Called from ws-dispatcher on file-mutating WS events (tool_result /
+    // complete). Debounced; no-ops when the panel is closed.
+    refreshIfOpen,
   };
 })();
 

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -175,6 +175,9 @@ WS.onEvent(ev => {
     case "tool_result":
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.appendToolResult(ev.result);
+      // Hot-reload the workspace file list — a tool may have created /
+      // modified / deleted files (write, edit, terminal rm/mv, etc.).
+      if (typeof Workspace !== "undefined") Workspace.refreshIfOpen();
       break;
 
     case "tool_stdout":
@@ -235,6 +238,8 @@ WS.onEvent(ev => {
         }
         Sessions.appendInfo(`✓ ${mainLine}`, cacheLine);
       }
+      // Final safety refresh of the workspace file list when the task ends.
+      if (typeof Workspace !== "undefined") Workspace.refreshIfOpen();
       break;
 
     case "request_feedback":


### PR DESCRIPTION
## Problem

The workspace panel on the right of the main session view shows the working directory's file list, but after the AI creates / modifies / deletes files via tools, the list does not refresh automatically. Users have to manually click the refresh button or switch sessions to see the latest state, which breaks the flow.

## Fix

Reuse the existing WebSocket channel — no new backend events or dependencies:

- `ws-dispatcher.js`: call `Workspace.refreshIfOpen()` at the end of the `tool_result` case (covers all file operations: write/edit/terminal rm/mv, etc.) and the `complete` case (end-of-task fallback).
- `workspace.js`: add `refreshIfOpen()` with a 600ms debounce that no-ops when the panel is closed or there is no session (zero cost when hidden). `loadRoot({preserveExpanded})` silently rebuilds the tree while **keeping expanded directories open**, shows no loading placeholder, and updates only the `#workspace-tree` region — it never reloads the whole page.

Cross-module communication uses the existing public method `Workspace.refreshIfOpen()` rather than introducing a CustomEvent. No new UI event type is added, so the history-replay trio is not involved.

Known blind spot: files edited manually in an IDE / external terminal do not trigger a refresh (WS events only come from AI tool calls); the manual refresh button remains as a fallback, which is the intended scope.

## Test

- `node --check` passes on both JS files.
- `bundle exec rspec spec/code_style_spec.rb`: 170 examples, 0 failures.
- Manual test with a local server: after the AI creates / modifies / deletes files, the workspace list refreshes automatically, expanded directories stay expanded, and the chat area and scroll position are unaffected.