### PR TITLE
fix(settings): lock default-model checkbox when only one model exists (C-5677)

### DIFF
--- a/lib/clacky/web/settings.js
+++ b/lib/clacky/web/settings.js
@@ -169,7 +169,14 @@ const Settings = (() => {
       document.getElementById("model-modal-baseurl").value = model.base_url || "";
       document.getElementById("model-modal-apikey").value = model.api_key_masked || "";
       document.getElementById("model-modal-default-field").style.display = "";
-      document.getElementById("model-modal-set-default").checked = (model.type === "default");
+      // Lock the checkbox when this is the only configured model: the system
+      // must always have one default (backend re-promotes on save), so
+      // unchecking would be a silent no-op. Force-checked + disabled makes
+      // the constraint visible without any extra copy.
+      const setDefaultCb = document.getElementById("model-modal-set-default");
+      const isOnlyModel = _models.length === 1;
+      setDefaultCb.checked = isOnlyModel ? true : (model.type === "default");
+      setDefaultCb.disabled = isOnlyModel;
 
       // Set provider dropdown value
       const matched = _findProviderByBaseUrl(model.base_url);
@@ -190,6 +197,9 @@ const Settings = (() => {
       // Default to checked for new models — most users want their first/new
       // model to take over as the default.
       document.getElementById("model-modal-set-default").checked = true;
+      // Reset disabled flag in case the previous open was edit-mode on the
+      // sole-model lock path.
+      document.getElementById("model-modal-set-default").disabled = false;
 
       // Reset provider dropdown
       _modalSelectedProviderId = null;


### PR DESCRIPTION
## Problem
In the Edit Model dialog, unchecking "Set as default" when only one model is configured had no real effect: `Clacky::AgentConfig` re-promotes the sole model to `type: "default"` on save. The UI allowed a meaningless action with no feedback.

## Fix
When `_models.length === 1`, force the checkbox **checked + disabled** in edit mode — the lock conveys "must stay default" without extra copy or i18n. Also reset `disabled = false` on the add-model path so the flag doesn't leak across modal opens. Pure front-end, no backend or i18n changes.

<img width="1512" height="863" alt="Snapzy_2026-06-22_15-19-19_934" src="https://github.com/user-attachments/assets/f8aa37ff-634b-426f-bdc9-bf74719f9e66" />


## Test
- ✅ Single model: edit dialog shows checkbox checked and greyed-out
- ✅ Add a second model, edit either: checkbox is interactive again
- ✅ Delete back to one model, edit: checkbox locked again
- ✅ Edit (locked) → close → Add Model: new-model checkbox is enabled