### PR TITLE
fix(replay): skip reasoning-only assistant messages to match live (C-5672)

### DIFF
--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -502,14 +502,24 @@ module Clacky
 
         case msg[:role].to_s
         when "assistant"
-          # Text content — prepend reasoning/thinking content wrapped in <think> tags
-          # so the Web UI renders it as a collapsible thinking block
-          text = extract_text_from_content(msg[:content]).to_s.strip
+          # Mirror the live guard at agent.rb (`if response[:content] && !response[:content].empty?`):
+          # only emit an assistant_message when the model produced actual content.
+          # Reasoning-only turns (empty content + reasoning_content + tool_calls)
+          # are silent in live mode; on replay they must stay silent too — otherwise
+          # a phantom <think>-only bubble splits consecutive tool_calls into separate
+          # UI groups, breaking the "N tool(s) used" collapse after refresh (C-5672).
+          raw_text  = extract_text_from_content(msg[:content]).to_s.strip
           reasoning = msg[:reasoning_content]
-          if reasoning && !reasoning.to_s.strip.empty?
-            text = "<think>\n#{reasoning}\n</think>\n#{text}"
+          unless raw_text.empty?
+            text = if reasoning && !reasoning.to_s.strip.empty?
+              # Prepend reasoning wrapped in <think> tags so the Web UI renders it
+              # as a collapsible thinking block.
+              "<think>\n#{reasoning}\n</think>\n#{raw_text}"
+            else
+              raw_text
+            end
+            ui.show_assistant_message(text, files: [])
           end
-          ui.show_assistant_message(text, files: []) unless text.empty?
 
           # Tool calls embedded in assistant message
           Array(msg[:tool_calls]).each do |tc|


### PR DESCRIPTION
## Problem

After refresh or session switch, tool calls that were collapsed as "N tool(s) used" while the task was running expand into N separate single-tool groups, cluttering the message stream (C-5672). Reproduces with thinking-mode models such as DeepSeek V4.

Root cause: when an LLM turn produces only `reasoning_content` plus `tool_calls` (empty `content`), the live path skips emitting an assistant_message via the guard at `agent.rb:558` (`if response[:content] && !response[:content].empty?`). On replay, however, `SessionSerializer#_replay_single_message` wraps the empty content with `<think>...</think>` and emits it anyway, producing a phantom assistant bubble between consecutive tool_calls. The Web UI breaks the tool group on every assistant_message, so one collapsed group becomes N expanded groups.

## Fix

Mirror the live guard on replay: only emit `assistant_message` when the original `content` is non-empty. Reasoning-only turns stay silent on replay, exactly as they do live. Turns with real text plus reasoning still render the thinking block as before.

session.json is untouched — the reasoning-only message is still persisted (the LLM context needs it and tool_call ids must pair with later tool_results); we simply don't feed that bubble to the UI on replay. The accompanying `tool_calls` are still emitted normally.

## Test

- ✅ DeepSeek V4 session with consecutive parallel tool_calls — refresh keeps "N tool(s) used" collapsed
- ✅ Normal thinking-mode reply (text + reasoning) — thinking block and body still render after refresh
- ✅ Plain reply without reasoning — unchanged
- ✅ Sessions without thinking-mode models — unchanged