### PR TITLE
fix(tools): edit performs literal replacement (C-5682)

### DIFF
--- a/lib/clacky/tools/edit.rb
+++ b/lib/clacky/tools/edit.rb
@@ -67,8 +67,20 @@ module Clacky
             }
           end
 
-          # Perform replacement
-          content = replace_all ? content.gsub(actual_old_string, new_string) : content.sub(actual_old_string, new_string)
+          # Perform literal replacement.
+          #
+          # NOTE: Use the block form (`sub(old) { new }`) instead of the
+          # two-arg form (`sub(old, new)`). The two-arg form interprets
+          # backslash escapes (\&, \1, \`, \', \\) in the replacement
+          # as sed-style backreferences, silently mangling literal
+          # backslashes and these escape sequences. The block form
+          # performs no such interpretation, matching the edit tool's
+          # literal-replacement contract.
+          content = if replace_all
+                      content.gsub(actual_old_string) { new_string }
+                    else
+                      content.sub(actual_old_string) { new_string }
+                    end
 
           File.write(path, content)
 

--- a/spec/clacky/tools/edit_spec.rb
+++ b/spec/clacky/tools/edit_spec.rb
@@ -176,6 +176,110 @@ RSpec.describe Clacky::Tools::Edit do
     end
   end
 
+  describe "literal replacement (no backreference interpretation)" do
+    # Regression: prior to the block-form fix, String#sub(old, new) interpreted
+    # \&, \1, \`, \', \\ in new_string as sed-style backreferences, silently
+    # mangling literal backslashes and these escape sequences. The edit tool's
+    # contract is literal replacement, so these specs lock that down.
+  
+    it "preserves literal backslash-ampersand without expanding to whole match" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "hello world")
+  
+        result = tool.execute(path: file_path, old_string: "world", new_string: "[\\&]")
+  
+        expect(result[:error]).to be_nil
+        expect(File.read(file_path)).to eq("hello [\\&]")
+      end
+    end
+  
+    it "preserves literal backslash-1 without expanding to capture group" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "abc")
+  
+        result = tool.execute(path: file_path, old_string: "b", new_string: "\\1")
+  
+        expect(result[:error]).to be_nil
+        expect(File.read(file_path)).to eq("a\\1c")
+      end
+    end
+  
+    it "preserves a literal single backslash byte" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "[/]")
+  
+        result = tool.execute(path: file_path, old_string: "[/]", new_string: "[/\\]")
+  
+        expect(result[:error]).to be_nil
+        expect(File.binread(file_path).bytes).to eq([0x5b, 0x2f, 0x5c, 0x5d])
+      end
+    end
+  
+    it "preserves literal double backslash" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "x")
+  
+        result = tool.execute(path: file_path, old_string: "x", new_string: "\\\\")
+  
+        expect(result[:error]).to be_nil
+        expect(File.read(file_path)).to eq("\\\\")
+      end
+    end
+  
+    it "preserves literal backslash-ampersand across all occurrences with replace_all" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "x x x")
+  
+        result = tool.execute(path: file_path, old_string: "x", new_string: "\\&", replace_all: true)
+  
+        expect(result[:error]).to be_nil
+        expect(result[:replacements]).to eq(3)
+        expect(File.read(file_path)).to eq("\\& \\& \\&")
+      end
+    end
+  
+    it "preserves literal backslash-1 across all occurrences with replace_all" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "a a a")
+  
+        result = tool.execute(path: file_path, old_string: "a", new_string: "\\1", replace_all: true)
+  
+        expect(result[:error]).to be_nil
+        expect(File.read(file_path)).to eq("\\1 \\1 \\1")
+      end
+    end
+  
+    it "preserves literal single backslash across all occurrences with replace_all" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "a a a")
+  
+        result = tool.execute(path: file_path, old_string: "a", new_string: "\\", replace_all: true)
+  
+        expect(result[:error]).to be_nil
+        expect(File.binread(file_path)).to eq("\\ \\ \\")
+      end
+    end
+  
+    it "preserves literal double backslash across all occurrences with replace_all" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "br.txt")
+        File.write(file_path, "a a")
+  
+        result = tool.execute(path: file_path, old_string: "a", new_string: "\\\\", replace_all: true)
+  
+        expect(result[:error]).to be_nil
+        expect(File.read(file_path)).to eq("\\\\ \\\\")
+      end
+    end
+  end
+  
   describe "#to_function_definition" do
     it "returns OpenAI function calling format" do
       definition = tool.to_function_definition


### PR DESCRIPTION
## Problem

`edit` tool silently mangles content containing literal backslashes or sed-style escape sequences (`\&`, `\1`, `` \` ``, `\'`, `\\`).

Root cause at `lib/clacky/tools/edit.rb:71`:

```ruby
content = replace_all ? content.gsub(actual_old_string, new_string) : content.sub(actual_old_string, new_string)
```

`String#sub(old, new)` and `gsub(old, new)` treat `new` as a sed-style template — `\&` expands to the whole match, `\1` to capture group 1, `\\` to a single backslash. The edit tool's contract is *literal* replacement, so this violates user expectations and silently corrupts files.

Real-world breakage: writing Ruby regex `%r{[/\\]}`, Python escape strings `"\n"`, JSON literals `"\\"`, LaTeX `\\`, etc.

## Fix

Switch to the block form which performs no escape interpretation:

```ruby
content = if replace_all
            content.gsub(actual_old_string) { new_string }
          else
            content.sub(actual_old_string) { new_string }
          end
```

## Test
<img width="1511" height="863" alt="Snapzy_2026-06-24_10-42-49_186" src="https://github.com/user-attachments/assets/6e7b38ac-c203-4335-be3d-97caee2ceae3" />

✅ 8 new regression specs in `edit_spec.rb` covering `\&`, `\1`, single & double backslash, for both `sub` and `gsub` (`replace_all`) paths.
✅ Verified specs catch the bug: reverting the fix makes 6 of 8 specs fail.
✅ Full suite: 2427/2427 green (was 2419, +8 new).