### PR TITLE
fix(web): shield code spans before math extraction so code isn't rendered as LaTeX (C-5635)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -118,6 +118,16 @@ const Sessions = (() => {
 
     let html;
     if (typeof marked !== "undefined") {
+      // Restore KTX placeholders that ended up inside code regions back to
+      // their original literal — those weren't math, just text that happened
+      // to look like math (C-5635). Marked alone decides what's a code region.
+      const restoreMathInCode = (s) =>
+        s.replace(/\u0000KTX(\d+)\u0000/g, (_, i) => {
+          const m = math[+i];
+          if (m) m.disabled = true;     // suppress later KaTeX render
+          return m ? m.raw : "";
+        });
+
       const renderer = new marked.Renderer();
       renderer.link = function({ href, title, text }) {
         const titleAttr = title ? ` title="${title}"` : "";
@@ -126,6 +136,7 @@ const Sessions = (() => {
       // Override code block rendering: apply syntax highlighting + header with
       // language label and copy button.
       renderer.code = function({ text: code, lang }) {
+        code = restoreMathInCode(code);
         const language = (lang || "").split(/\s+/)[0]; // strip extra info after lang
         const highlighted = _highlightCode(code, language);
         const displayLang = language || "text";
@@ -146,6 +157,10 @@ const Sessions = (() => {
           `</div>`
         );
       };
+      // Inline code: same restoration, then plain <code> with HTML escaping.
+      renderer.codespan = function({ text }) {
+        return `<code>${escapeHtml(restoreMathInCode(text))}</code>`;
+      };
       try {
         html = marked.parse(prepared, { breaks: true, gfm: true, renderer });
       } catch (_) {
@@ -157,7 +172,11 @@ const Sessions = (() => {
     }
 
     if (math.length) {
-      html = html.replace(/\u0000KTX(\d+)\u0000/g, (_, i) => _renderMath(math[+i]));
+      html = html.replace(/\u0000KTX(\d+)\u0000/g, (_, i) => {
+        const m = math[+i];
+        if (!m || m.disabled) return "";   // already restored by renderer
+        return _renderMath(m);
+      });
     }
     return html;
   }
@@ -181,22 +200,30 @@ const Sessions = (() => {
 
   // Pull $$...$$, \[...\], $...$, \(...\) out of `text` and replace each with a
   // sentinel placeholder so marked won't mangle the LaTeX source. The matched
-  // segments are pushed (with display flag) onto `out` for later KaTeX rendering.
+  // segments are pushed onto `out` as { body, display, raw } for later KaTeX
+  // rendering or — if the placeholder ends up landing inside a code block /
+  // code span — restoration to the original literal by the renderer (C-5635).
+  //
+  // Why no code-block detection here: we don't want a second, parallel notion
+  // of "what counts as code" living next to marked's. Instead we extract math
+  // unconditionally, then let marked be the single arbiter — its
+  // renderer.code / renderer.codespan hooks restore any placeholder that
+  // turns out to be inside a code region (see _markedParse).
   function _extractMath(text, out, placeholder) {
     // Order matters: longest/most-specific delimiters first.
     const patterns = [
-      { re: /\$\$([\s\S]+?)\$\$/g,        display: true  },
-      { re: /\\\[([\s\S]+?)\\\]/g,    display: true  },
-      { re: /\\\(([\s\S]+?)\\\)/g,    display: false },
+      { re: /\$\$([\s\S]+?)\$\$/g,                                        display: true,  wrap: (b) => `$$${b}$$`     },
+      { re: /\\\[([\s\S]+?)\\\]/g,                                          display: true,  wrap: (b) => `\\[${b}\\]`   },
+      { re: /\\\(([\s\S]+?)\\\)/g,                                          display: false, wrap: (b) => `\\(${b}\\)`   },
       // Inline $...$: avoid $$, escaped \$, and prevent crossing newlines/blanks.
-      { re: /(^|[^\$])\$(?!\s)([^\$\n]+?)(?<!\s)\$(?!\d)/g, display: false, hasPrefix: true },
+      { re: /(^|[^\$])\$(?!\s)([^\$\n]+?)(?<!\s)\$(?!\d)/g, display: false, hasPrefix: true, wrap: (b) => `$${b}$` },
     ];
     let result = text;
-    for (const { re, display, hasPrefix } of patterns) {
+    for (const { re, display, hasPrefix, wrap } of patterns) {
       result = result.replace(re, (m, a, b) => {
         const body = hasPrefix ? b : a;
         const idx  = out.length;
-        out.push({ body, display });
+        out.push({ body, display, raw: wrap(body) });
         return (hasPrefix ? a : "") + placeholder(idx);
       });
     }


### PR DESCRIPTION
## Problem

Inside code blocks (``` ``` ``` fences and inline `code`), shell snippets with `‘or‘‘​—e.g.‘(date)`, `tooln​ame‘,‘TOOLN​AME‘,‘CMD=cmd` — were rendered as LaTeX, corrupting the displayed code (C-5635).

Root cause: `_extractMath` ran the `...` / `...` regexes over the whole text and had no idea which delimiters lived inside code regions.

## Fix

Before running the math regexes, shield code spans (fenced blocks and inline code) behind placeholders, then restore them afterwards. The math regexes never see `$`/`_` inside code. Real formulas outside code (includingmulti-line `...`) are still extracted before marked, so they render as before.

## Test

- ✅ Code fence with `(date)‘,‘tool_name`, `TOOL_NAME`, `CMD=$cmd` → literal code
- ✅ Inline code `` `$cmd` ``, `` `TOOL_NAME` `` → literal
- ✅ Multi-line `...` probability formulas → still rendered
- ✅ Inline `...`, `E=mc2` outside code → still rendered
- ✅ Mixed: `x1​` inside fence literal, `y=2` outside rendered