### PR TITLE
fix(web): exclude cron sessions from session-list page quota (C-5647)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -628,7 +628,7 @@ module Clacky
         non_pinned_part = non_pinned_part.first(limit)
         sessions = pinned_part + non_pinned_part
 
-        json_response(res, 200, { sessions: sessions, has_more: has_more, cron_count: @registry.cron_count })
+        json_response(res, 200, { sessions: sessions, has_more: has_more, cron_count: @registry.cron_count, cron_has_running: @registry.cron_has_running, cron_latest_created_at: @registry.cron_latest_created_at })
       end
 
       def api_create_session(req, res)
@@ -4405,7 +4405,7 @@ module Clacky
           page = @registry.list(limit: 21)
           has_more = page.size > 20
           all_sessions = page.first(20)
-          conn.send_json(type: "session_list", sessions: all_sessions, has_more: has_more, cron_count: @registry.cron_count)
+          conn.send_json(type: "session_list", sessions: all_sessions, has_more: has_more, cron_count: @registry.cron_count, cron_has_running: @registry.cron_has_running, cron_latest_created_at: @registry.cron_latest_created_at)
 
         when "run_task"
           # Client sends this after subscribing to guarantee it's ready to receive

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -214,6 +214,17 @@ module Clacky
 
         # `before` cursor ONLY applies to non-pinned (paginated) sessions.
         non_pinned = non_pinned.select { |s| (s[:created_at] || "") < before } if before
+
+        # Main list view (type == nil) excludes cron sessions from the
+        # paginated tail: cron sessions are folded into a single virtual
+        # "group entry" rendered by the frontend, so letting them consume the
+        # page `limit` would starve the visible quota (e.g. 15 cron + 5 real
+        # → only 6 rows shown). Cron sessions still reach the frontend via the
+        # dedicated cron sub-view (type == "cron"), where this guard is a no-op
+        # and normal pagination applies. cron_count is computed separately and
+        # unaffected.
+        non_pinned = non_pinned.reject { |s| s_source(s) == "cron" } if type.nil?
+
         non_pinned = non_pinned.first(limit) if limit
 
         # Pinned section: only included on the first page (before == nil) so
@@ -318,6 +329,36 @@ module Clacky
       def cron_count
         return 0 unless @session_manager
         @session_manager.all_sessions.count { |s| s_source(s) == "cron" }
