### PR TITLE
fix(dir-picker): sync path input on directory navigation (C-5644)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -4252,10 +4252,10 @@ const Sessions = (() => {
         treeContainer.innerHTML = `<div class="dp-loading">${t("sib.dir.loading", "加载中...")}</div>`;
         if (dirPath) { pathInput.value = dirPath; selectedPath = dirPath; }
         // Auto-detect absolute mode: path is absolute and outside working directory
-        const useAbsolute = absolute || (dirPath.startsWith("/") && (!rootDir || !dirPath.startsWith(rootDir)));
+        const useAbsolute = absolute || (dirPath.startsWith("/") && (!rootDir || !(dirPath === rootDir || dirPath.startsWith(rootDir + "/"))));
         // Convert absolute path to relative path for API
         let relPath = dirPath;
-        if (!useAbsolute && rootDir && dirPath.startsWith(rootDir)) {
+        if (!useAbsolute && rootDir && (dirPath === rootDir || dirPath.startsWith(rootDir + "/"))) {
           relPath = dirPath.substring(rootDir.length).replace(/^\/+/, "");
         }
         try {
@@ -4264,7 +4264,7 @@ const Sessions = (() => {
           if (rootDir && presets.children.length === 0) {
             setupPresets();
             // Update pathInput to show absolute path
-            if (rootDir !== currentDir && !currentDir.startsWith(rootDir)) {
+            if (rootDir !== currentDir && !(currentDir === rootDir || currentDir.startsWith(rootDir + "/"))) {
               pathInput.value = rootDir;
               selectedPath = rootDir;
             }
@@ -4357,9 +4357,9 @@ const Sessions = (() => {
         }
 
         // Determine if we need absolute mode (path outside working directory)
-        const isAbsolute = parentPath.startsWith("/") && (!rootDir || !parentPath.startsWith(rootDir));
+        const isAbsolute = parentPath.startsWith("/") && (!rootDir || !(parentPath === rootDir || parentPath.startsWith(rootDir + "/")));
         let relPath = parentPath;
-        if (!isAbsolute && rootDir && parentPath.startsWith(rootDir)) {
+        if (!isAbsolute && rootDir && (parentPath === rootDir || parentPath.startsWith(rootDir + "/"))) {
           relPath = parentPath.substring(rootDir.length).replace(/^\/+/, "");
         }
 

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -4250,6 +4250,7 @@ const Sessions = (() => {
       // Load tree for a given path
       async function loadTreeForPath(dirPath, absolute = false) {
         treeContainer.innerHTML = `<div class="dp-loading">${t("sib.dir.loading", "加载中...")}</div>`;
+        if (dirPath) { pathInput.value = dirPath; selectedPath = dirPath; }
         // Auto-detect absolute mode: path is absolute and outside working directory
         const useAbsolute = absolute || (dirPath.startsWith("/") && (!rootDir || !dirPath.startsWith(rootDir)));
         // Convert absolute path to relative path for API


### PR DESCRIPTION
## Summary

Two fixes for the working directory picker modal:

### 1. Path input not syncing on directory navigation (C-5644)
Double-clicking a folder to enter a subdirectory, selecting a preset, or picking an autocomplete suggestion now updates the breadcrumb path input. Previously only single-click selection did this.

### 2. "Load failed" when selecting similarly-named directories
If the working directory was `.clacky`, selecting `.clacky.test` from the autocomplete caused a load failure. `startsWith(rootDir)` was too greedy — `.clacky.test` starts with `.clacky` as a string, so the
absolute path was incorrectly converted to a relative sub-path. Fixed with proper path-boundary checking.

## Changes
- `lib/clacky/web/sessions.js` (6 insertions, 5 deletions)

## How to test
1. Open the working directory picker → confirm the path input shows the current directory on first open
2. Double-click into a subdirectory → confirm path input updates
3. Use preset buttons → confirm path input updates
4. Use autocomplete to pick a similarly-named sibling directory (e.g. `.clacky.test` when cwd is `.clacky`) → no "load failed"