### PR TITLE
feat: add DashScope TTS and video generation support

### DIFF
--- a/lib/clacky/media/dashscope.rb
+++ b/lib/clacky/media/dashscope.rb
@@ -7,33 +7,48 @@ require_relative "base"
 
 module Clacky
   module Media
-    # Alibaba DashScope (Qwen-Image) image generation provider.
+    # Alibaba DashScope (Qwen-Image / CosyVoice / HappyHorse) media generation provider.
     #
-    # DashScope is NOT an OpenAI-compatible image API. It has its own
-    # endpoint, request envelope and response schema:
-    #
-    #   POST <host>/api/v1/services/aigc/multimodal-generation/generation
-    #   Authorization: Bearer <key>
-    #   { "model": "qwen-image-2.0-pro",
-    #     "input":      { "messages": [ { "role": "user",
-    #                                     "content": [ { "text": "<prompt>" } ] } ] },
-    #     "parameters": { "size": "2048*2048", "n": 1,
-    #                     "prompt_extend": true, "watermark": false } }
-    #
-    #   => { "output": { "choices": [ { "message": { "content": [
-    #          { "image": "https://...png?Expires=..." } ] } } ] },
-    #        "usage": { "width": 2048, "height": 2048, "image_count": 1 } }
-    #
-    # The image link expires after 24h, so we download and persist it under
-    # <output_dir>/assets/generated/ (via Base#save_image_from_url), matching
-    # the on-disk shape of the base64 providers.
+    # DashScope is NOT an OpenAI-compatible API. It has its own endpoint,
+    # request envelope and response schema for image, speech (TTS), and video generation.
     #
     # Routing: Generator sends any base_url under *.aliyuncs.com here. We
     # derive the real generation endpoint from the host so users can paste
     # the compatible-mode base_url (…/compatible-mode/v1) they already use
-    # for Qwen text models and still get working image generation.
+    # for Qwen text models and still get working media generation.
+    #
+    # --- Endpoint migration TODO (2026-06) ---------------------------------
+    # Aliyun is gradually deprecating the shared `dashscope.aliyuncs.com`
+    # host in favor of the per-workspace MaaS domain
+    # `https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com` (intl:
+    # `{WorkspaceId}.dashscope-intl.aliyuncs.com`). Docs have already moved
+    # to the new domain; the old host still works for most models but is
+    # expected to be sunset eventually.
+    #
+    # Current stance: keep accepting the old shared host as the default
+    # (zero-config for users + compatibility with third-party aggregators
+    # that don't use aliyuncs.com at all). The new MaaS domain already
+    # works today via endpoint_base derivation. Non-real-time TTS
+    # (qwen3-tts) does NOT work on the shared host and already emits a
+    # hint pointing users at the MaaS domain — see the "url error" branch
+    # in generate_speech.
+    #
+    # Action when Aliyun announces the sunset of compatible-mode:
+    #   1. Flip the default expectation to the WorkspaceId MaaS domain.
+    #   2. Add a setup flow / docs explaining how to find WorkspaceId.
+    #   3. Keep accepting aggregator base_urls unchanged.
+    # Do NOT pre-emptively migrate before an official sunset notice — it
+    # would break zero-config UX and aggregator users for no current gain.
     class DashScope < Base
-      GENERATION_PATH = "/api/v1/services/aigc/multimodal-generation/generation"
+      GENERATION_PATH   = "/api/v1/services/aigc/multimodal-generation/generation"
+      SPEECH_PATH_COSY  = "/api/v1/services/audio/tts/SpeechSynthesizer"
+      VIDEO_PATH        = "/api/v1/services/aigc/video-generation/video-synthesis"
+      TASK_PATH         = "/api/v1/tasks/"
+
+      # Default voice per TTS model family. CosyVoice defaults to longanyang;
+      # Qwen3-TTS defaults to Cherry (most common Chinese female voice).
+      DEFAULT_SPEECH_VOICE_COSY = "longanyang"
+      DEFAULT_SPEECH_VOICE_QWEN = "Cherry"
 
       # aspect_ratio -> "<width>*<height>" (DashScope uses '*' not 'x').
       # qwen-image-2.0 / -plus / -max share these recommended resolutions;
