### PR TITLE
Fix: jump to session that is not loaded in sidebar (C-5679)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -576,6 +576,9 @@ module Clacky
           elsif method == "GET" && path.match?(%r{^/api/sessions/[^/]+/messages$})
             session_id = path.sub("/api/sessions/", "").sub("/messages", "")
             api_session_messages(session_id, req, res)
+          elsif method == "GET" && path.match?(%r{^/api/sessions/[^/]+$})
+            session_id = path.sub("/api/sessions/", "")
+            api_get_session(session_id, res)
           elsif method == "PATCH" && path.match?(%r{^/api/sessions/[^/]+$})
             session_id = path.sub("/api/sessions/", "")
             api_rename_session(session_id, req, res)
@@ -681,6 +684,16 @@ module Clacky
         sessions = pinned_part + non_pinned_part
 
         json_response(res, 200, { sessions: sessions, has_more: has_more, cron_count: @registry.cron_count })
+      end
+
+      # GET /api/sessions/:id — fetch a single session by id (memory + disk merged).
+      # Used by the frontend Router when navigating to a session that isn't in
+      # the paged sidebar list (search results, URL deep links, share links,
+      # browser back/forward, external notifications, etc.).
+      def api_get_session(session_id, res)
+        row = @registry.snapshot(session_id)
+        return json_response(res, 404, { error: "Session not found" }) unless row
+        json_response(res, 200, { session: row })
       end
 
       def api_create_session(req, res)

--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -116,7 +116,10 @@ const Router = (() => {
   }
 
   // Core: apply a view change. Called both from navigate() and hashchange.
-  function _apply(view, params = {}) {
+  // Async because the "session" case may need to fetch /api/sessions/:id when
+  // the target session isn't in the paged sidebar list (search clicks, URL
+  // deep links, share links, browser back/forward, notification jumps).
+  async function _apply(view, params = {}) {
     _current = view;
     _params  = params;
 
@@ -150,10 +153,14 @@ const Router = (() => {
 
       case "session": {
         const id = params.id;
-        const s  = Sessions.find(id);
+        // findOrFetch falls back to the backend when the session isn't in the
+        // sidebar's paged `_sessions` (search results, URL deep links, share
+        // links, browser back/forward). On success it caches the row in the
+        // local `_extraSessions` pool so subsequent sync `find` calls hit too.
+        const s  = await Sessions.findOrFetch(id);
         if (!s) {
-          // Session not found (e.g. deleted) — fall back to welcome
-          _apply("welcome");
+          // Truly not found (deleted, or never existed) — fall back to welcome.
+          await _apply("welcome");
           return;
         }
         _setHash(`session/${id}`);
@@ -277,7 +284,7 @@ const Router = (() => {
       return;
     }
     const { view, params } = _parseHash(location.hash);
-    _apply(view, params);
+    _apply(view, params).catch(err => console.error("Router._apply failed:", err));
   });
 
   return {
@@ -286,13 +293,16 @@ const Router = (() => {
 
     /** Navigate to a view. This is the only way panels should change. */
     navigate(view, params = {}) {
-      _apply(view, params);
+      // Fire-and-forget: _apply is async (may fetch /api/sessions/:id), but
+      // navigate() keeps a sync signature so all existing call sites are
+      // unaffected. Errors are logged; UI falls back to welcome on missing id.
+      _apply(view, params).catch(err => console.error("Router._apply failed:", err));
     },
 
     /** Restore state from current URL hash (called once on boot after data loads). */
     restoreFromHash() {
       const { view, params } = _parseHash(location.hash);
-      _apply(view, params);
+      _apply(view, params).catch(err => console.error("Router._apply failed:", err));
     },
   };
 })();

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -29,6 +29,12 @@ const Sessions = (() => {
   // Search results live in their own list, rendered into the overlay's
   // #session-search-results — they NEVER replace the sidebar session list.
   let   _searchResults     = [];
+  // Sessions resolved by id but not in the paged sidebar list — e.g. landed
+  // here via search-result click, URL deep link, share link, browser
+  // back/forward, or external notification jump. Acts as a local cache for
+  // `findOrFetch`. Excluded from sidebar render and from the loadMore cursor
+  // so the pagination of `_sessions` stays correct.
+  const _extraSessions     = [];
   // Active search result split when _filter.q is non-empty:
   // { nameIds: Set<id>, contentIds: Set<id>, contentLoaded: bool }
   let   _searchSplit       = null;
@@ -2017,7 +2023,41 @@ const Sessions = (() => {
     get all()        { return _sessions; },
     get activeId()   { return _activeId; },
     get searchOpen() { return _searchOpen; },
-    find: id => _sessions.find(s => s.id === id),
+    find: id => _sessions.find(s => s.id === id)
+              || _extraSessions.find(s => s.id === id),
+
+    // Async variant of `find`: when not found in memory, falls back to
+    // GET /api/sessions/:id which returns the on-disk session merged with
+    // any live in-memory state (see SessionRegistry#snapshot in
+    // session_registry.rb). Resolved rows are cached in `_extraSessions`
+    // so subsequent synchronous `find` calls hit too. Returns null on
+    // 404 / network error.
+    //
+    // Use this in code paths where missing-id should NOT silently fail
+    // (Router navigation: search clicks, URL deep links, share links,
+    // browser back/forward, notification jumps). For tight synchronous
+    // paths (WS dispatch, status updates) keep using `find`.
+    async findOrFetch(id) {
+      if (!id) return null;
+      const local = _sessions.find(s => s.id === id)
+                 || _extraSessions.find(s => s.id === id);
+      if (local) return local;
+      try {
+        const resp = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
+        if (!resp.ok) return null;
+        const data = await resp.json();
+        if (!data || !data.session) return null;
+        // Race guard: another caller may have hydrated meanwhile.
+        if (!_sessions.find(s => s.id === id)
+            && !_extraSessions.find(s => s.id === id)) {
+          _extraSessions.push(data.session);
+        }
+        return data.session;
+      } catch (e) {
+        console.error("Sessions.findOrFetch failed:", e);
+        return null;
+      }
+    },
 
     // Composer entry point — called by Skill autocomplete keydown handler
     // (in app.js) when the user presses Enter without an active completion.


### PR DESCRIPTION
## Problem
Clicking a search result for a session outside the loaded sidebar window does not navigate — URL hash updates but chat view stays put. Same bug hits URL deep links, shared links, back/forward, and notification jumps.

Root cause: `Router._apply` calls `Sessions.find(id)`, which only scans the paginated `_sessions` array.

## Fix
- Backend: `GET /api/sessions/:id` — thin wrapper over existing `SessionRegistry#snapshot`.
- Frontend: `Sessions.findOrFetch(id)` falls back to the endpoint and parks the result in a separate `_extraSessions` pool (excluded from sidebar render and `loadMore` cursor).
- Router: `_apply` is now async; `session` case awaits `findOrFetch`, call sites stay fire-and-forget.

## Test
- ✅ `ruby -c http_server.rb` / `node --check sessions.js app.js`
- ✅ Search → click unloaded session → chat opens
- ✅ Deep link `#session/<old-id>` in fresh tab → chat opens
- ✅ Sidebar `loadMore` cursor unaffected by hydrated extras
- ✅ `GET /api/sessions/<bogus>` → 404