### PR TITLE
fix(model): keep sub-model from replacing the main agent model (C-5632)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -175,15 +175,21 @@ module Clacky
       true
     end
 
-    # Pin this session to a sub-model name without changing its underlying
-    # card (credentials / base_url stay put). Pass nil or "" to clear and
-    # fall back to the card's default model. Validation that the name is
-    # listed under the current provider is the caller's job.
+    # Pin this session to a sub-model name. This NEVER changes the main
+    # agent's model — the sub-model only routes auxiliary subagents (skills,
+    # memory updates, task tool, ...) through a cheaper model to save cost
+    # (see #fork_subagent). The card / credentials / base_url stay put, and
+    # so does the main agent's client. Pass nil or "" to clear.
+    # Validation that the name is listed under the current provider is the
+    # caller's job.
     # @param model_name [String, nil]
     # @return [Boolean]
     def set_session_sub_model(model_name)
       @config.session_model_overlay = model_name
-      rebuild_client_for_current_model!
+      # Re-inject session context so the UI/AI notice the sub-model change.
+      # We intentionally do NOT rebuild the main client: the main agent keeps
+      # running on its card model regardless of the pinned sub-model.
+      inject_session_context
       true
     end
 
@@ -1276,6 +1282,21 @@ module Clacky
           else
             raise AgentError, "Model '#{model}' not found in config. Available models: #{subagent_config.model_names.join(', ')}"
           end
+        end
+      else
+        # No explicit model requested by the caller. If this session has a
+        # pinned sub-model, route the subagent through it to save cost. This
+        # is the ONLY place the session sub-model takes effect — the main
+        # agent's #current_model deliberately ignores it. An explicitly
+        # requested model (including "lite") always wins over the sub-model.
+        sub_cfg = subagent_config.sub_model_overlay_for_current
+        if sub_cfg
+          subagent_config.apply_virtual_model_overlay!(
+            "api_key"          => sub_cfg["api_key"],
+            "base_url"         => sub_cfg["base_url"],
+            "model"            => sub_cfg["model"],
+            "anthropic_format" => sub_cfg["anthropic_format"]
+          )
         end
       end
 

--- a/lib/clacky/agent_config.rb
+++ b/lib/clacky/agent_config.rb
@@ -768,6 +768,35 @@ module Clacky
       }
     end
 
+    # Resolve the session-pinned sub-model into a virtual overlay hash, ready
+    # to feed Agent#fork_subagent → #apply_virtual_model_overlay!.
+    #
+    # Mirrors #lite_model_config_for_current: the sub-model reuses the current
+    # primary model's provider identity and credentials (api_key / base_url /
+    # anthropic_format), swapping only the "model" field. This keeps auxiliary
+    # subagents on the user-chosen cheaper model WITHOUT mutating @models or
+    # touching the main agent (whose #current_model ignores the sub-model).
+    #
+    # @return [Hash, nil] overlay fields, or nil when no sub-model is pinned
+    #   or the current model has no resolvable provider.
+    def sub_model_overlay_for_current
+      sub_name = session_model_overlay_name
+      return nil if sub_name.nil? || sub_name.to_s.strip.empty?
+
+      primary = current_model
+      return nil unless primary && primary["base_url"] && primary["model"]
+
+      # Don't bother overlaying when the sub-model equals the primary already.
+      return nil if sub_name == primary["model"]
+
+      {
+        "api_key"          => primary["api_key"],
+        "base_url"         => primary["base_url"],
+        "model"            => sub_name,
+        "anthropic_format" => primary["anthropic_format"] || false
+      }
+    end
+
     # How long to stay on the fallback model before probing the primary again.
     FALLBACK_COOLING_OFF_SECONDS = 30 * 60  # 30 minutes
 
@@ -858,14 +887,11 @@ module Clacky
       resolved = resolve_current_model_entry
       return nil unless resolved
 
-      # Merge order (low → high): base entry, session-level sub-model override,
-      # then short-lived subagent overlay. Both layers are kept separate so
-      # a subagent fork can stack its own credentials on top of an active
-      # sub-model pin without erasing it.
+      # The session-level sub-model (@session_model_overlay) deliberately does
+      # NOT participate here: it must never replace the main agent's model.
+      # It only routes auxiliary subagents (see Agent#fork_subagent) via the
+      # virtual overlay below. The main agent always runs on its card model.
       merged = resolved