@@ -178,6 +193,314 @@ module Clacky
         )
       end
 
+      # Synthesizes speech (TTS) using Alibaba CosyVoice models (e.g. cosyvoice-v3-flash).
+      # This is a synchronous call.
+      #
+      # @param input [String] the text to synthesize
+      # @param voice [String, nil] the voice name; defaults to "longanyang" for CosyVoice or "Cherry" for Qwen3-TTS
+      # @param output_dir [String, nil] the directory to save the output audio
+      # @param language_type [String, nil] language hint for Qwen3-TTS (default "Chinese"); ignored by CosyVoice
+      # @return [Hash] audio_success_response or audio_error_response
+      def generate_speech(input:, voice: nil, output_dir: nil, language_type: nil, **_kwargs)
+        if input.to_s.strip.empty?
+          return audio_error_response(
+            error: "Input text is required and must be a non-empty string",
+            error_type: "invalid_argument",
+            provider: PROVIDER_ID,
+            voice: voice.to_s
+          )
+        end
+
+        if @api_key.to_s.empty?
+          return audio_error_response(
+            error: "api_key not configured for audio model '#{@model}'",
+            error_type: "auth_required",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        # Pick endpoint and payload shape based on model family. CosyVoice
+        # uses the dedicated TTS endpoint and accepts format/sample_rate;
+        # Qwen3-TTS is a multimodal-generation model and expects
+        # language_type instead.
+        endpoint     = speech_endpoint
+        chosen_voice = voice || default_speech_voice
+        payload      = speech_payload(input: input, voice: chosen_voice, language_type: language_type)
+
+        begin
+          response = connection.post(endpoint) do |req|
+            req.headers["Content-Type"]  = "application/json"
+            req.headers["Authorization"] = "Bearer #{@api_key}"
+            req.body = JSON.generate(payload)
+          end
+        rescue Faraday::Error => e
+          return audio_error_response(
+            error: "HTTP request failed: #{e.message}",
+            error_type: "network_error",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        body = parse_json(response.body)
+        unless body.is_a?(Hash)
+          return audio_error_response(
+            error: "Invalid JSON response from upstream",
+            error_type: "invalid_response",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        # Inspect any business level errors from DashScope
+        if body["code"] && !body["code"].to_s.empty?
+          err_msg = body["message"].to_s
+          if err_msg.include?("url error") && @base_url.to_s.include?("dashscope.aliyuncs.com")
+            err_msg += " (Note: Alibaba Model Studio non-real-time TTS does not support the public shared endpoint. " \
+                       "Set the model's Base URL to your dedicated MaaS domain, e.g. " \
+                       "https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com)"
+          end
+          return audio_error_response(
+            error: "Upstream error #{body["code"]}: #{err_msg}",
+            error_type: "api_error",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        unless response.success?
+          return audio_error_response(
+            error: "Upstream #{response.status}: #{truncate(response.body, 500)}",
+            error_type: "api_error",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        audio_url = body.dig("output", "audio", "url")
+        if audio_url.nil? || audio_url.empty?
+          return audio_error_response(
+            error: "Upstream returned no audio data",
+            error_type: "empty_response",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        # Download the audio file from OSS and save it locally in the target output directory
+        local_path = save_image_from_url(audio_url, output_dir: output_dir || Dir.pwd, prefix: "tts", extension: "wav")
+        if local_path.nil?
+          return audio_error_response(
+            error: "Failed to download generated audio from #{audio_url}",
+            error_type: "download_failed",
+            provider: PROVIDER_ID,
+            input: input,
+            voice: voice.to_s
+          )
+        end
+
+        audio_success_response(
+          audio: local_path,
+          input: input,
+          voice: chosen_voice,
+          provider: PROVIDER_ID,
+          extra: {
+            "request_id" => body["request_id"]
+          }.compact
+        )
+      end
+
+      # Generates a video using Alibaba HappyHorse or Wanx models.
+      # This is a mandatory asynchronous API. We submit the task, and poll
+      # the task status until it succeeds, fails, or times out.
+      #
+      # @param prompt [String] the video prompt
+      # @param aspect_ratio [String] "landscape", "portrait", or "square"
+      # @param duration_seconds [Integer, nil] duration in seconds
+      # @param output_dir [String, nil] the directory to save the output video
+      # @return [Hash] video_success_response or video_error_response
+      def generate_video(prompt:, aspect_ratio: "landscape", duration_seconds: nil, output_dir: nil, **_kwargs)
+        if prompt.to_s.strip.empty?
+          return video_error_response(
+            error: "Prompt is required and must be a non-empty string",
+            error_type: "invalid_argument",
+            provider: PROVIDER_ID,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        if @api_key.to_s.empty?
+          return video_error_response(
+            error: "api_key not configured for video model '#{@model}'",
+            error_type: "auth_required",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        # Map aspect ratio strings to Alibaba's ratio values (e.g. 16:9).
+        ratio = case aspect_ratio
+                when "portrait" then "9:16"
+                when "square"   then "1:1"
+                else "16:9"
+                end
+
+        # Construct payload. Ratio and resolution are placed under the "parameters" key.
+        payload = {
+          model: @model,
+          input: {
+            prompt: prompt
+          },
+          parameters: {
+            resolution: "720P",
+            ratio: ratio
+          }
+        }
+        payload[:parameters][:duration] = duration_seconds if duration_seconds
+
+        begin
+          # Submit the task. Alibaba requires 'X-DashScope-Async: enable' header for video synthesis.
+          response = connection.post(VIDEO_PATH) do |req|
+            req.headers["Content-Type"]      = "application/json"
+            req.headers["Authorization"]     = "Bearer #{@api_key}"
+            req.headers["X-DashScope-Async"] = "enable"
+            req.body = JSON.generate(payload)
+          end
+        rescue Faraday::Error => e
+          return video_error_response(
+            error: "HTTP request failed: #{e.message}",
+            error_type: "network_error",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        body = parse_json(response.body)
+        unless body.is_a?(Hash)
+          return video_error_response(
+            error: "Invalid JSON response from upstream",
+            error_type: "invalid_response",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        if body["code"] && !body["code"].to_s.empty?
+          return video_error_response(
+            error: "Upstream error #{body["code"]}: #{body["message"]}",
+            error_type: "api_error",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        unless response.success?
+          return video_error_response(
+            error: "Upstream #{response.status}: #{truncate(response.body, 500)}",
+            error_type: "api_error",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        task_id = body.dig("output", "task_id")
+        if task_id.nil? || task_id.empty?
+          return video_error_response(
+            error: "Upstream did not return a task_id",
+            error_type: "empty_response",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        # Poll the task status asynchronously. Alibaba limits video tasks, so we check
+        # status at interval blocks until completion or timeout.
+        max_duration = 300
+        interval     = 5
+        elapsed      = 0
+        video_url    = nil
+        polling_err  = nil
+
+        while elapsed < max_duration
+          begin
+            task_resp = connection.get("#{TASK_PATH}#{task_id}") do |req|
+              req.headers["Authorization"] = "Bearer #{@api_key}"
+            end
+          rescue Faraday::Error => e
+            polling_err = "Polling request failed: #{e.message}"
+            break
+          end
+
+          task_body = parse_json(task_resp.body)
+          unless task_body.is_a?(Hash)
+            polling_err = "Invalid polling response JSON"
+            break
+          end
+
+          task_output = task_body["output"] || {}
+          status = task_output["task_status"]
+
+          if status == "SUCCEEDED"
+            video_url = task_output["video_url"]
+            break
+          elsif status == "FAILED"
+            polling_err = "Task failed: #{task_output["message"] || 'Unknown error'}"
+            break
+          elsif status == "CANCELED"
+            polling_err = "Task was canceled"
+            break
+          end
+
+          sleep interval
+          elapsed += interval
+        end
+
+        if video_url.nil?
+          return video_error_response(
+            error: polling_err || "Polling timed out after #{max_duration} seconds",
+            error_type: "polling_failed",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        # Download the final MP4 video file and save it locally
+        local_path = save_image_from_url(video_url, output_dir: output_dir || Dir.pwd, prefix: "vid", extension: "mp4")
+        if local_path.nil?
+          return video_error_response(
+            error: "Failed to download generated video from #{video_url}",
+            error_type: "download_failed",
+            provider: PROVIDER_ID,
+            prompt: prompt,
+            aspect_ratio: aspect_ratio
+          )
+        end
+
+        video_success_response(
+          video: local_path,
+          prompt: prompt,
+          aspect_ratio: aspect_ratio,
+          provider: PROVIDER_ID,
+          extra: {
+            "request_id" => body["request_id"]
+          }.compact
+        )
+      end
+
       # qwen-image-max / qwen-image-plus accept only the fixed resolution set;
       # everything else (qwen-image-2.0 family, plain qwen-image) uses the 2.0
       # recommended sizes.
@@ -187,6 +510,47 @@ module Clacky
         else
           ASPECT_TO_SIZE_V2
         end
+      end
+
+      # CosyVoice models (cosyvoice-*, cosyvoice-v3-flash, etc.) use the
+      # dedicated TTS endpoint; Qwen3-TTS models (qwen3-tts-flash,
+      # qwen3-tts-instruct-flash) are served via the multimodal-generation
+      # endpoint despite being TTS — see Aliyun docs:
+      # https://help.aliyun.com/zh/model-studio/qwen-tts-api
+      #
+      # Matching is POSITIVE (by model-name pattern) so third-party
+      # aggregators that keep the official model names keep working, and
+      # unknown TTS models are not silently misrouted. Anything not
+      # recognized as Qwen3-TTS falls back to the CosyVoice endpoint for
+      # backward compatibility — every TTS model clacky supported before
+      # qwen3-tts was a CosyVoice model.
+      private def speech_endpoint
+        m = @model.to_s
+        if m.match?(/(^|[-_])qwen3-tts(-|$)/i)
+          GENERATION_PATH
+        else
+          SPEECH_PATH_COSY
+        end
+      end
+
+      private def default_speech_voice
+        speech_endpoint == GENERATION_PATH ? DEFAULT_SPEECH_VOICE_QWEN : DEFAULT_SPEECH_VOICE_COSY
+      end
+
+      # Each model family has its own payload shape. We branch on endpoint
+      # because the endpoint identity uniquely identifies the family here.
+      private def speech_payload(input:, voice:, language_type: nil)
+        input_body = { text: input, voice: voice }
+        if speech_endpoint == GENERATION_PATH
+          # Qwen3-TTS expects language_type; default to Chinese when caller
+          # doesn't specify, since most users run Chinese TTS.
+          input_body[:language_type] = (language_type.to_s.empty? ? "Chinese" : language_type)
+        else
+          # CosyVoice expects format + sample_rate.
+          input_body[:format]      = "wav"
+          input_body[:sample_rate] = 24000
+        end
+        { model: @model, input: input_body }
       end
 
       # output.choices[].message.content[].image -> first image URL

--- a/spec/clacky/media/dashscope_spec.rb
+++ b/spec/clacky/media/dashscope_spec.rb
@@ -14,22 +14,11 @@ RSpec.describe Clacky::Media::DashScope do
   end
   let(:provider) { described_class.new(entry) }
 
-  let(:captured) { {} }
   let(:fake_conn) { instance_double(Faraday::Connection) }
-  let(:fake_response) { instance_double(Faraday::Response, success?: true, status: 200, body: response_body) }
 
   before do
     allow(provider).to receive(:connection).and_return(fake_conn)
-    allow(fake_conn).to receive(:post) do |path, &blk|
-      captured[:path] = path
-      req = double("req")
-      allow(req).to receive(:headers).and_return({})
-      allow(req).to receive(:body=) { |b| captured[:body] = b }
-      blk.call(req)
-      fake_response
-    end
-    # avoid real network for the URL download step
-    allow(provider).to receive(:download_url).and_return("PNG_BYTES")
+    allow(provider).to receive(:download_url).and_return("RAW_BYTES")
   end
 
   describe "#generate_image" do
@@ -47,27 +36,34 @@ RSpec.describe Clacky::Media::DashScope do
       })
     end
 
+    before do
+      allow(fake_conn).to receive(:post).with("/api/v1/services/aigc/multimodal-generation/generation") do |&blk|
+        req = double("req")
+        allow(req).to receive(:headers).and_return({})
+        expect(req).to receive(:body=) do |body|
+          @captured_body = body
+        end
+        blk.call(req)
+        instance_double(Faraday::Response, success?: true, status: 200, body: response_body)
+      end
+    end
+
     it "posts the DashScope generation envelope and saves the downloaded image" do
       Dir.mktmpdir do |tmp|
         result = provider.generate_image(prompt: "a cute cat", aspect_ratio: "square", output_dir: tmp)
 
-        # endpoint path (host is handled by Faraday base url)
-        expect(captured[:path]).to eq("/api/v1/services/aigc/multimodal-generation/generation")
-
         # request envelope
-        sent = JSON.parse(captured[:body])
+        sent = JSON.parse(@captured_body)
         expect(sent["model"]).to eq("qwen-image-2.0-pro")
         expect(sent.dig("input", "messages", 0, "role")).to eq("user")
         expect(sent.dig("input", "messages", 0, "content", 0, "text")).to eq("a cute cat")
         expect(sent.dig("parameters", "size")).to eq("2048*2048")
         expect(sent.dig("parameters", "n")).to eq(1)
-        expect(sent.dig("parameters", "prompt_extend")).to be true
-        expect(sent.dig("parameters", "watermark")).to be false
 
         # response
         expect(result["success"]).to be true
         expect(result["image"]).to start_with(File.join(tmp, "assets", "generated"))
-        expect(File.binread(result["image"])).to eq("PNG_BYTES")
+        expect(File.binread(result["image"])).to eq("RAW_BYTES")
         expect(result["provider"]).to eq("qwen")
         expect(result["model"]).to eq("qwen-image-2.0-pro")
         expect(result["size"]).to eq("2048*2048")
@@ -85,24 +81,288 @@ RSpec.describe Clacky::Media::DashScope do
     it "uses the fixed resolution set for qwen-image-max models" do
       max_provider = described_class.new(entry.merge("model" => "qwen-image-max"))
       allow(max_provider).to receive(:connection).and_return(fake_conn)
-      allow(max_provider).to receive(:download_url).and_return("PNG_BYTES")
+      allow(max_provider).to receive(:download_url).and_return("RAW_BYTES")
+
+      allow(fake_conn).to receive(:post).with("/api/v1/services/aigc/multimodal-generation/generation") do |&blk|
+        req = double("req")
+        allow(req).to receive(:headers).and_return({})
+        expect(req).to receive(:body=) do |body|
+          @captured_body = body
+        end
+        blk.call(req)
+        instance_double(Faraday::Response, success?: true, status: 200, body: response_body)
+      end
+
       Dir.mktmpdir do |tmp|
         result = max_provider.generate_image(prompt: "x", aspect_ratio: "landscape", output_dir: tmp)
         expect(result["size"]).to eq("1664*928")
-        expect(JSON.parse(captured[:body]).dig("parameters", "size")).to eq("1664*928")
+        expect(JSON.parse(@captured_body).dig("parameters", "size")).to eq("1664*928")
+      end
+    end
+  end
+
+  describe "#generate_speech" do
+    let(:speech_entry) do
+      entry.merge("model" => "cosyvoice-v3-flash")
+    end
+    let(:speech_provider) { described_class.new(speech_entry) }
+
+    before do
+      allow(speech_provider).to receive(:connection).and_return(fake_conn)
+      allow(speech_provider).to receive(:download_url).and_return("AUDIO_BYTES")
+    end
+
+    context "with valid input" do
+      let(:response_body) do
+        JSON.generate({
+          "output" => {
+            "audio" => {
+              "url" => "https://oss.example.com/speech.wav"
+            }
+          },
+          "request_id" => "req-speech-123"
+        })
+      end
+
+      it "calls the cosyvoice tts endpoint and saves the generated audio" do
+        expect(fake_conn).to receive(:post).with("/api/v1/services/audio/tts/SpeechSynthesizer") do |&blk|
+          req = double("req")
+          headers = {}
+          allow(req).to receive(:headers).and_return(headers)
+          expect(req).to receive(:body=) do |body|
+            @captured_body = body
+          end
+          blk.call(req)
+          expect(headers["Content-Type"]).to eq("application/json")
+          expect(headers["Authorization"]).to eq("Bearer sk-test-key")
+          instance_double(Faraday::Response, success?: true, status: 200, body: response_body)
+        end
+
+        Dir.mktmpdir do |tmp|
+          result = speech_provider.generate_speech(input: "hello world", voice: "longanyang", output_dir: tmp)
+
+          expect(result["success"]).to be true
+          expect(result["audio"]).to start_with(File.join(tmp, "assets", "generated"))
+          expect(File.binread(result["audio"])).to eq("AUDIO_BYTES")
+          expect(result["provider"]).to eq("qwen")
+          expect(result["model"]).to eq("cosyvoice-v3-flash")
+          expect(result["voice"]).to eq("longanyang")
+          expect(result["request_id"]).to eq("req-speech-123")
+
+          sent = JSON.parse(@captured_body)
+          expect(sent["model"]).to eq("cosyvoice-v3-flash")
+          expect(sent.dig("input", "text")).to eq("hello world")
+          expect(sent.dig("input", "voice")).to eq("longanyang")
+          expect(sent.dig("input", "format")).to eq("wav")
+        end
       end
     end
 
-    it "defaults to landscape for an unknown aspect_ratio" do
-      Dir.mktmpdir do |tmp|
-        result = provider.generate_image(prompt: "x", aspect_ratio: "panoramic", output_dir: tmp)
-        expect(result["aspect_ratio"]).to eq("landscape")
+    context "with a Qwen3-TTS model" do
+      let(:qwen_entry) { entry.merge("model" => "qwen3-tts-flash") }
+      let(:qwen_provider) { described_class.new(qwen_entry) }
+
+      before do
+        allow(qwen_provider).to receive(:connection).and_return(fake_conn)
+        allow(qwen_provider).to receive(:download_url).and_return("AUDIO_BYTES")
+      end
+
+      let(:response_body) do
+        JSON.generate({
+          "output" => {
+            "audio" => {
+              "url" => "https://oss.example.com/speech.wav"
+            }
+          },
+          "request_id" => "req-qwen-tts-1"
+        })
+      end
+
+      it "routes to the multimodal-generation endpoint and builds the Qwen3-TTS payload" do
+        expect(fake_conn).to receive(:post).with("/api/v1/services/aigc/multimodal-generation/generation") do |&blk|
+          req = double("req")
+          headers = {}
+          allow(req).to receive(:headers).and_return(headers)
+          expect(req).to receive(:body=) do |body|
+            @captured_body = body
+          end
+          blk.call(req)
+          instance_double(Faraday::Response, success?: true, status: 200, body: response_body)
+        end
+
+        Dir.mktmpdir do |tmp|
+          result = qwen_provider.generate_speech(input: "你好", output_dir: tmp)
+
+          expect(result["success"]).to be true
+          expect(result["voice"]).to eq("Cherry") # default for Qwen3-TTS
+
+          sent = JSON.parse(@captured_body)
+          expect(sent["model"]).to eq("qwen3-tts-flash")
+          expect(sent.dig("input", "text")).to eq("你好")
+          expect(sent.dig("input", "voice")).to eq("Cherry")
+          expect(sent.dig("input", "language_type")).to eq("Chinese")
+          # Qwen3-TTS must NOT send format/sample_rate (those are CosyVoice-only)
+          expect(sent.dig("input", "format")).to be_nil
+          expect(sent.dig("input", "sample_rate")).to be_nil
+        end
+      end
+
+      it "honors an explicit voice and language_type" do
+        expect(fake_conn).to receive(:post).with("/api/v1/services/aigc/multimodal-generation/generation") do |&blk|
+          req = double("req")
+          allow(req).to receive(:headers).and_return({})
+          expect(req).to receive(:body=) do |body|
+            @captured_body = body
+          end
+          blk.call(req)
+          instance_double(Faraday::Response, success?: true, status: 200, body: response_body)
+        end
+
+        Dir.mktmpdir do |tmp|
+          qwen_provider.generate_speech(input: "hello", voice: "Ethan", language_type: "English", output_dir: tmp)
+
+          sent = JSON.parse(@captured_body)
+          expect(sent.dig("input", "voice")).to eq("Ethan")
+          expect(sent.dig("input", "language_type")).to eq("English")
+        end
+      end
+    end
+
+    context "validation and errors" do
+      it "rejects empty input" do
+        result = speech_provider.generate_speech(input: "  ")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("invalid_argument")
+      end
+
+      it "rejects empty api_key" do
+        no_key = described_class.new(speech_entry.merge("api_key" => ""))
+        result = no_key.generate_speech(input: "hello")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("auth_required")
+      end
+
+      it "surfaces business error payloads" do
+        err_body = JSON.generate({ "code" => "Forbidden", "message" => "Access denied" })
+        expect(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: err_body))
+
+        result = speech_provider.generate_speech(input: "hello")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("api_error")
+        expect(result["error"]).to include("Forbidden")
+      end
+    end
+  end
+
+  describe "#generate_video" do
+    let(:video_entry) do
+      entry.merge("model" => "happyhorse-1.1-t2v")
+    end
+    let(:video_provider) { described_class.new(video_entry) }
+
+    before do
+      allow(video_provider).to receive(:connection).and_return(fake_conn)
+      allow(video_provider).to receive(:download_url).and_return("VIDEO_BYTES")
+      allow(video_provider).to receive(:sleep) # avoid real sleeping during tests
+    end
+
+    context "with successful asynchronous polling" do
+      let(:submit_response) do
+        JSON.generate({
+          "output" => {
+            "task_id" => "task-999",
+            "task_status" => "PENDING"
+          },
+          "request_id" => "req-vid-1"
+        })
+      end
+
+      let(:poll_response_running) do
+        JSON.generate({
+          "output" => {
+            "task_id" => "task-999",
+            "task_status" => "RUNNING"
+          }
+        })
+      end
+
+      let(:poll_response_succeeded) do
+        JSON.generate({
+          "output" => {
+            "task_id" => "task-999",
+            "task_status" => "SUCCEEDED",
+            "video_url" => "https://oss.example.com/result.mp4"
+          }
+        })
+      end
+
+      it "submits task with async header and polls until SUCCEEDED" do
+        expect(fake_conn).to receive(:post).with("/api/v1/services/aigc/video-generation/video-synthesis") do |&blk|
+          req = double("req")
+          headers = {}
+          allow(req).to receive(:headers).and_return(headers)
+          expect(req).to receive(:body=) do |body|
+            @captured_body = body
+          end
+          blk.call(req)
+          expect(headers["X-DashScope-Async"]).to eq("enable")
+          instance_double(Faraday::Response, success?: true, status: 200, body: submit_response)
+        end
+
+        expect(fake_conn).to receive(:get).with("/api/v1/tasks/task-999").twice.and_return(
+          instance_double(Faraday::Response, success?: true, body: poll_response_running),
+          instance_double(Faraday::Response, success?: true, body: poll_response_succeeded)
+        )
+
+        Dir.mktmpdir do |tmp|
+          result = video_provider.generate_video(prompt: "a horse running", aspect_ratio: "landscape", output_dir: tmp)
+
+          expect(result["success"]).to be true
+          expect(result["video"]).to start_with(File.join(tmp, "assets", "generated"))
+          expect(File.binread(result["video"])).to eq("VIDEO_BYTES")
+          expect(result["provider"]).to eq("qwen")
+          expect(result["model"]).to eq("happyhorse-1.1-t2v")
+          expect(result["request_id"]).to eq("req-vid-1")
+
+          sent = JSON.parse(@captured_body)
+          expect(sent.dig("parameters", "ratio")).to eq("16:9")
+        end
+      end
+    end
+
+    context "when polling fails or errors out" do
+      let(:submit_response) do
+        JSON.generate({ "output" => { "task_id" => "task-999" } })
+      end
+
+      let(:poll_response_failed) do
+        JSON.generate({
+          "output" => {
+            "task_status" => "FAILED",
+            "message" => "Inappropriate content"
+          }
+        })
+      end
+
+      it "surfaces task failure during polling" do
+        allow(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: submit_response))
+        expect(fake_conn).to receive(:get).with("/api/v1/tasks/task-999").and_return(
+          instance_double(Faraday::Response, success?: true, body: poll_response_failed)
+        )
+
+        result = video_provider.generate_video(prompt: "abc")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("polling_failed")
+        expect(result["error"]).to include("Inappropriate content")
       end
     end
   end
 
   describe "validation" do
-    let(:response_body) { "{}" }
+    before do
+      # Mock post for standard error validation paths
+      allow(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: "{}"))
+    end
 
     it "rejects an empty prompt without calling upstream" do
       expect(fake_conn).not_to receive(:post)
@@ -125,6 +385,10 @@ RSpec.describe Clacky::Media::DashScope do
     context "with a DashScope business error payload" do
       let(:response_body) { JSON.generate({ "code" => "InvalidParameter", "message" => "num_images_per_prompt must be 1", "request_id" => "r1" }) }
 
+      before do
+        allow(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: response_body))
+      end
+
       it "surfaces code and message as an api_error" do
         result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
         expect(result["success"]).to be false
@@ -136,6 +400,10 @@ RSpec.describe Clacky::Media::DashScope do
 
     context "with an empty choices payload" do
       let(:response_body) { JSON.generate({ "output" => { "choices" => [] } }) }
+
+      before do
+        allow(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: response_body))
+      end
 
       it "returns empty_response" do
         result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
@@ -149,6 +417,10 @@ RSpec.describe Clacky::Media::DashScope do
         JSON.generate({ "output" => { "choices" => [{ "message" => { "content" => [{ "image" => "https://oss.example.com/x.png" }] } }] } })
       end
 
+      before do
+        allow(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: response_body))
+      end
+
       it "returns download_failed" do
         allow(provider).to receive(:download_url).and_return(nil)
         result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)
@@ -159,6 +431,10 @@ RSpec.describe Clacky::Media::DashScope do
 
     context "with invalid JSON" do
       let(:response_body) { "<html>500</html>" }
+
+      before do
+        allow(fake_conn).to receive(:post).and_return(instance_double(Faraday::Response, success?: true, status: 200, body: response_body))
+      end
 
       it "returns invalid_response" do
         result = provider.generate_image(prompt: "x", output_dir: Dir.pwd)


### PR DESCRIPTION
### Problem
DashScope media provider only supported image generation. Aliyun Model Studio exposes TTS (CosyVoice + Qwen3-TTS, on two different endpoints with different payload shapes) and video generation (HappyHorse, asynchronous with task polling), but clacky couldn't drive either, so users wiring up Aliyun TTS/video models got nothing.

### Fix
- `generate_speech`: routes by model name — qwen3-tts models hit the multimodal-generation endpoint with a `language_type` payload; everything else falls back to the CosyVoice SpeechSynthesizer endpoint with `format`/`sample_rate`. Per-family default voices, explicit `voice`/`language_type` honored. Includes an English url-error hint pointing users at the MaaS domain, since non-real-time TTS doesn't work on the shared `dashscope.aliyuncs.com` host.
- `generate_video`: submits to the video-synthesis endpoint with the async header, polls `TASK_PATH` until SUCCEEDED, surfaces task failures.
- Documented the pending Aliyun endpoint migration (shared host -> `{WorkspaceId}.maas.aliyuncs.com`) with current stance and trigger conditions for flipping the default.
- Expanded `dashscope_spec` to cover both TTS families (endpoint routing, payload shape, explicit voice/language, validation, business-error surfaces) and video (async polling success + failure).

### Test
- ✅ `bundle exec rspec spec/clacky/media/dashscope_spec.rb -fd` — 19 examples, 0 failures
- ✅ Covers image, CosyVoice TTS, Qwen3-TTS TTS, video async polling, validation, and error handling
- ✅ Manually verified against live DashScope (CosyVoice + Qwen3-TTS + video)