### PR TITLE
fix(billing): remove billing-section class from sessions list to show all rows (C-5680)

### DIFF
--- a/lib/clacky/web/billing.js
+++ b/lib/clacky/web/billing.js
@@ -878,7 +878,7 @@ const Billing = (() => {
   function _renderSessionList() {
     if (!_sessions || _sessions.length === 0) {
       return `
-        <div class="billing-section billing-sessions-section">
+        <div class="billing-sessions-section">
           <h3>${I18n.t("billing.sessions") || "Sessions"}</h3>
           <div class="billing-sessions-empty">${I18n.t("billing.noSessions") || "No session data"}</div>
         </div>
@@ -926,7 +926,7 @@ const Billing = (() => {
     }).join("");
 
     return `
-      <div class="billing-section billing-sessions-section">
+      <div class="billing-sessions-section">
         <h3>${I18n.t("billing.sessions") || "Sessions"}</h3>
         <div class="billing-sessions-header">
           <span class="billing-cell billing-cell-index">#</span>


### PR DESCRIPTION
**Problem**

On the billing page, the "Session Usage" list was visually truncated to ~10 rows even when the API returned up to 100 sessions. Users picking "This Month" only saw a tiny fraction of their actual sessions, with no scrollbar and no overflow indicator.

Root cause is a CSS class collision in `_renderSessionList`. The container was rendered with `class="billing-section billing-sessions-section"`. The `.billing-section` rule is designed for the small cards inside `.billing-bottom-grid` (token / model breakdown) and pins them to `height: 16rem` with `overflow-y: auto`. The session list wrapper accidentally inherited that fixed height. `.billing-sessions-section` then redeclares `overflow: hidden`, which overrides the `auto` scroll, so the extra rows are simply clipped — no scrollbar, no visual hint that more data exists. Backend, API and data flow are all correct (`/api/billing/sessions?period=month&limit=100` returns 100 rows as expected); the truncation is purely a CSS height inheritance bug in the frontend.

**Fix**

Drop the `billing-section` class from both the empty-state and the populated-state branches of `_renderSessionList`. The session list is a full-width list, not a bottom-grid card, so it should not share the fixed-height card constraint in the first place. `.billing-sessions-section` already redeclares its own background, border and padding, so removing `billing-section` has zero visual impact beyond restoring natural height. The list now expands to fit all rows and scrolls together with the page.

**Test**

- Open billing page, pick "This Month" with >10 sessions in data: full list renders, no clipping.
- Pick a range with 0 sessions: empty state renders correctly with the same styling as before.
- Verify `.billing-bottom-grid` cards (token-breakdown / model-breakdown) still keep the `16rem` height — they were never touched.
- Verify computed style on `.billing-sessions-section`: `height: auto`, `scrollHeight === clientHeight`, no overflow clipping.