### PR TITLE
feat: memory card edit button with inline editing

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -9198,6 +9198,7 @@ body.setup-mode[data-theme="dark"] {
 
 /* Shared base for per-card buttons. */
 .btn-memory-curate,
+.btn-memory-edit,
 .btn-memory-delete,
 .btn-memory-expand {
   padding: 0.3125rem 0.625rem;
@@ -9213,7 +9214,8 @@ body.setup-mode[data-theme="dark"] {
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
-.btn-memory-curate:hover {
+.btn-memory-curate:hover,
+.btn-memory-edit:hover {
   border-color: var(--color-text-primary);
   background: var(--color-bg-hover);
 }

--- a/lib/clacky/web/features/profile/store.js
+++ b/lib/clacky/web/features/profile/store.js
@@ -136,6 +136,25 @@ const ProfileStore = (() => {
       await Profile.loadAll();
     },
 
+    /** Update a memory file's content. Returns { ok, error }. */
+    async updateMemory(filename, content) {
+      try {
+        const res = await fetch("/api/memories/" + encodeURIComponent(filename), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content })
+        });
+        const data = await res.json();
+        if (!res.ok || !data.ok) throw new Error(data.error || "Save failed");
+        await _loadMemories();
+        _emit("profile:memoriesChanged");
+        return { ok: true };
+      } catch (e) {
+        console.error("[Profile] update memory failed", e);
+        return { ok: false, error: e.message };
+      }
+    },
+
     /** Open an /onboard path:<abs> curate session for a memory. */
     async curateMemory(m) {
       const absPath = m.path || ("~/.clacky/memories/" + m.filename);

--- a/lib/clacky/web/features/profile/view.js
+++ b/lib/clacky/web/features/profile/view.js
@@ -179,10 +179,18 @@ const ProfileView = (() => {
         </div>
       </div>
       <div class="memory-card-actions">
-        <button class="btn-memory-curate" title="${_t("memories.curateTitle")}">
+        <button class="btn-memory-edit" title="${_t("memories.edit")}">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 20h9"/>
             <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>
+          </svg>
+          <span>${_t("memories.edit")}</span>
+        </button>
+        <button class="btn-memory-curate" title="${_t("memories.curateTitle")}">
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M15 4V2"/><path d="M15 16v-2"/><path d="M8 9h2"/><path d="M20 9h2"/>
+            <path d="M17.8 11.8 19 13"/><path d="M15 9h.01"/><path d="M17.8 6.2 19 5"/>
+            <path d="m3 21 9-9"/><path d="M12.2 6.2 11 5"/>
           </svg>
           <span>${_t("memories.curate")}</span>
         </button>
@@ -207,6 +215,9 @@ const ProfileView = (() => {
     body.className = "memory-card-body";
     body.style.display = "none";
     card.appendChild(body);
+
+    head.querySelector(".btn-memory-edit")
+      .addEventListener("click", (e) => { e.stopPropagation(); _editMemory(m); });
 
     head.querySelector(".btn-memory-curate")
       .addEventListener("click", (e) => { e.stopPropagation(); _curateMemory(m); });
@@ -279,6 +290,21 @@ const ProfileView = (() => {
       alert(_t("profile.curateFail") + ": " + e.message);
       if (btn) btn.disabled = false;
     }
+  }
+
+  async function _editMemory(m) {
+    const res = await Profile.fetchMemory(m.filename);
+    if (!res.ok) { alert(_t("memories.curateFail") + ": " + res.error); return; }
+
+    CodeEditor.open({
+      content: res.content,
+      title: m.topic || m.filename,
+      language: "markdown",
+      onSave: async (newContent) => {
+        const r = await Profile.updateMemory(m.filename, newContent);
+        if (!r.ok) throw new Error(r.error);
+      }
+    });
   }
 
   async function _curateMemory(m) {


### PR DESCRIPTION
- Add edit button to memory cards with pencil icon
- Fix list not refreshing after save by reloading memories before emit
- Differentiate edit (pencil) and curate (wand) icons
- Style edit button consistent with other action buttons
