### PR TITLE
fix(terminal): adaptive GBK/UTF-8 decoding for PTY output (C-5631)

### DIFF
--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -340,10 +340,6 @@ module Clacky
           project_root: cwd || Dir.pwd
         )
 
-        # PowerShell 5 on Chinese Windows emits CP936/GBK by default; force
-        # UTF-8 so our PTY (which decodes as UTF-8) doesn't see ??? bytes.
-        safe_command = force_powershell_utf8(safe_command)
-
         # Background / dedicated path — never reuse the persistent shell,
         # because these commands stay running and would occupy the slot.
         if background
@@ -1521,45 +1517,6 @@ module Clacky
         lines = text.split(/\r?\n/).reject { |l| l.strip.empty? }
         return "" if lines.empty?
         lines.last(DISPLAY_TAIL_LINES).join("\n")
-      end
-
-      # PowerShell 5 on Chinese Windows defaults [Console]::OutputEncoding
-      # to CP936/GBK; our PTY decodes as UTF-8 so non-ASCII output becomes
-      # `???`. Inject UTF-8 setup into the user's PowerShell command so the
-      # shell emits UTF-8 bytes regardless of host locale.
-      POWERSHELL_PREAMBLE =
-        "[Console]::OutputEncoding=[Text.Encoding]::UTF8;"
-
-      # Only rewrites simple `powershell[.exe]` / `pwsh[.exe]` invocations.
-      # Skips -File / -EncodedCommand / commands already handling encoding /
-      # pipelines (anything risky to splice).
-      private def force_powershell_utf8(command)
-        cmd = command.to_s
-        return command unless cmd =~ /\A\s*(?:powershell(?:\.exe)?|pwsh(?:\.exe)?)\b/i
-        return command if cmd =~ /OutputEncoding/i
-        return command if cmd =~ /\s-(?:File|EncodedCommand|enc|f)\b/i
-
-        # `-Command "..."` form: pipeline / chain characters inside the
-        # quoted body are PowerShell-internal, not shell-level, so we splice
-        # safely into the quoted string.
-        if (m = cmd.match(/\A(\s*(?:powershell(?:\.exe)?|pwsh(?:\.exe)?)\s+(?:[^"'\s]+\s+)*?-(?:Command|c)\s+)(["'])(.*)\2(\s*(?:<\s*\S+\s*)?)\z/i))
-          head, quote, body, tail = m[1], m[2], m[3], m[4].to_s
-          return "#{head}#{quote}#{POWERSHELL_PREAMBLE}#{body}#{quote}#{tail}"
-        end
-
-        # Outside the quoted-Command form, refuse to splice if there's any
-        # shell-level pipe / chain — too risky to get the boundaries right.
-        return command if cmd =~ /[|&;]/
-
-        if (m = cmd.match(/\A(\s*(?:powershell(?:\.exe)?|pwsh(?:\.exe)?))(.*)\z/i))
-          exe, rest = m[1], m[2].to_s.strip
-          return command if rest.start_with?("-") && rest !~ /\A-(?:Command|c)\b/i
-          rest = rest.sub(/\A-(?:Command|c)\b\s*/i, "")
-          inner = rest.empty? ? POWERSHELL_PREAMBLE.chomp(";") : "#{POWERSHELL_PREAMBLE}#{rest}"
-          return %Q{#{exe} -Command "#{inner}"}
-        end
-
-        command
       end
     end
   end

--- a/lib/clacky/tools/terminal/output_cleaner.rb
+++ b/lib/clacky/tools/terminal/output_cleaner.rb
@@ -35,9 +35,7 @@ module Clacky
         def clean(raw)
           return "" if raw.nil? || raw.empty?
 
-          s = raw.dup
-          s.force_encoding(Encoding::UTF_8)
-          s = s.scrub("?") unless s.valid_encoding?
+          s = Clacky::Utils::Encoding.pty_to_utf8(raw)
 
           s = s.gsub(CSI_REGEX, "")
           s = s.gsub(OSC_REGEX, "")

--- a/lib/clacky/utils/encoding.rb
+++ b/lib/clacky/utils/encoding.rb
@@ -75,6 +75,31 @@ module Clacky
         to_utf8(data)
       end
 
+      # Decode a raw PTY byte stream to valid UTF-8, auto-detecting the source
+      # encoding. UTF-8 is tried first (Linux/macOS and modern programs); when
+      # the bytes are not valid UTF-8 they are decoded as GBK/CP936 (Simplified
+      # Chinese Windows powershell.exe / cmd.exe default output); anything that
+      # still fails is scrubbed.
+      #
+      # MUST be called on complete byte runs — callers slice on "\n" (0x0A),
+      # which is never a trailing byte of a GBK or UTF-8 multibyte sequence, so
+      # a character is never split across the boundary.
+      #
+      # @param data [String, nil] raw PTY bytes (binary/ASCII-8BIT)
+      # @return [String] valid UTF-8 string
+      def self.pty_to_utf8(data)
+        return "" if data.nil? || data.empty?
+
+        s = data.dup.force_encoding("UTF-8")
+        return s if s.valid_encoding?
+
+        data.dup
+            .force_encoding("GBK")
+            .encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+      rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+        to_utf8(data)
+      end
+
       # Return an ASCII-safe UTF-8 copy of *str* suitable for security regex
       # pattern matching.  Any byte that is not valid in the source encoding, or
       # that cannot be represented in UTF-8, is replaced with '?'.  The

--- a/spec/clacky/tools/terminal_spec.rb
+++ b/spec/clacky/tools/terminal_spec.rb
@@ -897,69 +897,6 @@ RSpec.describe Clacky::Tools::Terminal do
     end
   end
 
-  describe "#force_powershell_utf8" do
-    let(:terminal) { described_class.new }
-    def call(cmd)
-      terminal.send(:force_powershell_utf8, cmd)
-    end
-
-    it "injects UTF-8 setup into -Command \"...\" form, preserving the rest" do
-      out = call(%q{powershell.exe -Command "Get-NetIPAddress | Select-Object InterfaceAlias"})
-      expect(out).to eq(%q{powershell.exe -Command "[Console]::OutputEncoding=[Text.Encoding]::UTF8;Get-NetIPAddress | Select-Object InterfaceAlias"})
-    end
-
-    it "handles -c short form and pwsh" do
-      expect(call(%q{powershell.exe -c "Get-Process"})).to include("UTF8;Get-Process")
-      expect(call(%q{pwsh -Command "Get-Date"})).to start_with("pwsh -Command \"[Console]")
-    end
-
-    it "rewrites bare invocation into -Command form" do
-      out = call(%q{powershell.exe Get-Process})
-      expect(out).to eq(%q{powershell.exe -Command "[Console]::OutputEncoding=[Text.Encoding]::UTF8;Get-Process"})
-    end
-
-    it "handles -Command without quotes" do
-      out = call(%q{powershell -Command Get-Date})
-      expect(out).to eq(%q{powershell -Command "[Console]::OutputEncoding=[Text.Encoding]::UTF8;Get-Date"})
-    end
-
-    it "splices through other PS flags like -NoProfile" do
-      out = call(%q{powershell.exe -NoProfile -Command "Get-Process"})
-      expect(out).to include("-NoProfile -Command \"[Console]")
-      expect(out).to end_with("Get-Process\"")
-    end
-
-    it "leaves -File invocations alone" do
-      cmd = %q{powershell.exe -File foo.ps1}
-      expect(call(cmd)).to eq(cmd)
-    end
-
-    it "leaves -EncodedCommand alone" do
-      cmd = %q{powershell.exe -EncodedCommand SQBuAHYAbwBrAGUA}
-      expect(call(cmd)).to eq(cmd)
-    end
-
-    it "is idempotent when OutputEncoding is already set" do
-      cmd = %q{powershell.exe -Command "[Console]::OutputEncoding=[Text.Encoding]::UTF8; Get-Date"}
-      expect(call(cmd)).to eq(cmd)
-    end
-
-    it "ignores non-powershell commands" do
-      expect(call("ls /tmp")).to eq("ls /tmp")
-      expect(call("cmd.exe /c dir")).to eq("cmd.exe /c dir")
-    end
-
-    it "refuses to splice across shell-level pipelines" do
-      cmd = %q{cat foo | powershell.exe -Command "Get-Date"}
-      expect(call(cmd)).to eq(cmd)
-    end
-
-    it "handles bare `powershell.exe` with no args" do
-      out = call("powershell.exe")
-      expect(out).to start_with("powershell.exe -Command \"[Console]")
-    end
-  end
-
   # ---------------------------------------------------------------------------
   # #exe_needs_stdin_isolation? — decides whether the user-command wrapper
   # should append `</dev/null` so Windows .exe interop children don't inherit
@@ -1166,6 +1103,19 @@ RSpec.describe Clacky::Tools::Terminal do
 
       it "is idempotent on already-clean text" do
         expect(described_class.clean("hello world\n")).to eq("hello world\n")
+      end
+
+      it "decodes GBK output from Chinese Windows shells" do
+        # Real bytes from `powershell.exe -Command "Write-Host '你好，世界'"` on CP936.
+        raw = [0xC4, 0xE3, 0xBA, 0xC3, 0xA3, 0xAC, 0xCA, 0xC0, 0xBD, 0xE7, 0x0D, 0x0A].pack("C*").b
+        cleaned = described_class.clean(raw)
+
+        expect(cleaned.encoding).to eq(Encoding::UTF_8)
+        expect(cleaned).to eq("你好，世界\n")
+      end
+
+      it "preserves UTF-8 Chinese unchanged (Linux/macOS)" do
+        expect(described_class.clean("你好，世界\n".encode("UTF-8").b)).to eq("你好，世界\n")
       end
 
       it "scrubs invalid UTF-8 byte sequences into a valid UTF-8 string" do

--- a/spec/clacky/utils/encoding_spec.rb
+++ b/spec/clacky/utils/encoding_spec.rb
@@ -78,6 +78,73 @@ RSpec.describe Clacky::Utils::Encoding do
     end
   end
 
+  describe ".pty_to_utf8" do
+    context "with nil or empty input" do
+      it "returns empty string for nil" do
+        expect(described_class.pty_to_utf8(nil)).to eq("")
+      end
+
+      it "returns empty string for empty string" do
+        expect(described_class.pty_to_utf8("")).to eq("")
+      end
+    end
+
+    context "with UTF-8 bytes (Linux/macOS and modern programs)" do
+      it "decodes UTF-8 Chinese unchanged" do
+        result = described_class.pty_to_utf8("你好，世界".encode("UTF-8").b)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result).to eq("你好，世界")
+      end
+
+      it "passes ASCII through unchanged" do
+        result = described_class.pty_to_utf8("Hello World\n".b)
+        expect(result).to eq("Hello World\n")
+      end
+
+      it "preserves multibyte emoji" do
+        expect(described_class.pty_to_utf8("OK 完成 ✓".encode("UTF-8").b)).to eq("OK 完成 ✓")
+      end
+    end
+
+    context "with GBK bytes (Simplified Chinese Windows powershell.exe / cmd.exe)" do
+      # Real bytes captured from `powershell.exe -Command "Write-Host '你好，世界'"`
+      # on a CP936 host: c4e3 bac3 a3ac cac0 bde7
+      let(:gbk_greeting) do
+        [0xC4, 0xE3, 0xBA, 0xC3, 0xA3, 0xAC, 0xCA, 0xC0, 0xBD, 0xE7].pack("C*").b
+      end
+
+      it "falls back to GBK and decodes correctly" do
+        result = described_class.pty_to_utf8(gbk_greeting)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result).to eq("你好，世界")
+      end
+
+      it "decodes a GBK line with trailing CRLF (cmd.exe form)" do
+        bytes = gbk_greeting + [0x0D, 0x0A].pack("C*").b
+        result = described_class.pty_to_utf8(bytes)
+        expect(result).to eq("你好，世界\r\n")
+      end
+    end
+
+    context "with genuinely invalid bytes" do
+      it "scrubs unrepresentable sequences rather than raising" do
+        raw = [0xFF, 0xFE, 0xFD].pack("C*").b
+        expect { described_class.pty_to_utf8(raw) }.not_to raise_error
+        expect(described_class.pty_to_utf8(raw).encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context "line-based slicing never splits a multibyte char (PTY \\n boundary)" do
+      it "decodes each GBK line correctly when split on \\n" do
+        line = [0xC4, 0xE3, 0xBA, 0xC3].pack("C*").b   # 你好 in GBK
+        stream = line + "\n".b + line + "\n".b
+        decoded = stream.split("\n".b, -1).map { |seg| described_class.pty_to_utf8(seg) }
+        expect(decoded[0]).to eq("你好")
+        expect(decoded[1]).to eq("你好")
+      end
+    end
+  end
+
   describe "code audit: all backtick command calls must be wrapped with cmd_to_utf8 or to_utf8" do
     # Core lib files only — exclude default_skills (deploy/channel scripts run in controlled envs)
     CORE_SOURCE_FILES = (


### PR DESCRIPTION
## Problem

On Chinese Windows/WSL, PowerShell 5 and cmd.exe emit non-ASCII output in CP936/GBK, while our PTY reader decoded bytes as UTF-8 unconditionally. GBK bytes are invalid UTF-8, so Chinese characters were scrubbed into `???`.

The previous fix injected a UTF-8 preamble into the user's PowerShell command (`force_powershell_utf8` / `POWERSHELL_PREAMBLE`). This was fragile: it only matched simple `powershell -Command "..."` forms, skipped `cmd.exe`, and broke down for chained commands (`&&`), pipelines, and arbitrary `.exe` invocations.

## Fix

Stop rewriting commands. Decode adaptively at the read end instead:

- Add `Encoding.pty_to_utf8(data)` — try UTF-8 first (`valid_encoding?`), fall back to GBK, and scrub as a last resort.
- Route `OutputCleaner.clean` through `pty_to_utf8`.
- Remove `force_powershell_utf8`, `POWERSHELL_PREAMBLE`, and their call site.

This is treats the root cause and covers every command shape (cmd.exe, `&&` chains, pipelines, any exe). macOS/Linux are unaffected: their output is valid UTF-8, so they hit the UTF-8 branch first — byte-for-byte identical to before. `redirect_exe_stdin` (an unrelated `.exe` stdin concern) is left untouched.

## Test

- ✅ `encoding_spec.rb` — UTF-8 passthrough, real GBK byte arrays, CRLF cases
- ✅ `terminal_spec.rb` — `OutputCleaner.clean` GBK decode + UTF-8 preserve
- ✅ Related specs: 119 examples, 0 failures
- ✅ Full suite: 2490 examples, 0 failures (macOS)
- ✅ Manual WSL: `powershell.exe -Command "Write-Host '你好，世界'"`, cmd.exe, and `&&`-chained commands all render Chinese correctly