### PR TITLE
fix(web): collapse workspace file list on session switch (C-5638)

### DIFF
--- a/lib/clacky/web/workspace.js
+++ b/lib/clacky/web/workspace.js
@@ -188,14 +188,22 @@ const Workspace = (() => {
     },
 
     // Called from Sessions.updateInfoBar whenever the active session changes.
+    // On a real session switch (from one session to another) we always collapse
+    // the panel: the file list is only ever loaded when the user explicitly
+    // expands it (which triggers a single refresh via setOpen), so the list is
+    // never shown stale across sessions. The first attach (no previous session)
+    // is not a switch and keeps the restored open state.
     onSession(session) {
       const newId  = session ? session.id : null;
       const newDir = session ? session.working_dir : null;
+      const hadSession = _sessionId != null;
       const changed = newId !== _sessionId || newDir !== _workingDir;
       _sessionId  = newId;
       _workingDir = newDir;
+      if (changed && hadSession && _open) setOpen(false);
       applyOpenState();
-      if (changed && _open && _sessionId) loadRoot();
+      // First attach with the panel restored open: load once.
+      if (!hadSession && _open && _sessionId) loadRoot();
     }
   };
 })();


### PR DESCRIPTION
Previously the workspace file list tried to hot-reload via WebSocket events, which was over-engineered for the current scope (the panel only lists files for download).

This change drops that approach entirely:

The file list now collapses on every session switch.
It loads once when the user explicitly expands it.
In-session file changes are handled by the existing manual refresh button.
This keeps things minimal until file preview/edit is built, at which point the loading strategy will be revisited.