### PR TITLE
feat: detect default browser via OS identity to see through Chromium shells

### DIFF
--- a/lib/clacky/default_skills/browser-setup/SKILL.md
+++ b/lib/clacky/default_skills/browser-setup/SKILL.md
@@ -47,6 +47,27 @@ When unsure, show **both** lines (label them "China:" and "Global:") so the user
 
 If no subcommand is clear, default to `setup`.
 
+## Prerequisites Check — verify the default browser
+
+Ask the server for the user's default browser:
+
+```bash
+curl -s http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/browser/default
+```
+
+Response: `{ "id": "...", "browser": "chrome" | "edge" | "other" | "unknown" }`
+
+Act on `browser`:
+
+- **`chrome` / `edge`** → proceed with setup normally.
+- **`other`** → tell the user, in your own words, that browser automation
+  requires real Chrome or Edge, and that they can either switch their default
+  browser or just open Chrome/Edge for this. **Do not hard-block** — if they
+  already have Chrome/Edge open, let them continue. Offer download links per
+  the **Region-Aware Download Links** section above.
+- **`unknown`** (detection failed, or the endpoint errored) → skip this check
+  and proceed normally; the setup steps below will surface any real problem.
+
 ---
 
 ## `setup`
@@ -185,6 +206,10 @@ If still failing:
 > - Chrome/Edge is running
 > - You clicked "Allow remote debugging" in chrome://inspect/#remote-debugging
 > - No firewall is blocking localhost connections
+> - **Your browser is genuine Chrome or Edge** — skinned browsers built on Chromium
+>   (e.g. 360 Safe Browser, QQ Browser, Sogou, UC, Quark) look like Chrome but disable remote
+>   debugging, so automation cannot connect. If you are using one of these, please
+>   switch to real Chrome or Edge (download links above) and run `/browser-setup` again.
 >
 > Run `/browser-setup doctor` to diagnose the issue in detail.
 

--- a/lib/clacky/server/browser_manager.rb
+++ b/lib/clacky/server/browser_manager.rb
@@ -123,6 +123,15 @@ module Clacky
       }
     end
 
+    # Returns the OS-registered default browser identity. Delegates to
+    # BrowserDetector (which reads plist / registry / xdg — never UA, so it
+    # sees through Chromium-shell browsers). Consumed by the browser-setup
+    # skill to advise the user; this does NOT gate anything.
+    # @return [Hash] { id: String|nil, browser: "chrome"|"edge"|"other"|"unknown" }
+    def default_browser
+      Clacky::Utils::BrowserDetector.default_browser
+    end
+
     # Write browser.yml with the given config and reload the daemon.
     # Called by HttpServer POST /api/browser/configure.
     # @param chrome_version [String] detected Chrome major version

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -494,6 +494,7 @@ module Clacky
         when ["POST",   "/api/onboard/device/start"] then api_onboard_device_start(req, res)
         when ["POST",   "/api/onboard/device/poll"]  then api_onboard_device_poll(req, res)
         when ["GET",    "/api/browser/status"]    then api_browser_status(res)
+        when ["GET",    "/api/browser/default"]   then api_browser_default(res)
         when ["POST",   "/api/browser/configure"]  then api_browser_configure(req, res)
         when ["POST",   "/api/browser/reload"]    then api_browser_reload(res)
         when ["POST",   "/api/browser/toggle"]    then api_browser_toggle(res)
@@ -1194,6 +1195,16 @@ module Clacky
       end
       def api_browser_status(res)
         json_response(res, 200, @browser_manager.status)
+      end
+
+      # GET /api/browser/default
+      # Returns the OS-registered default browser identity so the browser-setup
+      # skill can advise the user. Reads system-level identity (plist/registry/
+      # xdg), not UA — sees through Chromium-shell browsers (e.g. 360).
+      def api_browser_default(res)
+        json_response(res, 200, @browser_manager.default_browser)
+      rescue StandardError => e
+        json_response(res, 500, { id: nil, browser: "unknown", error: e.message })
       end
 
       # POST /api/browser/configure

