### PR TITLE
fix(web): drop racy post-fetch sib write in model switch (C-5661)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -4166,9 +4166,12 @@ const Sessions = (() => {
         throw new Error(data.error || "Unknown error");
       }
 
-      // Update UI optimistically (will be confirmed by session_update broadcast)
-      const sibModel = $("sib-model");
-      if (sibModel) sibModel.textContent = modelName;
+      // The status bar is updated by the session_update broadcast that the
+      // backend emits inside this same request. Don't touch sibModel here:
+      // the broadcast typically arrives BEFORE this fetch resolves (WS frame
+      // vs HTTP response on separate TCP streams), so writing here would
+      // overwrite the already-correct value with an incomplete one (this
+      // function only knows the card name, not whether a sub-model is pinned).
 
       console.log(`Switched session ${sessionId} to model ${modelName} (${modelId})`);
     } catch (e) {
@@ -4196,11 +4199,10 @@ const Sessions = (() => {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Unknown error");
 
-      const sibModel = $("sib-model");
-      if (sibModel) {
-        sibModel.textContent = displayName || "";
-        sibModel.dataset.subModel = modelName || "";
-      }
+      // The status bar is updated by the session_update broadcast that the
+      // backend emits inside this same request. Don't touch sibModel here:
+      // the broadcast typically arrives BEFORE this fetch resolves, so any
+      // write here would race with (and often overwrite) the correct value.
     } catch (e) {
       console.error("Failed to switch sub-model:", e);
       alert("Failed to switch sub-model: " + e.message);


### PR DESCRIPTION
## Problem

After picking a sub-model via quick-switch, clicking the parent card row in the main-model dropdown flipped sib back to the card name and left it stuck there until refresh — backend state was correct, only the UI lied.

## Fix

`_switchModel` / `_switchSubModel` wrote `sibModel.textContent` *after* `await fetch`, but the PATCH handler broadcasts `session_update` synchronously, so the WS frame usually beats the HTTP response and `updateInfoBar` already painted the right value — then the post-fetch write clobbered it with a partial state. Drop both writes; let the broadcast be the single source of truth.

## Test

- ✅ Repro: pin M2.7 under M3, click M3 row → sib stays on `MiniMax-M2.7`
- ✅ Switch to another card → sib updates correctly
- ✅ Pin / clear sub-model → sib reflects backend state
- ✅ Refresh / session switch → no drift