### PR TITLE
Feat: cron entry sort and running indicator

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -27,6 +27,16 @@ const Sessions = (() => {
   let   _searchOpen        = false;   // is the search panel visible?
   let   _cronView          = false;  // are we in the cron sub-view?
   let   _cronCount         = 0;      // total cron sessions from server
+  // ── Cron sub-view independent pagination (commit 2) ──────────────────────
+  // The folded cron sub-view paginates *independently* of the outer list so
+  // that "Load more" inside it never advances the outer list's cursor, and so
+  // all cron sessions can be loaded even when they're sparse across the mixed
+  // outer pages. Cron rows fetched here are pushed into the shared `_sessions`
+  // array (with dedup), so WS updates / patch / remove keep working unchanged;
+  // we only track a separate cursor + hasMore/loading flags for the sub-view.
+  let   _cronBefore        = null;   // cursor: oldest cron created_at loaded into the sub-view
+  let   _cronHasMore       = false;  // are there older cron sessions to load?
+  let   _cronLoadingMore   = false;
   let   _pendingRunTaskId  = null;  // session_id waiting to send "run_task" after subscribe
   let   _pendingMessage    = null;  // { session_id, content } — slash command to send after subscribe
   // Buffer for tool_stdout lines that arrive before history has finished rendering.
@@ -1584,12 +1594,13 @@ const Sessions = (() => {
   }
 
   // Build the unified load-more button.
-  function _makeLoadMoreBtn() {
+  function _makeLoadMoreBtn(cron = false) {
     const btn = document.createElement("button");
     btn.className   = "btn-load-more-sessions";
-    btn.disabled    = _loadingMore;
-    btn.textContent = _loadingMore ? I18n.t("sessions.loadingMore") : I18n.t("sessions.loadMore");
-    btn.onclick = () => Sessions.loadMore();
+    const loading   = cron ? _cronLoadingMore : _loadingMore;
+    btn.disabled    = loading;
+    btn.textContent = loading ? I18n.t("sessions.loadingMore") : I18n.t("sessions.loadMore");
+    btn.onclick = () => cron ? Sessions.loadMoreCron() : Sessions.loadMore();
     return btn;
   }
 
@@ -1698,6 +1709,10 @@ const Sessions = (() => {
     el.onclick = () => {
       _cronView = true;
       Sessions.renderList();
+      // Method A: always (re-)load the freshest first page of cron sessions
+      // on entering the sub-view. Independent cursor — never touches the
+      // outer list's pagination.
+      Sessions.loadMoreCron({ reset: true });
     };
     container.appendChild(el);
   }
@@ -1881,6 +1896,53 @@ const Sessions = (() => {
         _loadingMore = false;
         Sessions.renderList({ skipScrollToActive: true });
         // Restore scroll position so the user stays where they were
+        if (sidebarList) sidebarList.scrollTop = savedScrollTop;
+      }
+    },
+
+    /** Cron sub-view pagination — independent cursor, does NOT touch the outer
+     *  list's `_hasMore` / `loadMore` cursor. Fetches the next page of cron
+     *  sessions (type=cron) and pushes them into the shared `_sessions` array
+     *  (deduped), so WS patch/remove/add keep working unchanged. Only the
+     *  sub-view's own cursor + flags advance. Pass `reset:true` to start over
+     *  from the newest cron page (used on entering the sub-view). */
+    async loadMoreCron({ reset = false } = {}) {
+      if (_cronLoadingMore) return;
+      if (!reset && !_cronHasMore) return;
+      _cronLoadingMore = true;
+      if (reset) { _cronBefore = null; _cronHasMore = false; }
+
+      const sidebarList = document.getElementById("sidebar-list");
+      const savedScrollTop = sidebarList ? sidebarList.scrollTop : 0;
+      Sessions.renderList({ skipScrollToActive: true });
+
+      try {
+        const params = new URLSearchParams({ limit: "20", type: "cron" });
+        if (_cronBefore) params.set("before", _cronBefore);
+
+        const res  = await fetch(`/api/sessions?${params}`);
+        if (!res.ok) return;
+        const data = await res.json();
+
+        const rows = data.sessions || [];
+        rows.forEach(s => {
+          if (!_sessions.find(x => x.id === s.id)) _sessions.push(s);
+        });
+        // Advance cursor to the oldest cron created_at in THIS batch (exclude
+        // pinned — backend returns all pinned on the first page, bypassing
+        // pagination, so their created_at must not drag the cursor back).
+        const oldest = rows.reduce((min, s) => {
+          if (s.pinned || !s.created_at) return min;
+          return (!min || s.created_at < min) ? s.created_at : min;
+        }, null);
+        if (oldest) _cronBefore = oldest;
+        _cronHasMore = !!data.has_more;
+        if (data.cron_count != null) _cronCount = data.cron_count;
+      } catch (e) {
+        console.error("loadMoreCron error:", e);
+      } finally {
+        _cronLoadingMore = false;
+        Sessions.renderList({ skipScrollToActive: true });
         if (sidebarList) sidebarList.scrollTop = savedScrollTop;
       }
     },
@@ -2112,21 +2174,14 @@ const Sessions = (() => {
         // Filter active: show all matching results flat, no group entry
         visible.forEach(s => _renderSessionItem(list, s));
       } else if (isCronView) {
-        // Cron sub-view: show only cron sessions.
-        // If none are loaded yet, auto-load more pages until we find them.
-        if (cronSessions.length === 0) {
-          if (_hasMore && !_loadingMore) {
-            list.innerHTML = `<div class="session-empty">${I18n.t("sessions.cronLoading")}</div>`;
-            Sessions.loadMore();  // async — will call renderList() again when done
-            return;               // skip empty-state / load-more button for now
-          }
-          if (_loadingMore) {
-            // A loadMore() call is already in flight (its own renderList call
-            // reached us).  Keep the loading indicator so the user never sees
-            // the "no sessions" empty state during the gap.
-            list.innerHTML = `<div class="session-empty">${I18n.t("sessions.cronLoading")}</div>`;
-            return;
-          }
+        // Cron sub-view: show only cron sessions, paginated independently via
+        // loadMoreCron() (the first page is fetched on entering the view).
+        // We never call the outer loadMore() here, so the outer list's cursor
+        // is left untouched. While the first page is in flight and nothing is
+        // loaded yet, show a loading placeholder instead of the empty state.
+        if (cronSessions.length === 0 && _cronLoadingMore) {
+          list.innerHTML = `<div class="session-empty">${I18n.t("sessions.cronLoading")}</div>`;
+          return;
         }
         cronSessions.forEach(s => _renderSessionItem(list, s));
       } else if (_cronCount > 0) {
@@ -2169,7 +2224,11 @@ const Sessions = (() => {
         list.innerHTML = `<div class="session-empty">${I18n.t("sessions.empty")}</div>`;
       }
 
-      if (_hasMore) list.appendChild(_makeLoadMoreBtn());
+      if (isCronView) {
+        if (_cronHasMore) list.appendChild(_makeLoadMoreBtn(true));
+      } else if (_hasMore) {
+        list.appendChild(_makeLoadMoreBtn());
+      }
 
       // Scroll active session into view so the sidebar always shows the current session.
       if (!skipScrollToActive) {

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1679,13 +1679,17 @@ const Sessions = (() => {
   }
 
   // ── Cron group entry (renders the folded "Scheduled Tasks" entry) ─────
-  function _renderCronGroupItem(container, count) {
+  // `hasRunning` mirrors a normal session's status dot: show the green
+  // (running) dot only when any folded cron session is currently running,
+  // and render no dot at all when the group is idle.
+  function _renderCronGroupItem(container, count, hasRunning = false) {
     const el = document.createElement("div");
     el.className = "session-item cron-group-item";
+    const dotHtml = hasRunning ? `<span class="session-dot dot-running"></span>` : "";
     el.innerHTML = `
       <div class="session-body">
         <div class="session-name">
-          <span class="session-dot dot-idle" style="display:inline-block;opacity:0.6"></span>
+          ${dotHtml}
           <span class="session-name__text">📋 ${I18n.t("sessions.cronGroup")} (${count})</span>
         </div>
         <div class="session-meta">${I18n.t("sessions.cronGroupMeta", { n: count })}</div>
@@ -2097,7 +2101,6 @@ const Sessions = (() => {
       const hasActiveFilter = !!(_filter.q || _filter.type || _filter.date);
       const isCronView      = _cronView && !hasActiveFilter;
       const cronSessions    = visible.filter(s => s.source === "cron");
-      const nonCronSessions = visible.filter(s => s.source !== "cron");
 
       // Update chat-section header based on view mode
       _updateChatHeader(isCronView);
@@ -2127,9 +2130,35 @@ const Sessions = (() => {
         }
         cronSessions.forEach(s => _renderSessionItem(list, s));
       } else if (_cronCount > 0) {
-        // Normal list view: group entry (uses total count, not just loaded) + non-cron sessions
-        _renderCronGroupItem(list, _cronCount);
-        nonCronSessions.forEach(s => _renderSessionItem(list, s));
+        // Normal list view: the cron group entry is a *virtual* row that
+        // participates in the time-ordering instead of being pinned to the
+        // top. We walk the already-sorted `visible` list and drop the group
+        // entry at the position of the newest (first-encountered) cron
+        // session — so it sits exactly where the latest folded cron task
+        // would sort by created_at. Pinning is intentionally ignored for the
+        // entry itself: a pinned cron session only takes effect *inside* the
+        // folded sub-view, not on the outer entry.
+        const cronHasRunning = cronSessions.some(s => s.status === "running");
+        let cronEntryRendered = false;
+        visible.forEach(s => {
+          if (s.source === "cron") {
+            // Render the group entry once, at the first (newest) cron slot;
+            // skip every individual cron session in the flat list.
+            if (!cronEntryRendered) {
+              _renderCronGroupItem(list, _cronCount, cronHasRunning);
+              cronEntryRendered = true;
+            }
+            return;
+          }
+          _renderSessionItem(list, s);
+        });
+        // NOTE: we intentionally do NOT append a fallback entry when no cron
+        // session is loaded yet. The group entry is a virtual row that must
+        // ride along with pagination: it only appears at the sort slot of the
+        // first loaded cron session. If the newest cron lives on a later page,
+        // the entry simply shows up once that page is loaded — rather than
+        // being forced onto the bottom of page 1 (which would mislead the
+        // sort position and miss the running state of an unpaged cron).
       } else {
         // Normal list view, no cron sessions
         visible.forEach(s => _renderSessionItem(list, s));


### PR DESCRIPTION
## Problem
The folded cron group entry in the session sidebar had two sets of issues:

**Entry display (commit 1)**
- The cron group entry was pinned to a fixed position instead of participating in the time-ordering, so it didn't follow the list's sort/pagination order.
- It used a static grey dot and gave no signal when a cron session was actively running.

**Sub-view pagination (commit 2)**
- The folded cron sub-view shared the outer session list's pagination cursor, so clicking "Load more" inside it advanced the outer list's cursor and polluted the main list.
- When cron sessions were sparse across the mixed outer pages, the sub-view could not load them all — it could only show whatever cron rows happened to be in the already-loaded outer pages.

## Fix
**Entry display (commit 1)**
- Render the cron group entry as a *virtual* row that participates in the time-ordering instead of being pinned.
- Show a live running dot (`.dot-running`) when any cron session is running; drop the static grey dot.
- `cron_count` comes from the server's full count so the entry stays accurate regardless of how many cron rows are currently loaded.

**Sub-view pagination (commit 2)**
- Give the cron sub-view its own independent pagination, fully client-side (no backend change): new cursor + flags `_cronBefore` / `_cronHasMore` / `_cronLoadingMore`, separate from the outer `_hasMore` / `loadMore`.
- New `loadMoreCron({ reset })` fetches `/api/sessions?type=cron&limit=20&before=<cursor>` and pushes rows into the shared `_sessions` array (with dedup), so WS `patch` / `remove` / `add` keep working unchanged.
- Entering the sub-view (re-)loads the freshest first page via `loadMoreCron({ reset: true })`.
- `_makeLoadMoreBtn(cron)` and the bottom "Load more" button branch on view mode, so the sub-view button never touches the outer cursor.
- Removed the old logic that borrowed the outer `loadMore()` to fill the cron sub-view.

## Test
- ✅ `node --check lib/clacky/web/sessions.js` passes.
- ✅ Manually verified: cron group entry follows the list order and shows the running dot live; cron sub-view paginates independently, "Load more" loads all cron sessions without polluting the outer list, and WS running indicators stay live.