+      end
+
+      # Whether ANY cron session is currently running. The main list view folds
+      # all cron sessions into one virtual "group entry"; its running dot can no
+      # longer be derived from per-session rows in the paginated list (cron rows
+      # are excluded from that list — see `list`). So we compute it here:
+      # take cron sessions from disk and look up their live status in memory
+      # (disk rows carry `source` but no live status; the in-memory map carries
+      # live status but no source — they join on session_id). Short-circuits on
+      # the first running cron, like a SQL EXISTS.
+      def cron_has_running
+        return false unless @session_manager
+        live = @mutex.synchronize { @sessions.transform_values { |s| s[:status] } }
+        @session_manager.all_sessions.any? do |s|
+          s_source(s) == "cron" && live[s[:session_id]] == :running
+        end
+      end
+
+      # Newest created_at among all cron sessions on disk (ISO8601 string), or
+      # nil when there are none. The main list folds cron into one virtual group
+      # entry; the frontend uses this timestamp to place that entry at the right
+      # slot in the time-sorted list — without it, removing cron rows from the
+      # paginated list would leave the entry no anchor to sort against.
+      def cron_latest_created_at
+        return nil unless @session_manager
+        @session_manager.all_sessions
+                        .select { |s| s_source(s) == "cron" }
+                        .map { |s| s[:created_at] }
+                        .compact
+                        .max
       end
 
       # Delete a session from registry (and interrupt its thread).

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -27,6 +27,8 @@ const Sessions = (() => {
   let   _searchOpen        = false;   // is the search panel visible?
   let   _cronView          = false;  // are we in the cron sub-view?
   let   _cronCount         = 0;      // total cron sessions from server
+  let   _cronHasRunning    = false;  // does any folded cron session run? (server-computed; main list excludes cron rows so this can't be derived locally)
+  let   _cronLatest        = null;   // newest cron created_at (server-computed); anchors the virtual group entry's sort slot in the main list
   // ── Cron sub-view independent pagination (commit 2) ──────────────────────
   // The folded cron sub-view paginates *independently* of the outer list so
   // that "Load more" inside it never advances the outer list's cursor, and so
@@ -1813,11 +1815,13 @@ const Sessions = (() => {
     // ── List management ───────────────────────────────────────────────────
 
     /** Populate list from initial session_list WS event (connect only). */
-    setAll(list, hasMore = false, cronCount = 0) {
+    setAll(list, hasMore = false, cronCount = 0, cronHasRunning = false, cronLatest = null) {
       _sessions.length = 0;
       _sessions.push(...list);
-      _hasMore   = !!hasMore;
-      _cronCount = cronCount;
+      _hasMore        = !!hasMore;
+      _cronCount      = cronCount;
+      _cronHasRunning = !!cronHasRunning;
+      _cronLatest     = cronLatest;
     },
 
     /** Insert a newly created session into the local list. */
@@ -1837,6 +1841,53 @@ const Sessions = (() => {
         Object.assign(s, fields);
       } else {
         _sessions.unshift({ id, ...fields });
+      }
+    },
+
+    /** Real-time running-state update for the folded cron group entry.
+     *  The main list excludes cron rows, so a cron session's session_update
+     *  must NOT be patched into `_sessions` (that would resurrect it in the
+     *  list and starve the page quota). Instead we track the group entry's
+     *  running dot from broadcast status.
+     *
+     *  A single session_update reflects only ONE cron session. Turning the dot
+     *  ON is unambiguous (this cron is running ⇒ at least one runs), and the
+     *  same event carries the cron's created_at — the newest timestamp — so we
+     *  advance the entry's sort slot at the SAME time, repositioning it
+     *  immediately instead of only after the cron finishes. Turning it OFF is
+     *  ambiguous — another cron may still run — so on an idle/stop event we
+     *  re-confirm the aggregate from the server instead of blindly clearing. */
+    applyCronRunning(isRunning, createdAt) {
+      if (isRunning) {
+        let changed = false;
+        if (createdAt && (!_cronLatest || createdAt > _cronLatest)) {
+          _cronLatest = createdAt;
+          changed = true;
+        }
+        if (!_cronHasRunning) {
+          _cronHasRunning = true;
+          changed = true;
+        }
+        if (changed) Sessions.renderList();
+      } else {
+        // Re-confirm: some OTHER cron may still be running.
+        Sessions.refreshCronRunning();
+      }
+    },
+
+    /** Lightweight re-fetch of just the cron aggregate flags (no list churn).
+     *  Used to re-confirm the group entry's running dot after a cron stops. */
+    async refreshCronRunning() {
+      try {
+        const res = await fetch("/api/sessions?limit=1");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.cron_count != null) _cronCount = data.cron_count;
+        if (data.cron_latest_created_at !== undefined) _cronLatest = data.cron_latest_created_at;
+        _cronHasRunning = !!data.cron_has_running;
+        Sessions.renderList();
+      } catch (e) {
+        console.error("refreshCronRunning error:", e);
       }
     },
 
@@ -1871,6 +1922,7 @@ const Sessions = (() => {
         // the oldest pinned one and the real last-loaded non-pinned row.
         const oldest = _sessions.reduce((min, s) => {
           if (s.pinned) return min;                       // ignore pinned
+          if (s.source === "cron") return min;            // ignore cron (folded out of main list)
           if (!s.created_at) return min;
           return (!min || s.created_at < min) ? s.created_at : min;
         }, null);
@@ -1890,6 +1942,8 @@ const Sessions = (() => {
         });
         _hasMore   = !!data.has_more;
         _cronCount = data.cron_count || 0;
+        if (data.cron_has_running != null) _cronHasRunning = !!data.cron_has_running;
+        if (data.cron_latest_created_at !== undefined) _cronLatest = data.cron_latest_created_at;
       } catch (e) {
         console.error("loadMore error:", e);
       } finally {
@@ -1938,6 +1992,8 @@ const Sessions = (() => {
         if (oldest) _cronBefore = oldest;
         _cronHasMore = !!data.has_more;
         if (data.cron_count != null) _cronCount = data.cron_count;
+        if (data.cron_has_running != null) _cronHasRunning = !!data.cron_has_running;
+        if (data.cron_latest_created_at !== undefined) _cronLatest = data.cron_latest_created_at;
       } catch (e) {
         console.error("loadMoreCron error:", e);
       } finally {
@@ -1975,6 +2031,8 @@ const Sessions = (() => {
         _sessions.push(...(data.sessions || []));
         _hasMore   = !!data.has_more;
         _cronCount = data.cron_count || 0;
+        if (data.cron_has_running != null) _cronHasRunning = !!data.cron_has_running;
+        if (data.cron_latest_created_at !== undefined) _cronLatest = data.cron_latest_created_at;
       } catch (e) {
         console.error("commitSearch error:", e);
       } finally {
@@ -2185,38 +2243,43 @@ const Sessions = (() => {
         }
         cronSessions.forEach(s => _renderSessionItem(list, s));
       } else if (_cronCount > 0) {
-        // Normal list view: the cron group entry is a *virtual* row that
-        // participates in the time-ordering instead of being pinned to the
-        // top. We walk the already-sorted `visible` list and drop the group
-        // entry at the position of the newest (first-encountered) cron
-        // session — so it sits exactly where the latest folded cron task
-        // would sort by created_at. Pinning is intentionally ignored for the
-        // entry itself: a pinned cron session only takes effect *inside* the
-        // folded sub-view, not on the outer entry.
-        const cronHasRunning = cronSessions.some(s => s.status === "running");
+        // Normal list view: the cron group entry is a *virtual* row sorted by
+        // time, not pinned to the top. The backend EXCLUDES cron rows from this
+        // paginated list (so they don't starve the page quota), handing us
+        // `_cronLatest` (newest cron created_at) and `_cronHasRunning` instead.
+        //
+        // Pinned sessions always stay at the very top, so we render them first,
+        // then drop the entry into the un-pinned tail just before the first row
+        // older than the newest cron — the slot a real cron row would sort into.
+        // `mainRows` also strips any cron rows lingering in `_sessions` from a
+        // prior cron sub-view visit; the main list shows them folded only.
+        const mainRows   = visible.filter(s => s.source !== "cron");
+        const pinnedRows = mainRows.filter(s => s.pinned);
+        const flowRows   = mainRows.filter(s => !s.pinned);
+        pinnedRows.forEach(s => _renderSessionItem(list, s));
+
         let cronEntryRendered = false;
-        visible.forEach(s => {
-          if (s.source === "cron") {
-            // Render the group entry once, at the first (newest) cron slot;
-            // skip every individual cron session in the flat list.
-            if (!cronEntryRendered) {
-              _renderCronGroupItem(list, _cronCount, cronHasRunning);
-              cronEntryRendered = true;
-            }
-            return;
+        flowRows.forEach(s => {
+          if (!cronEntryRendered && _cronLatest &&
+              (!s.created_at || s.created_at < _cronLatest)) {
+            _renderCronGroupItem(list, _cronCount, _cronHasRunning);
+            cronEntryRendered = true;
           }
           _renderSessionItem(list, s);
         });
-        // NOTE: we intentionally do NOT append a fallback entry when no cron
-        // session is loaded yet. The group entry is a virtual row that must
-        // ride along with pagination: it only appears at the sort slot of the
-        // first loaded cron session. If the newest cron lives on a later page,
-        // the entry simply shows up once that page is loaded — rather than
-        // being forced onto the bottom of page 1 (which would mislead the
-        // sort position and miss the running state of an unpaged cron).
+        // Newest cron is older than every loaded un-pinned session (or none
+        // are loaded): the entry sorts to the bottom of what's currently
+        // loaded. Only render it here when there are no more pages — otherwise
+        // it may still belong on a later page and we let it appear once that
+        // page loads, matching the pre-existing "ride along with pagination"
+        // behaviour.
+        if (!cronEntryRendered && (!_hasMore || flowRows.length === 0)) {
+          _renderCronGroupItem(list, _cronCount, _cronHasRunning);
+        }
       } else {
-        // Normal list view, no cron sessions
-        visible.forEach(s => _renderSessionItem(list, s));
+        // Normal list view, no cron sessions. Still strip any cron rows that
+        // may linger from a prior cron sub-view visit (they belong folded).
+        visible.filter(s => s.source !== "cron").forEach(s => _renderSessionItem(list, s));
       }
 
       // Empty state fallback

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -46,7 +46,7 @@ WS.onEvent(ev => {
 
     // ── Session list ───────────────────────────────────────────────────
     case "session_list": {
-      Sessions.setAll(ev.sessions || [], !!ev.has_more, ev.cron_count || 0);
+      Sessions.setAll(ev.sessions || [], !!ev.has_more, ev.cron_count || 0, !!ev.cron_has_running, ev.cron_latest_created_at || null);
       Sessions.renderList();
 
       // Restore URL hash once on initial connect; ignore subsequent session_list events.
@@ -112,6 +112,17 @@ WS.onEvent(ev => {
         if (ev.latency !== undefined) patch.latest_latency = ev.latency;
       }
       if (!sid) break;
+      // Cron sessions are folded out of the main list. A full-session update
+      // (shape 1, carries `source`) for a cron session always refreshes the
+      // group entry's running dot. If the row is NOT materialised in
+      // `_sessions` (we're not inside the cron sub-view), stop here —
+      // patching would resurrect the row and starve the page quota. If it IS
+      // present (cron sub-view loaded it), fall through to patch its own row
+      // too, so both the entry dot and the inline row update live.
+      if (ev.session && ev.session.source === "cron") {
+        Sessions.applyCronRunning(ev.session.status === "running", ev.session.created_at);
+        if (!Sessions.find(sid)) break;
+      }
       Sessions.patch(sid, patch);
       Sessions.renderList();
       if (sid === Sessions.activeId) {

--- a/spec/clacky/server/session_registry_spec.rb
+++ b/spec/clacky/server/session_registry_spec.rb
@@ -12,14 +12,14 @@ require "clacky/server/session_registry"
 RSpec.describe Clacky::Server::SessionRegistry do
   let(:default_config) { Clacky::AgentConfig.new }
 
-  def write_session_file(dir, session_id:, name:, created_at:, pinned: false)
+  def write_session_file(dir, session_id:, name:, created_at:, pinned: false, source: "manual")
     data = {
       session_id:    session_id,
       name:          name,
       created_at:    created_at,
       updated_at:    created_at,
       working_dir:   "/tmp",
-      source:        "manual",
+      source:        source,
       agent_profile: "general",
       pinned:        pinned,
       messages:      [],
@@ -227,6 +227,130 @@ RSpec.describe Clacky::Server::SessionRegistry do
       registry.each_live_agent { |id, agent, thread| seen << [id, agent, thread] }
 
       expect(seen).to be_empty
+    end
+  end
+
+  describe "cron folding (C-5647)" do
+    it "#list excludes cron sessions from the main view (type == nil)" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_manual1", name: "m1",
+                           created_at: "2026-04-01T00:00:00+00:00", source: "manual")
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+        write_session_file(dir, session_id: "sess_cron0002", name: "c2",
+                           created_at: "2026-04-03T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        ids = registry.list.map { |s| s[:id] }
+        expect(ids).to eq(["sess_manual1"])
+        expect(ids).not_to include("sess_cron0001", "sess_cron0002")
+      end
+    end
+
+    it "#list still returns cron sessions in the cron sub-view (type == 'cron')" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_manual1", name: "m1",
+                           created_at: "2026-04-01T00:00:00+00:00", source: "manual")
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        ids = registry.list(type: "cron").map { |s| s[:id] }
+        expect(ids).to eq(["sess_cron0001"])
+      end
+    end
+
+    it "#cron_count counts cron sessions regardless of the main-view exclusion" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_manual1", name: "m1",
+                           created_at: "2026-04-01T00:00:00+00:00", source: "manual")
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+        write_session_file(dir, session_id: "sess_cron0002", name: "c2",
+                           created_at: "2026-04-03T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        expect(registry.cron_count).to eq(2)
+      end
+    end
+
+    it "#cron_latest_created_at returns the newest cron created_at" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_manual1", name: "m1",
+                           created_at: "2026-04-10T00:00:00+00:00", source: "manual")
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+        write_session_file(dir, session_id: "sess_cron0002", name: "c2",
+                           created_at: "2026-04-03T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        # newest cron, NOT the newer manual session
+        expect(registry.cron_latest_created_at).to eq("2026-04-03T00:00:00+00:00")
+      end
+    end
+
+    it "#cron_latest_created_at returns nil when there are no cron sessions" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_manual1", name: "m1",
+                           created_at: "2026-04-01T00:00:00+00:00", source: "manual")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        expect(registry.cron_latest_created_at).to be_nil
+      end
+    end
+
+    it "#cron_has_running is false when no cron agent is live" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        expect(registry.cron_has_running).to be(false)
+      end
+    end
+
+    it "#cron_has_running is true when a cron session's in-memory status is running" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        registry.create(session_id: "sess_cron0001")
+        registry.update("sess_cron0001", status: :running)
+
+        expect(registry.cron_has_running).to be(true)
+      end
+    end
+
+    it "#cron_has_running is false when only a NON-cron session is running" do
+      Dir.mktmpdir("clacky_cron_spec") do |dir|
+        write_session_file(dir, session_id: "sess_manual1", name: "m1",
+                           created_at: "2026-04-01T00:00:00+00:00", source: "manual")
+        write_session_file(dir, session_id: "sess_cron0001", name: "c1",
+                           created_at: "2026-04-02T00:00:00+00:00", source: "cron")
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        registry.create(session_id: "sess_manual1")
+        registry.update("sess_manual1", status: :running)
+
+        expect(registry.cron_has_running).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

The session list paginates with a fixed window. Cron-triggered sessions and manual sessions share one list, so a burst of cron sessions starves the page quota and pushes real sessions off the first page. The folded "Scheduled Tasks" group entry also derived its running dot from whichever cron row happened to land in the window — unreliable.

## Fix

- Backend `SessionRegistry#list` excludes `source == "cron"` from the main view (`type == nil`); the cron sub-view (`type == "cron"`) is unaffected. Added two read-only aggregates `cron_has_running` / `cron_latest_created_at`, surfaced on both `/api/sessions` and the WS `session_list` payload.
- Frontend renders pinned rows first (always top), then drops the virtual group entry into the un-pinned tail at the slot the newest cron would sort into — so the entry never jumps above pinned sessions.
- A newly-started cron's `session_update` updates BOTH the running dot AND the entry's sort slot in the same render (its created_at is the newest), so the entry repositions immediately instead of only after the cron finishes.
- Turning the dot OFF is ambiguous (another cron may still run), so a cron stop re-confirms the aggregate via a lightweight refetch rather than blindly clearing it.
- A cron `session_update` only refreshes the entry's dot and is never patched into `_sessions`, so it can't resurrect into the main list and starve quota.

## Test

- `session_registry_spec`: 20 examples, 0 failures (8 new cases — main-view exclusion, sub-view retention, cron_count, cron_latest, cron_has_running).
- `node --check` passes on `sessions.js` / `ws-dispatcher.js`.
- Manual: verified pinned sessions stay on top, the group entry sorts by time, the running dot reflects live cron state, and a new cron repositions the entry immediately (no "light up first, move later" flicker).
- Note: `refreshCronRunning` fires a request per cron-idle event with no debounce; no churn observed in manual testing, left as-is to keep the change minimal.