### PR TITLE
Fix/onboard popup blocker

### DIFF
--- a/lib/clacky/web/onboard.js
+++ b/lib/clacky/web/onboard.js
@@ -423,6 +423,8 @@ const Onboard = (() => {
     const zh = _selectedLang === "zh";
     _setDeviceError("");
 
+    const w = window.open("about:blank", "_blank", "noopener");
+
     let data;
     try {
       const res = await fetch("/api/onboard/device/start", { method: "POST" });
@@ -432,6 +434,7 @@ const Onboard = (() => {
     }
 
     if (!data || !data.ok) {
+      if (w && !w.closed) w.close();
       _setDeviceError((data && data.error) || (zh ? "无法发起登录，请稍后重试。" : "Could not start login. Please try again."));
       return;
     }
@@ -443,7 +446,11 @@ const Onboard = (() => {
     if (link && url) link.href = url;
 
     _showDevicePending(true);
-    if (url) window.open(url, "_blank", "noopener");
+    if (w && !w.closed) {
+      w.location.href = url;
+    } else {
+      window.open(url, "_blank", "noopener");
+    }
 
     _devicePolling = true;
     _pollDevice(data.device_code, (data.interval || 5) * 1000);

--- a/lib/clacky/web/onboard.js
+++ b/lib/clacky/web/onboard.js
@@ -423,7 +423,7 @@ const Onboard = (() => {
     const zh = _selectedLang === "zh";
     _setDeviceError("");
 
-    const w = window.open("about:blank", "_blank", "noopener");
+    const w = window.open("about:blank", "_blank");
 
     let data;
     try {
@@ -449,7 +449,7 @@ const Onboard = (() => {
     if (w && !w.closed) {
       w.location.href = url;
     } else {
-      window.open(url, "_blank", "noopener");
+      window.open(url, "_blank");
     }
 
     _devicePolling = true;


### PR DESCRIPTION
## Problem

On older browsers (e.g. Safari), starting OAuth device login from the onboarding welcome page opened a blank tab instead of navigating to the authorization page.

The previous fix pre-opened a tab synchronously to bypass the popup blocker, but passed `"noopener"` to `window.open`. With `noopener`, `window.open` always returns `null`, so the window handle (`w`) was lost — the code could never set `w.location.href`, and the pre-opened tab stayed on `about:blank`. The fallback `window.open(url)` ran after `await fetch`, outside the user-gesture context, and got blocked again.

## Fix

Drop `"noopener"` from both `window.open` calls so the synchronously pre-opened tab returns a usable handle. After the device code is fetched, `w.location.href` navigates that tab to `https://www.openclacky.com/device?code=<code>`.

## Test

- ✅ Safari: click "一键获取，免费开始" → tab opens and lands on the device page (no blank tab)
- ✅ Tab navigates to the correct `.../device?code=<code>` url
- ✅ Popup blocker no longer intercepts the navigation