### PR TITLE
fix(server): serve history user images via proxy URL to avoid base64 replay lag (C-5653)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -45,7 +45,12 @@ module Clacky
           if url
             url
           elsif type.to_s == "image" && path && File.exist?(path.to_s)
-            Utils::FileProcessor.image_path_to_data_url(path) rescue "expired:#{name}"
+            # Serve via the /api/local-image proxy instead of inlining a base64
+            # data URL. Inlining forced a synchronous disk-read + full base64
+            # encode + downscale on every history replay (2-3s lag for sessions
+            # with downgraded text-model images). The proxy lets the browser
+            # lazy-load + cache the image, keeping the replay response tiny.
+            "/api/local-image?path=#{CGI.escape(path.to_s)}"
           elsif name
             type.to_s == "image" ? "expired:#{name}" : "pdf:#{name}"
           end


### PR DESCRIPTION
## Problem

Reopening a session that contains user-uploaded images caused a 2–3s freeze before the history rendered. `HistoryCollector#show_user_message` inlined every image as a base64 `data:` URL, forcing a synchronous disk-read + full base64 encode + downscale on **every** history replay. Sessions with text-model (downgraded) images were the worst hit, producing huge replay payloads. ✅ Confirmed root cause via regression to the image-storage path.

## Fix

Serve history user images through the existing `/api/local-image` proxy instead of inlining base64:

```ruby
"/api/local-image?path=#{CGI.escape(path.to_s)}"
```

The browser now lazy-loads + caches images (`Cache-Control: private, max-age=3600`), keeping the replay response tiny. Encoding matches the decode side (`api_serve_local_image`) and the existing `rewrite_local_image_urls` path (both `CGI.escape` / `CGI.unescape`). ✅ Only the image branch's value is changed — the `type == "image"` guard and the PDF badge branch from 0cd3cf2 are untouched (zero conflict).

## Test

- ✅ Reopened multiple image-heavy sessions — all render instantly, no lag.
- ✅ PDF history still shows correctly (0cd3cf2 fix preserved).
- ✅ `ruby -c` passes; `CGI.escape` resolves via the existing `webrick` require (no new `require` needed).