### PR TITLE
fix(ui): stop sidebar from scrolling back to active session on content updates (C-5665)

### DIFF
--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -171,7 +171,7 @@ const Router = (() => {
         // Input field remains usable so user can type while waiting
         $("btn-send").disabled = true;
         WS.send({ type: "subscribe", session_id: id });
-        Sessions.renderList();
+        Sessions.renderList({ scrollToActive: true });
         $("user-input").focus();
 
         // Load session-scoped skill list (filtered by agent profile) for slash autocomplete

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -2107,11 +2107,12 @@ const Sessions = (() => {
       if (_loadingMore || !_hasMore) return;
       _loadingMore = true;
 
-      // Save scroll position so the sidebar doesn't jump back to the active
-      // session when renderList() forces scroll-to-active.
+      // Save scroll position so the sidebar stays put across the DOM rebuild
+      // that renderList() performs (clearing + repopulating the list can reset
+      // the container's scrollTop).
       const sidebarList = document.getElementById("sidebar-list");
       const savedScrollTop = sidebarList ? sidebarList.scrollTop : 0;
-      Sessions.renderList({ skipScrollToActive: true });
+      Sessions.renderList();
 
       try {
         // Cursor: oldest activity time (updated_at, falling back to
@@ -2147,7 +2148,7 @@ const Sessions = (() => {
         console.error("loadMore error:", e);
       } finally {
         _loadingMore = false;
-        Sessions.renderList({ skipScrollToActive: true });
+        Sessions.renderList();
         // Restore scroll position so the user stays where they were
         if (sidebarList) sidebarList.scrollTop = savedScrollTop;
       }
@@ -2167,7 +2168,7 @@ const Sessions = (() => {
 
       const sidebarList = document.getElementById("sidebar-list");
       const savedScrollTop = sidebarList ? sidebarList.scrollTop : 0;
-      Sessions.renderList({ skipScrollToActive: true });
+      Sessions.renderList();
 
       try {
         const params = new URLSearchParams({ limit: "20", type: "cron" });
@@ -2197,7 +2198,7 @@ const Sessions = (() => {
         console.error("loadMoreCron error:", e);
       } finally {
         _cronLoadingMore = false;
-        Sessions.renderList({ skipScrollToActive: true });
+        Sessions.renderList();
         if (sidebarList) sidebarList.scrollTop = savedScrollTop;
       }
     },
@@ -2502,7 +2503,7 @@ const Sessions = (() => {
 
     // ── Rendering ─────────────────────────────────────────────────────────
 
-    renderList({ skipScrollToActive = false } = {}) {
+    renderList({ scrollToActive = false } = {}) {
       // Sort helper: pinned first, then most-recently-active by updated_at
       const byPinnedAndTime = (a, b) => {
         // Pinned sessions always come first
@@ -2583,8 +2584,13 @@ const Sessions = (() => {
         list.appendChild(_makeLoadMoreBtn());
       }
 
-      // Scroll active session into view so the sidebar always shows the current session.
-      if (!skipScrollToActive) {
+      // Scroll the active session into view ONLY when the caller explicitly
+      // asks for it (i.e. the user just activated/switched to this session).
+      // Plain re-renders triggered by content updates (status/cost/task changes
+      // streamed in while an agent runs) must NOT move the sidebar — otherwise
+      // they yank the list back to the active row and interrupt the user who
+      // has scrolled away to browse other sessions.
+      if (scrollToActive) {
         const activeEl = list.querySelector(".session-item.active");
         if (activeEl) {
           // If the active session is the very first item, scroll to top of the sidebar


### PR DESCRIPTION
## Problem

When the session sidebar is scrolled so the active session is out of view, any real-time content update on the right (AI replies, streaming output) yanks the sidebar back to the active session, interrupting the user's browsing.

Root cause: `renderList()` carried a scroll-to-active side effect that ran by default on *every* re-render. Real-time `session_update` events (cost/status/task) call `renderList()` on each update, so content updates — unrelated to the user switching sessions — kept forcing the sidebar back to the active row.

This is the same scroll-jump class as C-5568 (load-more), which was only patched at one call site via `skipScrollToActive: true`. The real-time update path was never covered, so the bug resurfaced here.

## Fix

Invert the scroll semantics so rendering no longer moves the viewport:

- `renderList()` no longer scrolls by default. Scroll-to-active is now opt-in via an explicit `{ scrollToActive: true }` argument.
- Only the real session-activation path (Router `case "session"`) passes `scrollToActive: true`, so scrolling happens solely when the user switches sessions — exactly its original intent.
- Removed the now-redundant `skipScrollToActive: true` flags in `loadMore` / `loadMoreCron`; default behavior already does not scroll. The `savedScrollTop` guard is kept (it protects against scrollTop drift from the DOM rebuild, orthogonal to scroll-to-active). This also closes C-5568 at the root instead of per-call-site.

## Test

- ✅ Scroll active session out of view, trigger AI output on the right → sidebar stays put.
- ✅ Click a session that is partially/fully off-screen → it scrolls into view on activation; already-visible sessions do not scroll.
- ✅ Load-more from the middle of the list → no scroll jump (C-5568 stays fixed).
- ✅ Activation scroll affects only the sidebar, not the right chat area or the page.
- ✅ Cron group enter / paginate → no scroll jump.