### PR TITLE
feat(media): support Alibaba DashScope (Qwen-Image) image generation

### DIFF
--- a/lib/clacky/media/base.rb
+++ b/lib/clacky/media/base.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require "base64"
 require "securerandom"
+require "faraday"
 
 module Clacky
   module Media
@@ -38,6 +39,37 @@ module Clacky
         path  = File.join(target_dir, "#{prefix}_#{ts}_#{short}.#{extension}")
         File.binwrite(path, Base64.decode64(b64_data))
         path
+      end
+
+      # Download a remote image URL and persist it under
+      # <output_dir>/assets/generated/, mirroring save_b64_image so providers
+      # that return URLs (e.g. DashScope, whose links expire after 24h) land
+      # local files at the same path shape as base64 providers.
+      # Returns the absolute path on disk, or nil if the download fails.
+      private def save_image_from_url(url, output_dir:, prefix: "img", extension: "png")
+        body = download_url(url)
+        return nil if body.nil? || body.empty?
+
+        target_dir = File.join(output_dir, "assets", "generated")
+        FileUtils.mkdir_p(target_dir)
+        ts    = Time.now.strftime("%Y%m%d_%H%M%S")
+        short = SecureRandom.hex(4)
+        path  = File.join(target_dir, "#{prefix}_#{ts}_#{short}.#{extension}")
+        File.binwrite(path, body)
+        path
+      end
+
+      # Fetch raw bytes from a URL. Isolated so specs can stub it without a
+      # live HTTP call. Returns the response body String, or nil on failure.
+      private def download_url(url)
+        conn = Faraday.new do |f|
+          f.options.timeout      = 120
+          f.options.open_timeout = 10
+        end
+        resp = conn.get(url)
+        resp.success? ? resp.body : nil
+      rescue Faraday::Error
+        nil
       end
 
       private def success_response(image:, prompt:, aspect_ratio:, provider:, extra: {})