--- a/lib/clacky/utils/browser_detector.rb
+++ b/lib/clacky/utils/browser_detector.rb
@@ -39,6 +39,130 @@ module Clacky
       end
 
       # -----------------------------------------------------------------------
+      # Default browser identity (for browser-setup skill)
+      # -----------------------------------------------------------------------
+      #
+      # Reads the OS-registered default browser identity — NOT navigator.userAgent.
+      # This is the only reliable way to see through Chromium-shell browsers
+      # (360, UC, Sogou, Quark, QQ …): they spoof their UA to look like plain
+      # Chrome on third-party pages, but the system-level default-browser id they
+      # register cannot be faked (e.g. 360 registers ProgID "360seURL").
+      #
+      #   macOS → LaunchServices https handler Bundle ID  (e.g. com.google.chrome)
+      #   WSL   → Windows registry UserChoice ProgID       (e.g. ChromeHTML)
+      #   Linux → xdg-settings default-web-browser .desktop (e.g. google-chrome.desktop)
+      #
+      # The returned :browser is a coarse label the skill can act on. We do NOT
+      # block here — the browser-setup skill decides how to talk to the user.
+      #
+      # @return [Hash] { id: String|nil, browser: "chrome"|"edge"|"other"|"unknown" }
+
+      # Whitelist of genuine, CDP-automatable browsers per platform.
+      # Matched case-insensitively (macOS LaunchServices returns lowercase ids).
+      # Verified by real-machine testing: com.google.chrome, com.microsoft.edgemac,
+      # ChromeHTML, MSEdgeHTM (and 360seURL confirmed to fall outside).
+      DEFAULT_BROWSER_WHITELIST = {
+        macos: {
+          "chrome" => ["com.google.chrome"],
+          "edge"   => ["com.microsoft.edgemac"]
+        },
+        win: {
+          "chrome" => ["chromehtml"],
+          "edge"   => ["msedgehtm"]
+        },
+        linux: {
+          "chrome" => [/\Agoogle-chrome/],
+          "edge"   => [/\Amicrosoft-edge/]
+        }
+      }.freeze
+
+      # @return [Hash] { id: String|nil, browser: String }
+      def self.default_browser
+        os = EnvironmentDetector.os_type
+        id = case os
+             when :macos        then macos_default_browser_id
+             when :wsl          then win_default_browser_progid
+             when :linux        then linux_default_browser_desktop
+             end
+
+        rules =
+          case os
+          when :macos        then DEFAULT_BROWSER_WHITELIST[:macos]
+          when :wsl          then DEFAULT_BROWSER_WHITELIST[:win]
+          when :linux        then DEFAULT_BROWSER_WHITELIST[:linux]
+          end
+
+        browser = classify_default_browser(id, rules)
+        Clacky::Logger.info("[BrowserDetector] Default browser: id=#{id.inspect} → #{browser}")
+        { id: id, browser: browser }
+      end
+
+      # Match a default-browser id against a platform whitelist.
+      # @return [String] "chrome" | "edge" | "other" | "unknown"
+      private_class_method def self.classify_default_browser(id, rules)
+        return "unknown" if id.nil? || id.empty? || rules.nil?
+
+        needle = id.downcase
+        rules.each do |label, patterns|
+          patterns.each do |p|
+            matched = p.is_a?(Regexp) ? needle.match?(p) : needle == p
+            return label if matched
+          end
+        end
+        "other"
+      end
+
+      # macOS: read the https handler Bundle ID from LaunchServices.
+      # Uses `plutil -extract LSHandlers json` + Ruby JSON (no Python dependency).
+      # @return [String, nil] lowercase bundle id, e.g. "com.google.chrome"
+      private_class_method def self.macos_default_browser_id
+        plist = File.join(Dir.home,
+                          "Library", "Preferences",
+                          "com.apple.LaunchServices",
+                          "com.apple.launchservices.secure.plist")
+        return nil unless File.exist?(plist)
+
+        out, _err, st = Open3.capture3("plutil", "-extract", "LSHandlers", "json", "-o", "-", plist)
+        return nil unless st.success?
+
+        handlers = JSON.parse(out)
+        return nil unless handlers.is_a?(Array)
+
+        https = handlers.find { |h| h.is_a?(Hash) && h["LSHandlerURLScheme"] == "https" }
+        https&.dig("LSHandlerRoleAll")&.to_s&.downcase
+      rescue StandardError => e
+        Clacky::Logger.debug("[BrowserDetector] macOS default browser read failed: #{e.message}")
+        nil
+      end
+
+      # WSL: read the Windows default-browser ProgID from the registry via
+      # powershell.exe. The UserChoice key cannot be spoofed by shell browsers
+      # (360 registers "360seURL" here, fully exposed).
+      # @return [String, nil] ProgID, e.g. "ChromeHTML" / "MSEdgeHTM" / "360seURL"
+      private_class_method def self.win_default_browser_progid
+        cmd = '(Get-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice").ProgId'
+        out = Utils::Encoding.cmd_to_utf8(
+          `powershell.exe -NoProfile -Command #{Shellwords.escape(cmd)} 2>/dev/null`
+        ).strip.tr("\r\n", "")
+        out.empty? ? nil : out
+      rescue StandardError => e
+        Clacky::Logger.debug("[BrowserDetector] WSL default browser read failed: #{e.message}")
+        nil
+      end
+
+      # Linux: read the default browser .desktop name via xdg-settings.
+      # @return [String, nil] e.g. "google-chrome.desktop"
+      private_class_method def self.linux_default_browser_desktop
+        out = Utils::Encoding.cmd_to_utf8(
+          `xdg-settings get default-web-browser 2>/dev/null`
+        ).strip
+        out.empty? ? nil : out
+      rescue StandardError => e
+        Clacky::Logger.debug("[BrowserDetector] Linux default browser read failed: #{e.message}")
+        nil
+      end
+
+      # -----------------------------------------------------------------------
       # DevToolsActivePort file scan
       # -----------------------------------------------------------------------
 

