### PR TITLE
fix(web): sort recycled sessions by deleted_at instead of created_at (C-5649)

### DIFF
--- a/lib/clacky/tools/trash_manager.rb
+++ b/lib/clacky/tools/trash_manager.rb
@@ -514,7 +514,7 @@ module Clacky
           end
 
           session.merge(file_size: total)
-        end.sort_by { |s| s[:created_at] || "" }.reverse
+        end.sort_by { |s| s[:deleted_at] || s[:created_at] || "" }.reverse
       end
       private_class_method :_trash_sessions
     end


### PR DESCRIPTION
## Problem
In the recycle bin's "Session Recycle" list, soft-deleted sessions were not ordered by deletion time. Deleting sessions in order 1 → 2 → 3 produced a list whose order looked arbitrary — neither by deletion time nor by file size — making it hard to find a recently deleted session.

Root cause: `TrashManager._trash_sessions` sorted by `created_at` (creation time) instead of `deleted_at` (soft-delete time). Since trashed sessions keep their original creation timestamps, they were interleaved with each other by creation order, unrelated to when they were actually deleted.

## Fix
Sort the trash session list by `deleted_at` descending so the most recently deleted session appears first.

- `lib/clacky/tools/trash_manager.rb`: change the sort key in `_trash_sessions` from `s[:created_at]` to `s[:deleted_at]`, with `s[:created_at]` as a fallback for any legacy entries that predate the `deleted_at` stamp.

`deleted_at` is guaranteed to be written at soft-delete time (`TrashManager.soft_delete_session` stamps `deleted_at: Time.now.iso8601` before moving the session into the trash), so the new sort key is reliable; the `created_at` fallback is purely defensive for old data.

## Test
- ✅ `ruby -c lib/clacky/tools/trash_manager.rb` passes.
- ✅ Manually verified: deleting sessions in order 1 → 2 → 3 now lists them newest-deleted-first in the Session Recycle view.