### PR TITLE
fix: improve directory picker interactions and indentation

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -4135,8 +4135,7 @@ body {
   font-family: var(--font-mono, monospace);
   transition: border-color 0.15s;
   box-sizing: border-box;
-}
-.dir-picker-input:focus {
+}.dir-picker-input:focus {
   outline: none;
   border-color: var(--color-accent);
 }
@@ -4157,8 +4156,7 @@ body {
 .dp-path-container {
   flex-shrink: 0;
   position: relative;
-}
-/* Autocomplete dropdown */
+}/* Autocomplete dropdown */
 .dp-autocomplete {
   position: absolute;
   top: 100%;

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -3808,7 +3808,6 @@ const Sessions = (() => {
   // ── Tree-based directory picker ─────────────────────────────────────────
   const ICON_FOLDER_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>';
   const ICON_CARET_SVG  = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>';
-
   function showDirectoryPicker(currentDir, sessionId) {
     return new Promise((resolve) => {
       const t = (key, fallback) => {
@@ -3831,21 +3830,22 @@ const Sessions = (() => {
         const dirs = (data.entries || []).filter(e => e.type === "dir");
         // Convert relative paths to absolute
         dirs.forEach(d => {
-          d.absPath = absolute ? d.path : (rootDir.replace(/\/+$/, "") + "/" + d.path);
+          // Strip leading slashes from path to avoid double slashes
+          const cleanPath = d.path.replace(/^\/+/, "");
+          d.absPath = absolute ? ("/" + cleanPath) : (rootDir.replace(/\/+$/, "") + "/" + cleanPath);
           d.absolute = absolute; // Store absolute flag for child expansion
-        });
-        return dirs;
+        });        return dirs;
       }
 
       // Build a tree node for a directory entry
       function buildDirNode(entry, depth) {
         const node = document.createElement("div");
         node.className = "dp-node";
+        node.dataset.depth = depth; // Store depth for child expansion
 
         const row = document.createElement("div");
         row.className = "dp-row";
         row.style.paddingLeft = `${depth * 16 + 8}px`;
-
         const caret = document.createElement("span");
         caret.className = "dp-caret";
         caret.innerHTML = ICON_CARET_SVG;
@@ -3868,34 +3868,30 @@ const Sessions = (() => {
         children.style.display = "none";
         node.appendChild(children);
 
-        // Single-click: expand/collapse; Double-click: select directory
+        // Single-click: select directory (show path) + expand/collapse
         let clickTimer = null;
         row.addEventListener("click", (e) => {
           e.stopPropagation();
           if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
           clickTimer = setTimeout(() => {
             clickTimer = null;
+            // Select this directory
+            modal.querySelectorAll(".dp-row.selected").forEach(el => el.classList.remove("selected"));
+            row.classList.add("selected");
+            selectedPath = entry.absPath;
+            pathInput.value = entry.absPath;
+            // Also expand/collapse
             toggleExpand(entry, caret, children);
           }, 250);
         });
 
+        // Double-click: enter directory (navigate into it)
         row.addEventListener("dblclick", (e) => {
           e.stopPropagation();
           if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
-          // Select this directory
-          modal.querySelectorAll(".dp-row.selected").forEach(el => el.classList.remove("selected"));
-          row.classList.add("selected");
-          selectedPath = entry.absPath;
-          pathInput.value = entry.absPath;
+          // Enter this directory - reload tree with this as root
+          loadTreeForPath(entry.absPath, entry.absolute);
         });
-
-        // Caret click to toggle expand
-        caret.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
-          await toggleExpand(entry, caret, children);
-        });
-
         return node;
       }
 
@@ -3907,9 +3903,8 @@ const Sessions = (() => {
           return;
         }
         caret.classList.add("open");
-        children.style.display = "";
+        children.style.display = "flex";
         if (children.dataset.loaded === "1") return;
-
         children.innerHTML = `<div class="dp-loading">${t("sib.dir.loading", "加载中...")}</div>`;
         try {
           const dirs = await fetchDirs(entry.path, entry.absolute);
@@ -3917,11 +3912,13 @@ const Sessions = (() => {
           if (dirs.length === 0) {
             children.innerHTML = `<div class="dp-empty">${t("sib.dir.empty", "空目录")}</div>`;
           } else {
+            const parentNode = children.parentElement;
+            const parentDepth = parseInt(parentNode?.dataset?.depth) || 0;
+            const childDepth = parentDepth + 1;
             const frag = document.createDocumentFragment();
-            dirs.forEach(d => frag.appendChild(buildDirNode(d, (entry.path.split("/").length))));
+            dirs.forEach(d => frag.appendChild(buildDirNode(d, childDepth)));
             children.appendChild(frag);
-          }
-          children.dataset.loaded = "1";
+          }          children.dataset.loaded = "1";
         } catch (err) {
           console.error("dir picker load failed:", err);
           children.innerHTML = `<div class="dp-error">${t("sib.dir.loadError", "加载失败")}</div>`;
@@ -3996,7 +3993,6 @@ const Sessions = (() => {
       pathContainer.appendChild(autocomplete);
 
       body.appendChild(pathContainer);
-
       // Tree container
       const treeContainer = document.createElement("div");
       treeContainer.className = "dp-tree";


### PR DESCRIPTION
- Fix double slash in path display when expanding directories
- Change single-click to select directory (show path) + expand/collapse
- Change double-click to enter directory (navigate into it)
- Fix child directory indentation by properly tracking depth
- Remove separate caret click handler to avoid event conflicts
- Use explicit "flex" display value when expanding directories