--- a/spec/clacky/utils/browser_detector_default_spec.rb
+++ b/spec/clacky/utils/browser_detector_default_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/utils/browser_detector"
+
+# Focused on the default-browser identity detection (.default_browser) used by
+# the browser-setup skill to see through Chromium-shell browsers (e.g. 360),
+# which spoof their UA but cannot fake the OS-registered default-browser id.
+RSpec.describe Clacky::Utils::BrowserDetector do
+  describe ".classify_default_browser (whitelist matching)" do
+    let(:mac_rules) { described_class::DEFAULT_BROWSER_WHITELIST[:macos] }
+    let(:win_rules) { described_class::DEFAULT_BROWSER_WHITELIST[:win] }
+    let(:linux_rules) { described_class::DEFAULT_BROWSER_WHITELIST[:linux] }
+
+    def classify(id, rules)
+      described_class.send(:classify_default_browser, id, rules)
+    end
+
+    context "macOS bundle ids (case-insensitive)" do
+      it "labels Chrome" do
+        expect(classify("com.google.chrome", mac_rules)).to eq("chrome")
+        expect(classify("COM.GOOGLE.CHROME", mac_rules)).to eq("chrome")
+      end
+
+      it "labels Edge" do
+        expect(classify("com.microsoft.edgemac", mac_rules)).to eq("edge")
+      end
+
+      it "labels Safari as other" do
+        expect(classify("com.apple.safari", mac_rules)).to eq("other")
+      end
+    end
+
+    context "Windows ProgIDs (case-insensitive)" do
+      it "labels Chrome and Edge" do
+        expect(classify("ChromeHTML", win_rules)).to eq("chrome")
+        expect(classify("MSEdgeHTM", win_rules)).to eq("edge")
+      end
+
+      it "labels 360 as other (its real ProgID is exposed, not spoofed)" do
+        expect(classify("360seURL", win_rules)).to eq("other")
+      end
+    end
+
+    context "Linux .desktop names (prefix match)" do
+      it "labels Chrome and Edge variants" do
+        expect(classify("google-chrome.desktop", linux_rules)).to eq("chrome")
+        expect(classify("microsoft-edge-beta.desktop", linux_rules)).to eq("edge")
+      end
+
+      it "labels Firefox as other" do
+        expect(classify("firefox.desktop", linux_rules)).to eq("other")
+      end
+    end
+
+    context "missing / blank identity" do
+      it "returns unknown for nil or empty" do
+        expect(classify(nil, mac_rules)).to eq("unknown")
+        expect(classify("", mac_rules)).to eq("unknown")
+      end
+
+      it "returns unknown when rules are nil (unsupported OS)" do
+        expect(classify("com.google.chrome", nil)).to eq("unknown")
+      end
+    end
+  end
+
+  describe ".default_browser" do
+    it "classifies a macOS Chrome default" do
+      allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:macos)
+      allow(described_class).to receive(:macos_default_browser_id).and_return("com.google.chrome")
+
+      expect(described_class.default_browser).to eq(id: "com.google.chrome", browser: "chrome")
+    end
+
+    it "classifies a WSL 360 default as other" do
+      allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:wsl)
+      allow(described_class).to receive(:win_default_browser_progid).and_return("360seURL")
+
+      expect(described_class.default_browser).to eq(id: "360seURL", browser: "other")
+    end
+
+    it "classifies a Linux Edge default" do
+      allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:linux)
+      allow(described_class).to receive(:linux_default_browser_desktop).and_return("microsoft-edge.desktop")
+
+      expect(described_class.default_browser).to eq(id: "microsoft-edge.desktop", browser: "edge")
+    end
+
+    it "returns unknown when identity cannot be read" do
+      allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:macos)
+      allow(described_class).to receive(:macos_default_browser_id).and_return(nil)
+
+      expect(described_class.default_browser).to eq(id: nil, browser: "unknown")
+    end
+  end
+end


