### PR TITLE
fix(webui): detect scrollbar-drag as user scroll to stop auto-scroll (C-5629)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -411,42 +411,27 @@ const Sessions = (() => {
       _hideNewMessageBanner();
     });
 
-    // Detect actual user scroll interactions (wheel, touch, keyboard)
-    // These fire BEFORE the scroll event, so we can set the flag reliably.
-    const detectUserScroll = (e) => {
-      // Only flag if user is scrolling up (negative deltaY = scroll up)
-      // For wheel events: deltaY < 0 means scroll up
-      // For touch/keyboard: check scroll position in the scroll event
-      const isWheelUp = e.type === "wheel" && e.deltaY < 0;
-      const isKeyboardUp = e.type === "keydown" && (e.key === "ArrowUp" || e.key === "PageUp" || e.key === "Home");
-      
-      if (isWheelUp || isKeyboardUp) {
-        _userScrolledUp = true;
-      }
-    };
-
-    messages.addEventListener("wheel", detectUserScroll, { passive: true });
-    messages.addEventListener("keydown", detectUserScroll);
-    
-    // For touch devices: touchmove doesn't tell us direction, so check in scroll event
-    let touchStartY = 0;
-    messages.addEventListener("touchstart", (e) => {
-      touchStartY = e.touches[0].clientY;
-    }, { passive: true });
-    
-    messages.addEventListener("touchmove", (e) => {
-      const touchDeltaY = e.touches[0].clientY - touchStartY;
-      // touchDeltaY > 0 means finger moved down = content scrolls up
-      if (touchDeltaY > 5) {
-        _userScrolledUp = true;
-      }
-    }, { passive: true });
-
-    // Monitor scroll position: clear flag when user reaches bottom
+    // Single source of truth for "is the user browsing history?": the scroll
+    // position itself. Every scrolling method — mouse wheel, dragging the
+    // scrollbar, keyboard (Up/PageUp/Home/Space), touch swipe and momentum
+    // scrolling — funnels through the `scroll` event, so reading the position
+    // here covers them all with no blind spots.
+    //
+    // The previous approach instead listened to specific input events
+    // (wheel/keydown/touchmove) to *infer* intent. Dragging the scrollbar
+    // fires `scroll` but none of those, so it was never detected and AI
+    // messages kept yanking the view back to the bottom — see C-5629.
+    //
+    // Streaming-append safety: appending content grows scrollHeight but leaves
+    // scrollTop untouched (verified in-browser, even with overflow-anchor:auto),
+    // so a content update never moves us "away from bottom" and never trips a
+    // false positive here. The 150px threshold in _isAtBottom is extra slack.
     messages.addEventListener("scroll", () => {
       if (_isAtBottom(messages)) {
         _userScrolledUp = false;
         _hideNewMessageBanner();
+      } else {
+        _userScrolledUp = true;
       }
     });
   }


### PR DESCRIPTION
## Problem
While reading scrollback, dragging the scrollbar up did not pause auto-scroll: incoming AI messages forcibly snapped the view back to the bottom. The old logic *inferred* user intent by listening to specific input events (`wheel`/`keydown`/`touchmove`). Dragging the scrollbar fires `scroll` but none of those, so it was a blind spot and `_userScrolledUp` stayed `false`.

## Fix
Drive the flag from scroll **position** instead of input type. The `scroll` event is the single funnel for every scrolling method (wheel, scrollbar drag, keyboard, touch, momentum), so one check covers them all: set `_userScrolledUp = true` when not at bottom, clear it when back at bottom. Removed the now-redundant `wheel`/`keydown`/`touchstart`/`touchmove` listeners and the `detectUserScroll` helper.

## Test
- ✅ Drag scrollbar up while AI streams — view stays put, "new messages" banner shows
- ✅ Mouse wheel / keyboard (Up·PageUp·Home) / touch swipe up — same, not interrupted
- ✅ Scroll back to bottom — auto-follow resumes, banner clears
- ✅ Streaming while pinned to bottom — keeps following, no jitter (verified in-browser: append leaves scrollTop unchanged even with `overflow-anchor:auto`)
- ✅ Click banner / switch session — jumps to bottom and follows correctly