### PR TITLE
fix: auto-inject CLACKY_ACCESS_KEY in channel setup scripts

### DIFF
--- a/lib/clacky/default_skills/channel-manager/discord_setup.rb
+++ b/lib/clacky/default_skills/channel-manager/discord_setup.rb
@@ -100,6 +100,10 @@ def save_to_server(bot_token:)
   req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
   req.body = body
 
+  # Auto-inject access key from environment if available
+  access_key = ENV["CLACKY_ACCESS_KEY"]
+  req["Authorization"] = "Bearer #{access_key}" if access_key && !access_key.empty?
+
   res  = http.request(req)
   data = JSON.parse(res.body) rescue {}
 
@@ -107,7 +111,6 @@ def save_to_server(bot_token:)
     fail!("Failed to save Discord config: #{data["error"] || res.body.slice(0, 200)}")
   end
 end
-
 mode_idx = ARGV.index { |a| a.start_with?("--") }
 mode     = mode_idx ? ARGV[mode_idx] : nil
 arg      = mode_idx ? ARGV[mode_idx + 1] : nil

--- a/lib/clacky/default_skills/channel-manager/weixin_setup.rb
+++ b/lib/clacky/default_skills/channel-manager/weixin_setup.rb
@@ -154,6 +154,10 @@ def save_to_server(token:, base_url:)
   req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
   req.body = body
 
+  # Auto-inject access key from environment if available
+  access_key = ENV["CLACKY_ACCESS_KEY"]
+  req["Authorization"] = "Bearer #{access_key}" if access_key && !access_key.empty?
+
   res  = http.request(req)
   data = JSON.parse(res.body) rescue {}
 
@@ -165,7 +169,6 @@ def save_to_server(token:, base_url:)
 rescue => e
   fail!("Could not reach clacky server: #{e.message}")
 end
-
 # ---------------------------------------------------------------------------
 # Long-poll loop (shared by all modes)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Previously, weixin_setup.rb and discord_setup.rb failed with "Unauthorized: access key required" when calling the server API to save credentials, because the Authorization header was missing.

Now both scripts automatically read CLACKY_ACCESS_KEY from the environment and inject it as a Bearer token, so credential saving works without manual intervention.

Files changed:

weixin_setup.rb — add Authorization header in save_to_server discord_setup.rb — add Authorization header in save_to_server
