### PR TITLE
fix(server): count pagination by non-cron sessions so cron no longer starves the page (C-5647)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -613,17 +613,14 @@ module Clacky
         type ||= query["profile"].to_s.strip.then { |v| v.empty? ? nil : v }
         type ||= query["source"].to_s.strip.then  { |v| v.empty? ? nil : v }
 
-        # Fetch one extra NON-PINNED row to detect has_more without a separate count query.
-        # `registry.list` always returns ALL matching pinned rows first (on the
-        # first page; `before` == nil), followed by non-pinned rows up to `limit+1`.
-        # So has_more is determined by whether the non-pinned section overflowed.
-        sessions = @registry.list(limit: limit + 1, before: before, q: q, date: date, type: type)
-
-        # Split pinned vs non-pinned to apply has_more only to the non-pinned tail.
-        pinned_part, non_pinned_part = sessions.partition { |s| s[:pinned] }
-        has_more = non_pinned_part.size > limit
-        non_pinned_part = non_pinned_part.first(limit)
-        sessions = pinned_part + non_pinned_part
+        # Fill the page by NON-CRON count (cron is folded into one virtual entry
+        # on the frontend, so it must not eat the page budget — C-5647).
+        # `registry.list` collects `limit` non-cron non-pinned rows, carries
+        # along any cron rows passed on the way, and reports has_more via
+        # page_info. ALL matching pinned rows are still returned first.
+        page_info = {}
+        sessions  = @registry.list(limit: limit, before: before, q: q, date: date, type: type, page_info: page_info)
+        has_more  = page_info[:has_more]
 
         json_response(res, 200, { sessions: sessions, has_more: has_more, cron_count: @registry.cron_count })
       end
@@ -4390,11 +4387,12 @@ module Clacky
           interrupt_session(session_id)
 
         when "list_sessions"
-          # Initial load: newest 20 sessions regardless of source/profile.
-          # Single unified query — frontend shows all in one time-sorted list.
-          page = @registry.list(limit: 21)
-          has_more = page.size > 20
-          all_sessions = page.first(20)
+          # Initial load: newest page of sessions in one time-sorted list.
+          # Page is filled by non-cron count (cron is folded into one virtual
+          # entry on the frontend and must not eat the page budget — C-5647).
+          page_info = {}
+          all_sessions = @registry.list(limit: 20, page_info: page_info)
+          has_more = page_info[:has_more]
           conn.send_json(type: "session_list", sessions: all_sessions, has_more: has_more, cron_count: @registry.cron_count)
 
         when "run_task"

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -143,7 +143,15 @@ module Clacky
       #            nil = no source filter (all sessions)
       #   profile: "general"|"coding"|nil
       #            nil = no agent_profile filter
-      #   limit:   max sessions to return (applies to NON-PINNED only; see below)
+      #   limit:   max NON-CRON sessions to return (applies to NON-PINNED only;
+      #             see below). Cron sessions encountered while filling the page
+      #             are returned too but DO NOT count against `limit` — they are
+      #             folded into a single virtual entry on the frontend, so
+      #             counting them would starve manual sessions of the page
+      #             budget (C-5647). The page is filled by walking newest-first
+      #             until `limit` non-cron rows are collected, carrying along
+      #             every cron row passed on the way (a contiguous time range,
+      #             no gaps — so the `before` cursor stays correct).
       #   before:  ISO8601 cursor — only sessions with created_at < before
       #             (also applies to NON-PINNED only; pinned items are a separate
       #             logical section, they should never be paginated away)
@@ -157,8 +165,12 @@ module Clacky
       # Ordering of the returned array:
       #   [ ...all_pinned_matching (newest-first), ...non_pinned (newest-first, limited) ]
       #
+      # page_info: optional Hash — when given, list writes page_info[:has_more]
+      #            (true when more NON-CRON non-pinned rows exist beyond `limit`).
+      #            Lets callers learn has_more without re-counting / overfetching.
+      #
       # source and profile are orthogonal — either can be nil independently.
-      def list(limit: nil, before: nil, q: nil, date: nil, type: nil, include_pinned: true)
+      def list(limit: nil, before: nil, q: nil, date: nil, type: nil, include_pinned: true, page_info: nil)
         return [] unless @session_manager
 
         live = @mutex.synchronize do
@@ -214,7 +226,36 @@ module Clacky
 
         # `before` cursor ONLY applies to non-pinned (paginated) sessions.
         non_pinned = non_pinned.select { |s| (s[:created_at] || "") < before } if before
-        non_pinned = non_pinned.first(limit) if limit
+
+        # Fill the page by NON-CRON count: walk newest-first and collect up to
+        # `limit` non-cron rows, carrying along every cron row passed on the way
+        # (cron is "free" — it doesn't consume the page budget). This stops cron
+        # sessions from starving manual ones out of the first page (C-5647).
+        # The cron type sub-view (type == "cron") wants real cron pagination, so
+        # it keeps the plain first(limit) behaviour.
+        if limit
+          if type == "cron"
+            page_info[:has_more] = non_pinned.size > limit if page_info
+            non_pinned = non_pinned.first(limit)
+          else
+            result = []
+            non_cron_seen = 0
+            more = false
+            non_pinned.each do |s|
+              if s_source(s) == "cron"
+                result << s                  # carried along, not counted
+              elsif non_cron_seen >= limit
+                more = true                  # one more non-cron exists → has_more
+                break                        # ...but don't include it
+              else
+                result << s
+                non_cron_seen += 1
+              end
+            end
+            page_info[:has_more] = more if page_info
+            non_pinned = result
+          end
+        end
 
         # Pinned section: only included on the first page (before == nil) so
         # "load more" responses don't re-send them. On first page, return ALL


### PR DESCRIPTION
# Fix session list pagination starved by cron sessions (C-5647)

## Problem

The session sidebar list paginates in pages of 20. Pagination was counted by **total** sessions (cron + non-cron), so cron sessions consumed slots on the first page.

When a user had many cron sessions, they crowded out regular (non-cron) sessions on the first page. On refresh the first page could render mostly cron entries with only a handful of non-cron sessions — making it look as if the list had not re-rendered or had stale/persisted counts.

This was compounded by a secondary symptom: deleting those few non-cron sessions could empty the visible list down to a lone "Load more" button (a hollow state).

## Root cause

`SessionRegistry#list` built each page with a flat `first(limit)` over all sessions. Cron sessions counted against the page size, so a page of 20 might contain only a few non-cron sessions even when many more existed.

## Fix

Count pagination by **non-cron** sessions instead of by total:

- **`session_registry.rb`** — `list` now accepts a `page_info:` keyword. The main-timeline pagination accumulates sessions until it has gathered `limit` non-cron sessions, collecting any cron sessions encountered along the way (so cron entries still surface) without letting them consume the page budget. `has_more` is written into `page_info`. The cron sub-view (`type == "cron"`) keeps its original `first(limit)` behavior and now also reports the previously-missing `page_info[:has_more]`.
- **`http_server.rb`** — both `api_list_sessions` and the WS `list_sessions` handler now read `page_info[:has_more]` instead of fetching `limit + 1` and trimming the tail themselves.

With the first page guaranteed to hold a full set of non-cron sessions, the "hollow list after delete" symptom no longer reproduces — so no client-side backfill is needed.

## Testing

- `session_registry_spec` — 12 examples, 0 failures
- `http_server_spec` — 57 examples, 0 failures