### PR TITLE
feat: task prompt expandable preview and cron fix

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -1754,6 +1754,30 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.task-card-preview-expandable {
+  cursor: pointer;
+}
+.task-card-preview-expandable:hover {
+  color: var(--color-accent-primary);
+}
+.task-card-detail {
+  margin-top: 0.625rem;
+  padding: 0.625rem 0.75rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 6px;
+}
+.task-card-detail-content {
+  margin: 0;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 12rem;
+  overflow-y: auto;
+}
 .task-card-actions {
   display: flex;
   align-items: center;

--- a/lib/clacky/web/tasks.js
+++ b/lib/clacky/web/tasks.js
@@ -49,7 +49,7 @@ const Tasks = (() => {
       return isZh ? `每 ${n} 分钟` : `Every ${n} min`;
     }
     // Every N hours
-    if (isAny(min) && hour.startsWith("*/") && isAny(dom) && isAny(month) && isAny(dow)) {
+    if ((isAny(min) || isNum(min)) && hour.startsWith("*/") && isAny(dom) && isAny(month) && isAny(dow)) {
       const n = hour.slice(2);
       return isZh ? `每 ${n} 小时` : `Every ${n} hr`;
     }
@@ -108,13 +108,9 @@ const Tasks = (() => {
       ? `<span class="task-card-badge task-card-badge-paused">${I18n.t("tasks.paused")}</span>`
       : "";
 
-    const preview = (t.content || "")
-      .split("\n")
-      .map(l => l.trim())
-      .find(l => l.length > 0) || I18n.t("tasks.empty");
-    const previewText = preview.length > 120
-      ? escapeHtml(preview.slice(0, 120)) + "…"
-      : escapeHtml(preview);
+    const content = t.content || "";
+    const isTruncated = content.trim().length > 0;
+    const previewText = escapeHtml(content.replace(/\s+/g, " ").trim()) || escapeHtml(I18n.t("tasks.empty"));
 
     const toggleBtnHtml = t.scheduled ? (isPaused
       ? `<button class="task-action-btn task-btn-toggle task-btn-resume">
@@ -146,7 +142,7 @@ const Tasks = (() => {
             ${pausedBadge}
             ${schedLabel}
           </div>
-          <div class="task-card-preview">${previewText}</div>
+          <div class="task-card-preview${isTruncated ? " task-card-preview-expandable" : ""}">${previewText}</div>
         </div>
         <div class="task-card-actions">
           <button class="task-run-btn task-btn-run" title="${I18n.t("tasks.btn.run")}">
@@ -170,12 +166,24 @@ const Tasks = (() => {
             <span>${I18n.t("tasks.btn.delete")}</span>
           </button>
         </div>
-      </div>`;
+      </div>
+      ${isTruncated ? `<div class="task-card-detail" hidden><pre class="task-card-detail-content">${escapeHtml(content)}</pre></div>` : ""}`;
 
     row.querySelector(".task-btn-run").addEventListener("click", e => {
       e.stopPropagation();
       Tasks.run(t.name);
     });
+
+    if (isTruncated) {
+      const previewEl = row.querySelector(".task-card-preview");
+      const detailEl  = row.querySelector(".task-card-detail");
+      previewEl.addEventListener("click", e => {
+        e.stopPropagation();
+        const expanded = !detailEl.hidden;
+        detailEl.hidden = expanded;
+        row.classList.toggle("task-card-expanded", !expanded);
+      });
+    }
     const toggleBtn = row.querySelector(".task-btn-toggle");
     if (toggleBtn) {
       toggleBtn.addEventListener("click", e => {


### PR DESCRIPTION
- Flatten prompt content to single line for preview (CSS handles ellipsis)
- Add click-to-expand detail panel below task-card-main (buttons stay fixed)
- Style detail panel with border, bg, max-height + scroll
- Fix every-N-hours cron label: accept numeric minute field (e.g. 0 */2 * * *)
