### PR TITLE
fix(web): fix usage tooltip total value showing unreadable blue background (C-5633)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -9069,11 +9069,14 @@ body.setup-mode[data-theme="dark"] {
 .tooltip-date {
   font-weight: 600;
   color: var(--color-text-primary);
+  white-space: nowrap;
 }
-.tooltip-total {
+.tooltip-total-value {
   font-size: 0.875rem;
   color: var(--color-accent);
-  font-weight: 500;
+  font-weight: 600;
+  white-space: nowrap;
+  margin-left: 0.75rem;
 }
 .tooltip-row {
   display: flex;

--- a/lib/clacky/web/billing.js
+++ b/lib/clacky/web/billing.js
@@ -226,7 +226,7 @@ const Billing = (() => {
       tooltip.innerHTML = `
         <div class="tooltip-header">
           <span class="tooltip-date">${date}</span>
-          <span class="tooltip-total">${total} tokens</span>
+          <span class="tooltip-total-value">${total} tokens</span>
         </div>
         <div class="tooltip-row">
           <span class="tooltip-dot tooltip-total"></span>


### PR DESCRIPTION
## Problem

In **My Data → Usage**, hovering over a bar in the "Usage Details" chart shows a tooltip whose header (date + total value) renders the total value with a blue background and dark text, making it hard to read. With large numbers (hundreds of M tokens) the value can also crowd the date next to it.

## Root cause

The class name `tooltip-total` was reused for two different elements:

- the **header total value text** (`<span class="tooltip-total">… tokens</span>`)
- the **legend dot** in each detail row (`<span class="tooltip-dot tooltip-total">`)

The dot rule `.tooltip-total { background: #6366f1; }` was therefore also applied to the header value text, producing the blue background / dark text combination. This has nothing to do with text selection.

## Fix

- Rename the header value to a dedicated class `tooltip-total-value`, decoupling it from the dot styling, so the blue background no longer leaks onto the text.
- Add `white-space: nowrap` and spacing to the date/value so large numbers don't wrap or crowd the date.

## Test

Hard refresh, go to Usage Details, hover over a bar: the total value now shows as plain accent-colored text with no background, readable even with large numbers.