--- a/lib/clacky/media/dashscope.rb
+++ b/lib/clacky/media/dashscope.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+require "uri"
+require_relative "base"
+
+module Clacky
+  module Media
+    # Alibaba DashScope (Qwen-Image) image generation provider.
+    #
+    # DashScope is NOT an OpenAI-compatible image API. It has its own
+    # endpoint, request envelope and response schema:
+    #
+    #   POST <host>/api/v1/services/aigc/multimodal-generation/generation
+    #   Authorization: Bearer <key>
+    #   { "model": "qwen-image-2.0-pro",
+    #     "input":      { "messages": [ { "role": "user",
+    #                                     "content": [ { "text": "<prompt>" } ] } ] },
+    #     "parameters": { "size": "2048*2048", "n": 1,
+    #                     "prompt_extend": true, "watermark": false } }
+    #
+    #   => { "output": { "choices": [ { "message": { "content": [
+    #          { "image": "https://...png?Expires=..." } ] } } ] },
+    #        "usage": { "width": 2048, "height": 2048, "image_count": 1 } }
+    #
+    # The image link expires after 24h, so we download and persist it under
+    # <output_dir>/assets/generated/ (via Base#save_image_from_url), matching
+    # the on-disk shape of the base64 providers.
+    #
+    # Routing: Generator sends any base_url under *.aliyuncs.com here. We
+    # derive the real generation endpoint from the host so users can paste
+    # the compatible-mode base_url (…/compatible-mode/v1) they already use
+    # for Qwen text models and still get working image generation.
+    class DashScope < Base
+      GENERATION_PATH = "/api/v1/services/aigc/multimodal-generation/generation"
+
+      # aspect_ratio -> "<width>*<height>" (DashScope uses '*' not 'x').
+      # qwen-image-2.0 / -plus / -max share these recommended resolutions;
+      # the 2.0 series accepts arbitrary sizes within 512*512..2048*2048,
+      # the max/plus series only accept a fixed set, so we stick to values
+      # that are valid for every family.
+      ASPECT_TO_SIZE_V2 = {
+        "landscape" => "2688*1536", # 16:9
+        "square"    => "2048*2048", # 1:1
+        "portrait"  => "1536*2688"  # 9:16
+      }.freeze
+
+      ASPECT_TO_SIZE_MAX_PLUS = {
+        "landscape" => "1664*928",  # 16:9
+        "square"    => "1328*1328", # 1:1
+        "portrait"  => "928*1664"   # 9:16
+      }.freeze
+
+      DEFAULT_ASPECT = "landscape"
+      PROVIDER_ID    = "qwen"
+
+      def generate_image(prompt:, aspect_ratio: DEFAULT_ASPECT, output_dir: nil, n: 1, **_kwargs)
+        aspect = size_table.key?(aspect_ratio) ? aspect_ratio : DEFAULT_ASPECT
+        size   = size_table[aspect]
+
+        if prompt.to_s.strip.empty?
+          return error_response(
+            error: "Prompt is required and must be a non-empty string",
+            error_type: "invalid_argument",
+            provider: PROVIDER_ID,
+            aspect_ratio: aspect
+          )
+        end
+
+        if @api_key.to_s.empty?
+          return error_response(
+            error: "api_key not configured for image model '#{@model}'",
+            error_type: "auth_required",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        payload = {
+          model: @model,
+          input: {
+            messages: [
+              { role: "user", content: [{ text: prompt }] }
+            ]
+          },
+          parameters: {
+            size: size,
+            n: n,
+            prompt_extend: true,
+            watermark: false
+          }
+        }
+
+        begin
+          response = connection.post(GENERATION_PATH) do |req|
+            req.headers["Content-Type"]  = "application/json"
+            req.headers["Authorization"] = "Bearer #{@api_key}"
+            req.body = JSON.generate(payload)
+          end
+        rescue Faraday::Error => e
+          return error_response(
+            error: "HTTP request failed: #{e.message}",
+            error_type: "network_error",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        body = parse_json(response.body)
+        unless body.is_a?(Hash)
+          return error_response(
+            error: "Invalid JSON response from upstream",
+            error_type: "invalid_response",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        # DashScope reports business failures via top-level code/message,
+        # sometimes alongside a non-2xx status, sometimes 200.
+        if body["code"] && !body["code"].to_s.empty?
+          return error_response(
+            error: "Upstream error #{body["code"]}: #{body["message"]}",
+            error_type: "api_error",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        unless response.success?
+          return error_response(
+            error: "Upstream #{response.status}: #{truncate(response.body, 500)}",
+            error_type: "api_error",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        image_url = extract_image_url(body)
+        if image_url.nil?
+          return error_response(
+            error: "Upstream returned no image data",
+            error_type: "empty_response",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        local_path = save_image_from_url(image_url, output_dir: output_dir || Dir.pwd, prefix: "img")
+        if local_path.nil?
+          return error_response(
+            error: "Failed to download generated image from #{image_url}",
+            error_type: "download_failed",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect
+          )
+        end
+
+        usage = body["usage"]
+        success_response(
+          image: local_path,
+          prompt: prompt,
+          aspect_ratio: aspect,
+          provider: PROVIDER_ID,
+          extra: {
+            "size"      => size,
+            "usage"     => usage,
+            "request_id" => body["request_id"]
+          }.compact
+        )
+      end
+
+      # qwen-image-max / qwen-image-plus accept only the fixed resolution set;
+      # everything else (qwen-image-2.0 family, plain qwen-image) uses the 2.0
+      # recommended sizes.
+      private def size_table
+        if @model.to_s.match?(/qwen-image-(max|plus)/i)
+          ASPECT_TO_SIZE_MAX_PLUS
+        else
+          ASPECT_TO_SIZE_V2
+        end
+      end
+
+      # output.choices[].message.content[].image -> first image URL
+      private def extract_image_url(body)
+        choices = body.dig("output", "choices")
+        return nil unless choices.is_a?(Array)
+
+        choices.each do |choice|
+          content = choice.dig("message", "content")
+          next unless content.is_a?(Array)
+
+          content.each do |block|
+            img = block.is_a?(Hash) ? block["image"] : nil
+            return img if img.is_a?(String) && !img.empty?
+          end
+        end
+        nil
+      end
+
+      private def connection
+        Faraday.new(url: endpoint_base) do |f|
+          f.options.timeout      = 240
+          f.options.open_timeout = 10
+        end
+      end
+
+      # Derive the API root (scheme + host) from the configured base_url,
+      # discarding any path the user pasted (e.g. /compatible-mode/v1). The
+      # generation path is then appended by #connection.post. Falls back to
+      # the mainland host if the configured URL can't be parsed.
+      private def endpoint_base
+        uri = URI.parse(@base_url.to_s)
+        if uri.scheme && uri.host
+          "#{uri.scheme}://#{uri.host}"
+        else
+          "https://dashscope.aliyuncs.com"
+        end
+      rescue URI::InvalidURIError
+        "https://dashscope.aliyuncs.com"
+      end
+
+      private def parse_json(body)
+        JSON.parse(body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      private def truncate(str, max)
+        s = str.to_s
+        s.length > max ? "#{s[0, max]}..." : s
+      end
+    end
+  end
+end

--- a/lib/clacky/media/generator.rb
+++ b/lib/clacky/media/generator.rb
@@ -2,6 +2,7 @@
 
 require_relative "openai_compat"
 require_relative "gemini"
+require_relative "dashscope"
 
 module Clacky
   module Media
@@ -20,6 +21,17 @@ module Clacky
       GOOGLE_NATIVE_HOSTS = [
         "generativelanguage.googleapis.com",
         "aiplatform.googleapis.com"
+      ].freeze
+
+      # Hosts that speak Alibaba's native DashScope (Qwen-Image) API instead
+      # of an OpenAI-compatible facade. Matched as a substring so every
+      # regional variant (dashscope / dashscope-intl / dashscope-us, and the
+      # Singapore *.maas.aliyuncs.com workspace hosts) is caught. Third-party
+      # aggregators (SiliconFlow, OpenRouter, …) that re-expose qwen-image
+      # behind an OpenAI-compatible endpoint are NOT under aliyuncs.com, so
+      # they correctly keep going through OpenAICompat.
+      DASHSCOPE_NATIVE_HOSTS = [
+        "aliyuncs.com"
       ].freeze
 
       # @param agent_config [Clacky::AgentConfig]
@@ -60,6 +72,10 @@ module Clacky
       # Routing rules:
       #   • base_url points directly at a Google AI Studio host → Gemini
       #     (native /v1beta/models/<m>:generateContent schema).
+      #   • base_url points at an Alibaba DashScope host (*.aliyuncs.com) →
+      #     DashScope (native /api/v1/.../multimodal-generation schema for
+      #     Qwen-Image). Third-party aggregators re-exposing qwen-image behind
+      #     an OpenAI-compatible facade are NOT on aliyuncs.com and fall through.
       #   • everything else → OpenAICompat. This covers OpenAI itself, the
       #     openclacky gateway, OpenRouter, and any third-party proxy that
       #     re-exposes Gemini / Imagen / DALL-E behind /v1/images/generations.
@@ -69,6 +85,8 @@ module Clacky
         url = entry["base_url"].to_s
         if GOOGLE_NATIVE_HOSTS.any? { |host| url.include?(host) }
           Gemini.new(entry)
+        elsif DASHSCOPE_NATIVE_HOSTS.any? { |host| url.include?(host) }
+          DashScope.new(entry)
         else
           OpenAICompat.new(entry)
         end

--- a/spec/clacky/media/dashscope_spec.rb
+++ b/spec/clacky/media/dashscope_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "clacky/media/dashscope"
+
+RSpec.describe Clacky::Media::DashScope do
+  let(:entry) do
+    {
+      "model"    => "qwen-image-2.0-pro",
+      "base_url" => "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "api_key"  => "sk-test-key"
+    }
+  end
+  let(:provider) { described_class.new(entry) }
+
+  let(:captured) { {} }
+  let(:fake_conn) { instance_double(Faraday::Connection) }
+  let(:fake_response) { instance_double(Faraday::Response, success?: true, status: 200, body: response_body) }
+
+  before do
+    allow(provider).to receive(:connection).and_return(fake_conn)
+    allow(fake_conn).to receive(:post) do |path, &blk|
+      captured[:path] = path
+      req = double("req")
+      allow(req).to receive(:headers).and_return({})
+      allow(req).to receive(:body=) { |b| captured[:body] = b }
+      blk.call(req)
+      fake_response
+    end
+    # avoid real network for the URL download step
+    allow(provider).to receive(:download_url).and_return("PNG_BYTES")
+  end
+
+  describe "#generate_image" do
+    let(:response_body) do
+      JSON.generate({
+        "output" => {
+          "choices" => [
+            { "finish_reason" => "stop",
+              "message" => { "role" => "assistant",
+                             "content" => [{ "image" => "https://oss.example.com/x.png?Expires=1" }] } }
+          ]
+        },
+        "usage"      => { "width" => 2048, "height" => 2048, "image_count" => 1 },
+        "request_id" => "req-123"
+      })
+    end
+
+    it "posts the DashScope generation envelope and saves the downloaded image" do
+      Dir.mktmpdir do |tmp|
+        result = provider.generate_image(prompt: "a cute cat", aspect_ratio: "square", output_dir: tmp)
+
+        # endpoint path (host is handled by Faraday base url)
+        expect(captured[:path]).to eq("/api/v1/services/aigc/multimodal-generation/generation")
+
+        # request envelope
+        sent = JSON.parse(captured[:body])
+        expect(sent["model"]).to eq("qwen-image-2.0-pro")
+        expect(sent.dig("input", "messages", 0, "role")).to eq("user")
+        expect(sent.dig("input", "messages", 0, "content", 0, "text")).to eq("a cute cat")
+        expect(sent.dig("parameters", "size")).to eq("2048*2048")
+        expect(sent.dig("parameters", "n")).to eq(1)
+        expect(sent.dig("parameters", "prompt_extend")).to be true
+        expect(sent.dig("parameters", "watermark")).to be false
+
+        # response
+        expect(result["success"]).to be true
+        expect(result["image"]).to start_with(File.join(tmp, "assets", "generated"))
+        expect(File.binread(result["image"])).to eq("PNG_BYTES")
+        expect(result["provider"]).to eq("qwen")
+        expect(result["model"]).to eq("qwen-image-2.0-pro")
+        expect(result["size"]).to eq("2048*2048")
+        expect(result["request_id"]).to eq("req-123")
+      end
+    end
+
+    it "maps landscape/portrait to qwen-image-2.0 recommended sizes" do
+      Dir.mktmpdir do |tmp|
+        expect(provider.generate_image(prompt: "x", aspect_ratio: "landscape", output_dir: tmp)["size"]).to eq("2688*1536")
+        expect(provider.generate_image(prompt: "x", aspect_ratio: "portrait", output_dir: tmp)["size"]).to eq("1536*2688")
+      end
+    end
+
+    it "uses the fixed resolution set for qwen-image-max models" do
+      max_provider = described_class.new(entry.merge("model" => "qwen-image-max"))
+      allow(max_provider).to receive(:connection).and_return(fake_conn)
+      allow(max_provider).to receive(:download_url).and_return("PNG_BYTES")
+      Dir.mktmpdir do |tmp|
+        result = max_provider.generate_image(prompt: "x", aspect_ratio: "landscape", output_dir: tmp)
+        expect(result["size"]).to eq("1664*928")
+        expect(JSON.parse(captured[:body]).dig("parameters", "size")).to eq("1664*928")
+      end
+    end
+
+    it "defaults to landscape for an unknown aspect_ratio" do
+      Dir.mktmpdir do |tmp|
+        result = provider.generate_image(prompt: "x", aspect_ratio: "panoramic", output_dir: tmp)
+        expect(result["aspect_ratio"]).to eq("landscape")
+      end
+    end
+  end
+
+  describe "validation" do
+    let(:response_body) { "{}" }
+
+    it "rejects an empty prompt without calling upstream" do
+      expect(fake_conn).not_to receive(:post)
+      result = provider.generate_image(prompt: "   ", output_dir: Dir.pwd)
+      expect(result["success"]).to be false
+      expect(result["error_type"]).to eq("invalid_argument")
+    end
+
+    it "rejects a missing api_key without calling upstream" do
+      no_key = described_class.new(entry.merge("api_key" => ""))
+      allow(no_key).to receive(:connection).and_return(fake_conn)
+      expect(fake_conn).not_to receive(:post)
+      result = no_key.generate_image(prompt: "x", output_dir: Dir.pwd)
+      expect(result["success"]).to be false
+      expect(result["error_type"]).to eq("auth_required")
+    end
+  end
+
+  describe "error handling" do
+    context "with a DashScope business error payload" do
+      let(:response_body) { JSON.generate({ "code" => "InvalidParameter", "message" => "num_images_per_prompt must be 1", "request_id" => "r1" }) }
+
+      it "surfaces code and message as an api_error" do
+        result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("api_error")
+        expect(result["error"]).to include("InvalidParameter")
+        expect(result["error"]).to include("num_images_per_prompt")
+      end
+    end
+
+    context "with an empty choices payload" do
+      let(:response_body) { JSON.generate({ "output" => { "choices" => [] } }) }
+
+      it "returns empty_response" do
+        result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("empty_response")
+      end
+    end
+
+    context "when the image download fails" do
+      let(:response_body) do
+        JSON.generate({ "output" => { "choices" => [{ "message" => { "content" => [{ "image" => "https://oss.example.com/x.png" }] } }] } })
+      end
+
+      it "returns download_failed" do
+        allow(provider).to receive(:download_url).and_return(nil)
+        result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("download_failed")
+      end
+    end
+
+    context "with invalid JSON" do
+      let(:response_body) { "<html>500</html>" }
+
+      it "returns invalid_response" do
+        result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("invalid_response")
+      end
+    end
+  end
+
+  describe "#endpoint_base" do
+    it "derives scheme+host, discarding the pasted compatible-mode path" do
+      expect(provider.send(:endpoint_base)).to eq("https://dashscope.aliyuncs.com")
+    end
+
+    it "handles the intl host" do
+      p = described_class.new(entry.merge("base_url" => "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"))
+      expect(p.send(:endpoint_base)).to eq("https://dashscope-intl.aliyuncs.com")
+    end
+  end
+end

--- a/spec/clacky/media/generator_spec.rb
+++ b/spec/clacky/media/generator_spec.rb
@@ -45,6 +45,39 @@ RSpec.describe Clacky::Media::Generator do
         )
         expect(result["success"]).to be true
       end
+
+      it "routes an aliyuncs.com base_url to DashScope" do
+        image_entry = {
+          "model"    => "qwen-image-2.0-pro",
+          "type"     => "image",
+          "base_url" => "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          "api_key"  => "sk-test"
+        }
+        config = Clacky::AgentConfig.new(models: [image_entry])
+
+        fake_provider = instance_double(Clacky::Media::DashScope)
+        expect(Clacky::Media::DashScope).to receive(:new).and_return(fake_provider)
+        expect(fake_provider).to receive(:generate_image).and_return({ "success" => true })
+
+        described_class.new(config).generate_image(prompt: "a cat", output_dir: "/tmp/work")
+      end
+
+      it "routes a third-party aggregator (non-aliyuncs) qwen-image to OpenAICompat, not DashScope" do
+        image_entry = {
+          "model"    => "Qwen/Qwen-Image",
+          "type"     => "image",
+          "base_url" => "https://api.siliconflow.cn/v1",
+          "api_key"  => "sk-test"
+        }
+        config = Clacky::AgentConfig.new(models: [image_entry])
+
+        fake_provider = instance_double(Clacky::Media::OpenAICompat)
+        expect(Clacky::Media::DashScope).not_to receive(:new)
+        expect(Clacky::Media::OpenAICompat).to receive(:new).and_return(fake_provider)
+        expect(fake_provider).to receive(:generate_image).and_return({ "success" => true })
+
+        described_class.new(config).generate_image(prompt: "a cat", output_dir: "/tmp/work")
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

Configuring a Qwen-Image (`qwen-image-2.0` / `-max` / `-plus`) model for image generation failed. The media `Generator` only had two routes — Google-native hosts → `Gemini`, everything else → `OpenAICompat` (OpenAI `/images/generations`). But DashScope is **not** OpenAI-compatible: it uses a different endpoint, request envelope and response schema, so requests against it errored out.

| | OpenAI-compatible | DashScope Qwen-Image |
|---|---|---|
| Endpoint | `<base>/images/generations` | `.../aigc/multimodal-generation/generation` |
| Request | `{model, prompt, size, n}` | `{model, input.messages[].content[].text, parameters{size,...}}` |
| Response | `data[].b64_json / url` | `output.choices[].message.content[].image` (URL) |
| Size | `1536x1024` | `2048*2048` |

## Fix

Add a native DashScope provider, mirroring how the Gemini native adapter is routed by host:

- ✅ New `Media::DashScope < Base` — builds the `input.messages` / `parameters` envelope, posts to the real generation endpoint, parses `output.choices[].message.content[].image`, and surfaces DashScope's top-level `{code, message}` business errors.
- ✅ Route `*.aliyuncs.com` base_urls to DashScope in `Generator#build_provider_for`. Third-party aggregators (SiliconFlow, OpenRouter, …) that re-expose qwen-image behind an OpenAI-compatible facade are **not** on `aliyuncs.com`, so they keep going through `OpenAICompat` unchanged.
- ✅ Endpoint is derived from the host only — the pasted path (`/compatible-mode/v1` or `/api/v1`) is discarded and the correct generation path is appended, so users can reuse the base_url they already have for Qwen text models.
- ✅ Aspect→size mapping is per model family (2.0 vs max/plus) using `width*height`.
- ✅ DashScope image URLs expire after 24h, so `Base#save_image_from_url` downloads and persists them under `<output_dir>/assets/generated/`, matching the on-disk shape of the base64 providers.
- ✅ Chat models (e.g. `qwen3.7-max`, `type=default`) are untouched — they never enter the media `Generator`; routing is decided by model `type`, not host.

## Test

- ✅ `ruby -c` passes for all changed files.
- ✅ New `dashscope_spec.rb`: request envelope, per-family size mapping, response parsing, business-error / empty / download-failed / invalid-JSON paths, endpoint derivation.
- ✅ `generator_spec.rb`: `aliyuncs.com` → DashScope, and a non-aliyuncs aggregator qwen-image → OpenAICompat (not DashScope).
- ✅ `spec/clacky/media/` full suite: 31 examples, 0 failures.
- ✅ Verified end-to-end against a live DashScope key (real image generated).