### PR TITLE
feat: brand skill delete and skeleton loading

### DIFF
--- a/lib/clacky/brand_config.rb
+++ b/lib/clacky/brand_config.rb
@@ -961,7 +961,7 @@ module Clacky
     #
     # @param skill_name [String] The slug/name of the skill to remove.
     # @return [void]
-    private def delete_brand_skill!(skill_name)
+    def delete_brand_skill!(skill_name)
       # Remove files from disk.
       skill_dir = File.join(brand_skills_dir, skill_name)
       FileUtils.rm_rf(skill_dir) if Dir.exist?(skill_dir)

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -630,6 +630,9 @@ module Clacky
           elsif method == "DELETE" && path.match?(%r{^/api/skills/[^/]+$})
             name = URI.decode_www_form_component(path.sub("/api/skills/", ""))
             api_delete_skill(name, res)
+          elsif method == "DELETE" && path.match?(%r{^/api/brand/skills/[^/]+$})
+            slug = URI.decode_www_form_component(path.sub("/api/brand/skills/", ""))
+            api_delete_brand_skill(slug, res)
           elsif method == "POST" && path.match?(%r{^/api/brand/skills/[^/]+/install$})
             slug = URI.decode_www_form_component(path.sub("/api/brand/skills/", "").sub("/install", ""))
             api_brand_skill_install(slug, req, res)
@@ -1939,6 +1942,23 @@ module Clacky
           json_response(res, 422, { ok: false, error: result[:error] })
         end
       rescue StandardError, ScriptError => e
+        json_response(res, 500, { ok: false, error: e.message })
+      end
+
+      # DELETE /api/brand/skills/:slug
+      # Uninstalls a brand skill by removing its files and metadata.
+      def api_delete_brand_skill(slug, res)
+        brand = Clacky::BrandConfig.load
+        installed = brand.installed_brand_skills
+        unless installed.key?(slug)
+          json_response(res, 404, { ok: false, error: "Brand skill '#{slug}' is not installed" })
+          return
+        end
+
+        brand.delete_brand_skill!(slug)
+        @skill_loader = Clacky::SkillLoader.new(working_dir: nil, brand_config: brand)
+        json_response(res, 200, { ok: true })
+      rescue StandardError => e
         json_response(res, 500, { ok: false, error: e.message })
       end
 

--- a/lib/clacky/web/skills.js
+++ b/lib/clacky/web/skills.js
@@ -51,7 +51,21 @@ const Skills = (() => {
   async function _loadBrandSkills() {
     const container = $("brand-skills-list");
     if (!container) return;
-    container.innerHTML = `<div class="brand-skills-loading">${I18n.t("skills.loading")}</div>`;
+    container.innerHTML = Array.from({ length: 4 }).map(() => `
+      <div class="brand-skill-card">
+        <div class="brand-skill-card-main">
+          <div class="brand-skill-info">
+            <div class="brand-skill-title">
+              <span class="skel skel-title"></span>
+              <span class="skel" style="height:1rem;width:3.5rem;border-radius:4px;"></span>
+            </div>
+            <span class="skel skel-subtitle"></span>
+          </div>
+          <div class="brand-skill-actions">
+            <span class="skel" style="height:1.75rem;width:4.5rem;border-radius:6px;"></span>
+          </div>
+        </div>
+      </div>`).join("");
 
     try {
       const res  = await fetch("/api/brand/skills");
@@ -163,11 +177,16 @@ const Skills = (() => {
         <span class="brand-skill-version latest">v${escapeHtml(latestVersion)}</span>
         <button class="btn-brand-update" data-name="${escapeHtml(name)}">${I18n.t("skills.brand.btn.update")}</button>`;
     } else {
-      // Installed and up-to-date — show version badge + "Use" button
+      // Installed and up-to-date — show version badge + "Use" + delete buttons
       const displayVersion = installedVersion || latestVersion;
       statusHtml = `
         <span class="brand-skill-version installed">v${escapeHtml(displayVersion)} ✓</span>
-        <button class="btn-brand-use" data-name="${escapeHtml(name)}">${I18n.t("skills.brand.btn.use")}</button>`;
+        <button class="btn-brand-use" data-name="${escapeHtml(name)}">${I18n.t("skills.brand.btn.use")}</button>
+        <button class="btn-skill-delete btn-brand-delete" data-name="${escapeHtml(name)}" title="${I18n.t("skills.btn.delete")}">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+          </svg>
+        </button>`;
     }
 
     // Free skills show a "Free" badge; paid (encrypted) brand skills show "Private".
@@ -196,12 +215,17 @@ const Skills = (() => {
       </div>`;
 
     // Bind install/update/use buttons
-    const installBtn = card.querySelector(".btn-brand-install");
-    const updateBtn  = card.querySelector(".btn-brand-update");
-    const useBtn     = card.querySelector(".btn-brand-use");
+    const installBtn  = card.querySelector(".btn-brand-install");
+    const updateBtn   = card.querySelector(".btn-brand-update");
+    const useBtn      = card.querySelector(".btn-brand-use");
+    const deleteBtn   = card.querySelector(".btn-brand-delete");
     if (installBtn) installBtn.addEventListener("click", () => _installBrandSkill(name, installBtn));
     if (updateBtn)  updateBtn.addEventListener("click",  () => _installBrandSkill(name, updateBtn));
     if (useBtn)     useBtn.addEventListener("click",     () => _useInstalledSkill(name));
+    if (deleteBtn)  deleteBtn.addEventListener("click",  (e) => {
+      e.stopPropagation();
+      _deleteBrandSkill(name);
+    });
 
     return card;
   }
@@ -263,6 +287,24 @@ const Skills = (() => {
       _showBrandInstallError(btn, I18n.t("skills.brand.networkRetry"));
       btn.disabled    = false;
       btn.textContent = originalText;
+    }
+  }
+
+  async function _deleteBrandSkill(name) {
+    if (!confirm(I18n.t("skills.deleteConfirm", { name }))) return;
+    try {
+      const res  = await fetch(`/api/brand/skills/${encodeURIComponent(name)}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok || !data.ok) { alert(data.error || I18n.t("skills.deleteError")); return; }
+
+      const skill = _brandSkills.find(s => s.name === name);
+      if (skill) skill.installed_version = null;
+
+      _renderBrandSkills();
+      await Skills.load();
+      Modal.toast(I18n.t("skills.deleted", { name }), "success");
+    } catch (e) {
+      console.error("[Skills] brand skill delete failed", e);
     }
   }
 


### PR DESCRIPTION
- Expose delete_brand_skill! as public method in BrandConfig
- Add DELETE /api/brand/skills/:slug endpoint in http_server
- Show delete button on installed brand skill cards
- Replace loading text with shimmer skeleton cards (reuses .skel CSS)
