### PR TITLE
fix: default openclacky image model to Nano Banana 2 (or-gemini-3-1-flash-image)

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -59,7 +59,7 @@ module Clacky
           "or-gemini-3-1-flash-image"  => "Nano Banana 2",
           "or-gpt-image-2"             => "GPT Image 2"
         },
-        "default_image_model" => "or-gpt-image-2",
+        "default_image_model" => "or-gemini-3-1-flash-image",
         # Video generation models served by the openclacky gateway, which
         # routes them to Vertex AI Veo (async predictLongRunning under the
         # hood; the gateway hides the polling and returns the MP4 inline).


### PR DESCRIPTION
## Problem

The default image-generation model for the openclacky provider was `or-gpt-image-2` (GPT Image 2). The intended out-of-the-box default is Nano Banana 2 (`or-gemini-3-1-flash-image`).

## Fix

Set `default_image_model` to `or-gemini-3-1-flash-image` in the openclacky preset.

## Test

- ✅ Fresh openclacky setup → 设置 → 配置副模型 → 图片生成 defaults to "Nano Banana 2" (auto mode)
- ✅ `or-gemini-3-1-flash-image` is already declared in `image_models`, so the model dropdown is unchanged