### PR TITLE
fix(webui): prevent copy button from overlapping assistant message text (C-5646)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -1763,7 +1763,7 @@ body {
 
 .msg-user      { background: var(--color-accent-primary); color: var(--color-button-primary-text); align-self: flex-end; white-space: pre-wrap; }
 [data-theme="dark"] .msg-user { background: var(--color-accent-hover); }
-.msg-assistant { background: var(--color-bg-tertiary); border: 1px solid var(--color-border-primary); align-self: flex-start; }
+.msg-assistant { background: var(--color-bg-tertiary); border: 1px solid var(--color-border-primary); align-self: flex-start; padding-right: 2.25rem; }
 
 /* ── Copy button on assistant messages ────────────────────────────────────
    Hidden by default, revealed on bubble hover (same pattern as .msg-time).


### PR DESCRIPTION
## Problem
Copy button (📋) positioned at top-right of assistant bubbles (absolute, right:6px, width:26px) overlapped message text — bubble right padding was only 16px but the button occupied 0–32px from the right edge.

## Fix
Added `padding-right: 2.25rem` to `.msg-assistant`, reserving 36px on the right side so the copy button has its own clear zone and no longer overlaps text.

## Test
✅ Manual — long assistant messages no longer have trailing text obscured by the copy button.