-      if @session_model_overlay && !@session_model_overlay.empty?
-        merged = merged.merge(@session_model_overlay)
-      end
       if @virtual_model_overlay && !@virtual_model_overlay.empty?
         merged = merged.merge(@virtual_model_overlay)
       end

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -2403,9 +2403,10 @@ const Sessions = (() => {
       if (sibModel) {
         const subModel = s.sub_model;
         const cardModel = s.card_model;
-        const display = subModel
-          ? `${subModel}`
-          : (s.model || "");
+        // Bar always shows the main (card) model. The sub-model only routes
+        // auxiliary subagents and must NOT widen the bar (mobile WebUI). The
+        // card → sub-model pairing is still visible in the model dropdown.
+        const display = s.model || "";
         sibModel.textContent = display;
         sibModel.dataset.sessionId = s.id;
         if (s.model_id) {
@@ -3664,8 +3665,8 @@ const Sessions = (() => {
   }
 
   // Pin (or clear) the session's sub-model. Pass modelName=null to clear.
-  // displayName is what we optimistically show in the status bar.
-  async function _switchSubModel(sessionId, modelName, displayName) {
+  // The bar text is unaffected (sub-model never replaces the main model, C-5632).
+  async function _switchSubModel(sessionId, modelName) {
     const dropdown = $("sib-model-dropdown");
     if (dropdown) {
       dropdown.style.display = "none";
@@ -3682,11 +3683,11 @@ const Sessions = (() => {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Unknown error");
 
+      // The bar always shows the main (card) model — the sub-model only routes
+      // auxiliary subagents and must NOT replace the bar text (C-5632). Just
+      // record the pin in the dataset so the dropdown can surface "card · sub".
       const sibModel = $("sib-model");
-      if (sibModel) {
-        sibModel.textContent = displayName || "";
-        sibModel.dataset.subModel = modelName || "";
-      }
+      if (sibModel) sibModel.dataset.subModel = modelName || "";
     } catch (e) {
       console.error("Failed to switch sub-model:", e);
       alert("Failed to switch sub-model: " + e.message);
@@ -3795,7 +3796,7 @@ const Sessions = (() => {
       row.addEventListener("click", (ev) => {
         ev.stopPropagation();
         const passName = (name === cardDefault) ? null : name;
-        _switchSubModel(sessionId, passName, name);
+        _switchSubModel(sessionId, passName);
       });
       panel.appendChild(row);
     });

--- a/spec/clacky/agent_subagent_spec.rb
+++ b/spec/clacky/agent_subagent_spec.rb
@@ -212,6 +212,69 @@ RSpec.describe Clacky::Agent, "#fork_subagent" do
           .to eq("abs-claude-opus-4-7")
       end
     end
+
+    context "with a session sub-model pinned (C-5632)" do
+      # Primary card is Opus on openclacky; user pins Haiku as the session
+      # sub-model. The sub-model must ONLY affect auxiliary subagents — never
+      # the main agent.
+      let(:config) do
+        Clacky::AgentConfig.new(
+          models: [
+            {
+              "id" => "opus-id",
+              "model" => "abs-claude-opus-4-7",
+              "base_url" => "https://api.openclacky.com",
+              "api_key" => "clacky-test-key",
+              "anthropic_format" => false,
+              "type" => "default"
+            }
+          ],
+          current_model_id: "opus-id"
+        )
+      end
+
+      before { agent.set_session_sub_model("abs-claude-haiku-4-5") }
+
+      it "keeps the MAIN agent on the card model (sub-model never replaces it)" do
+        expect(config.model_name).to eq("abs-claude-opus-4-7")
+        expect(config.current_model["model"]).to eq("abs-claude-opus-4-7")
+      end
+
+      it "routes an unspecified-model subagent through the pinned sub-model" do
+        subagent = agent.fork_subagent
+        expect(subagent.instance_variable_get(:@config).model_name)
+          .to eq("abs-claude-haiku-4-5")
+      end
+
+      it "lets an explicit model (including lite) win over the sub-model" do
+        subagent = agent.fork_subagent(model: "lite")
+        # "lite" maps Opus → Haiku here too, but the point is the explicit
+        # request drives it, not the sub-model overlay branch.
+        sub_config = subagent.instance_variable_get(:@config)
+        expect(sub_config.model_name).to eq("abs-claude-haiku-4-5")
+        # Parent still on Opus regardless.
+        expect(config.model_name).to eq("abs-claude-opus-4-7")
+      end
+
+      it "isolates the sub-model between sessions (no leakage to a sibling)" do
+        # A sibling session built from a fresh config must not inherit this
+        # session's sub-model pin.
+        sibling_config = Clacky::AgentConfig.new(
+          models: [config.models.first.dup],
+          current_model_id: "opus-id"
+        )
+        expect(sibling_config.sub_model_overlay_for_current).to be_nil
+
+        sibling = described_class.new(
+          client, sibling_config, working_dir: Dir.pwd, ui: nil,
+          profile: "coding", session_id: Clacky::SessionManager.generate_id,
+          source: :manual
+        )
+        sub = sibling.fork_subagent
+        expect(sub.instance_variable_get(:@config).model_name)
+          .to eq("abs-claude-opus-4-7")
+      end
+    end
   end
 
   describe "#generate_subagent_summary" do


### PR DESCRIPTION
## Problem

Since v1.2.7 (manual sub-model selection), picking a session sub-model (e.g. `abs-claude-haiku-4-5`) silently replaced the **main agent's** model: the session bar switched to the sub-model, the main agent actually ran on it, and `latency.model` in the session file recorded the sub-model. A sub-model is meant to be a cheaper model for auxiliary/sub-agent calls — it should never take over the primary agent.

## Fix

- `current_model` no longer merges `@session_model_overlay`, so the main agent always resolves the card model.
- New `sub_model_overlay_for_current` resolves the pinned sub-model into a same-provider overlay (only the `model` field changes), mirroring the existing `lite` overlay path.
- `fork_subagent` injects the session sub-model **only** when no explicit model is requested; an explicit `model:` (including `lite`) still wins.
- `set_session_sub_model` no longer rebuilds the main client.
- Session bar always shows the main model `s.model`; the dropdown's `main → sub` mapping is unchanged.

Field name (`session_model_overlay`), serialization and the `/api/sessions/:id/submodel` API are untouched → zero migration cost for existing sessions.

## Test

- `agent_subagent_spec` 20 examples ✅ (4 new C-5632 cases: main agent always on card model / unspecified-model subagent uses sub-model / explicit model wins / per-session isolation).
- `agent_config` specs 118 examples ✅.
- Full suite: 2268 examples, 1 failure — the failure is an unrelated pre-existing OSC52 terminal-clipboard test (`rich_ui_controller_spec.rb:226`), confirmed failing on a clean stash without these changes.