### PR TITLE
feat: move set-default button to name row, align top-up link to right

### DIFF
--- a/lib/clacky/web/settings.js
+++ b/lib/clacky/web/settings.js
@@ -96,6 +96,10 @@ const Settings = (() => {
           <span class="model-card-grid-name">${_esc(displayName)}</span>
           ${isDefault ? `<span class="badge badge-default">${I18n.t("settings.models.badge.default")}</span>` : ""}
           ${isLite ? `<span class="badge badge-lite">${I18n.t("settings.models.badge.lite")}</span>` : ""}
+          ${!isDefault ? `<button class="btn-card-grid-action btn-card-grid-action-primary" data-index="${index}" data-action="default" style="margin-left:auto">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+            <span>${I18n.t("settings.models.btn.setDefault")}</span>
+          </button>` : ""}
         </div>
         <div class="model-card-grid-provider">${_esc(providerName)}</div>
         ${model.api_key_masked ? `<div class="model-card-grid-model">${_esc(model.api_key_masked)}</div>` : ""}
@@ -120,11 +124,7 @@ const Settings = (() => {
         </div>
       </div>
       <div class="model-card-grid-footer">
-        ${!isDefault ? `<button class="btn-card-grid-action btn-card-grid-action-primary" data-index="${index}" data-action="default">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-          <span>${I18n.t("settings.models.btn.setDefault")}</span>
-        </button>` : `<span></span>`}
-        ${websiteUrl ? `<a class="model-card-grid-link" href="${_esc(websiteUrl)}" target="_blank" rel="noopener noreferrer">
+        ${websiteUrl ? `<a class="model-card-grid-link" href="${_esc(websiteUrl)}" target="_blank" rel="noopener noreferrer" style="margin-left:auto">
           ${I18n.t("settings.models.link.topUp")}
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><path d="M8 7h9v9"/></svg>
         </a>` : ""}


### PR DESCRIPTION
- Set as default button moved from card footer to name row (right-aligned)
- Top-up / account link pushed to far right via margin-left:auto