### PR DESCRIPTION

<img width="1602" height="923" alt="clipboard_2026-06-23_16-44" src="https://github.com/user-attachments/assets/28290f10-0548-4671-8b37-991d7a339831" />


## Problem

Browser automation requires genuine Chrome/Edge (CDP open). Chromium-shell browsers (360 安全浏览器, QQ, 搜狗, UC, 夸克 …) keep remote debugging closed and cannot be driven. The previous approach detected the browser from `navigator.userAgent` in the frontend, but these shells **spoof their UA to look like plain Chrome** on third-party pages, so 360 was misclassified as Chrome and slipped through. UA-based detection is fundamentally unfixable here.

## Fix

Detect the **OS-registered default browser identity** in the backend instead of trusting UA — shells cannot fake this system-level id:

- `BrowserDetector.default_browser` reads, per OS:
  - macOS → LaunchServices https handler Bundle ID (`plutil` + Ruby JSON, no Python)
  - WSL   → Windows registry `UserChoice` ProgID (via `powershell.exe`)
  - Linux → `xdg-settings get default-web-browser` (.desktop name)
- Matches a data-driven whitelist (Chrome/Edge only) and returns `{ id, browser: "chrome"|"edge"|"other"|"unknown" }`.
- Exposed via `GET /api/browser/default`.
- The `browser-setup` skill calls this endpoint and advises the user in natural language. It does **not** hard-block: a user who already has Chrome/Edge open may continue. Removed the frontend UA detection and the prompt-injected  `[browser_type]` tag.

All whitelist values are verified on real machines: `com.google.chrome`, `com.microsoft.edgemac`, `ChromeHTML`, `MSEdgeHTM` (and 360 confirmed to expose its real `360seURL`, falling outside the whitelist).

## Test

- ✅ Added `spec/clacky/utils/browser_detector_default_spec.rb` — 13 examples, covering whitelist matching (case-insensitive, prefix for Linux) and per-OS classification (incl. 360 → `other`). All pass.
- ✅ `code_style_spec` passes (177 examples).
- ✅ Real-machine smoke: macOS default Chrome → `{ id: "com.google.chrome", browser: "chrome" }`.