### PR TITLE
fix(client): resolve vision support against request model (C-5636)

### DIFF
--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -34,11 +34,6 @@ module Clacky
       # some OpenRouter-compatible relays only honour Bearer — send both).
       @provider_id = provider_id
 
-      # Determine vision support once at construction time.
-      # Non-vision models (DeepSeek, Kimi, MiniMax, etc.) reject image_url
-      # content blocks; the conversion layer strips them when this is false.
-      @vision_supported = Providers.supports?(provider_id, :vision, model_name: @model)
-
       # Optional override for Faraday read_timeout (e.g. benchmark calls).
       # nil means use the default (300s for streaming).
       @read_timeout = read_timeout
@@ -343,9 +338,12 @@ module Clacky
       # OpenRouter proxies Claude with the same cache_control field convention as Anthropic direct.
       messages = apply_message_caching(messages) if caching_enabled
 
+      # Vision support is resolved against the request's actual model (which may
+      # differ from @model after a runtime switch or fallback override), so the
+      # conversion layer strips image_url blocks for non-vision models.
       body = MessageFormat::OpenAI.build_request_body(
         messages, model, tools, max_tokens, caching_enabled,
-        vision_supported: @vision_supported,
+        vision_supported: Providers.supports?(@provider_id, :vision, model_name: model),
         reasoning_effort: reasoning_effort
       )
       return send_openai_stream_request(body, on_chunk) if on_chunk

--- a/spec/clacky/client_vision_strip_model_switch_spec.rb
+++ b/spec/clacky/client_vision_strip_model_switch_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/client"
+
+# Regression guard (C-5636): vision support must be resolved against the
+# request's actual model, not the model the Client was constructed with.
+#
+# A Client built on a vision-capable model (qwen3.6-plus) used to cache
+# @vision_supported = true at construction time. When the request was then
+# sent with a non-vision model (qwen3.7-max) — via a runtime model switch or a
+# fallback override — image_url blocks were NOT stripped, and the upstream
+# rejected the request with:
+#   400 InternalError.Algo.InvalidParameter: ... [Unexpected item type in content.]
+RSpec.describe Clacky::Client, "vision strip follows request model" do
+  let(:api_key)  { "sk-test" }
+  let(:base_url) { "https://dashscope.aliyuncs.com/compatible-mode/v1" }
+
+  let(:client) do
+    described_class.new(api_key, base_url: base_url, model: "qwen3.6-plus")
+  end
+
+  let(:messages_with_image) do
+    [
+      { role: "user", content: [
+        { type: "text", text: "what is this?" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,#{"A" * 64}" } }
+      ] }
+    ]
+  end
+
+  def capture_request_body(request_model)
+    captured = nil
+    fake_response = instance_double(
+      Faraday::Response, status: 200,
+      body: { "choices" => [{ "message" => { "content" => "ok" } }] }.to_json
+    )
+    fake_conn = instance_double(Faraday::Connection)
+    allow(client).to receive(:openai_connection).and_return(fake_conn)
+    allow(fake_conn).to receive(:post) do |&block|
+      req = Struct.new(:body).new
+      block.call(req)
+      captured = JSON.parse(req.body)
+      fake_response
+    end
+
+    client.send(:send_openai_request, messages_with_image, request_model, [], 1024, false)
+    captured
+  end
+
+  it "strips image_url when the request model is non-vision (qwen3.7-max)" do
+    body = capture_request_body("qwen3.7-max")
+    content = body["messages"].last["content"]
+    flat = content.is_a?(Array) ? content.map { |b| b.to_s }.join : content.to_s
+
+    expect(flat).not_to include("image_url")
+    expect(flat).to include("Image content removed")
+  end
+
+  it "keeps image_url when the request model is vision-capable (qwen3.6-plus)" do
+    body = capture_request_body("qwen3.6-plus")
+    content = body["messages"].last["content"]
+    types = content.map { |b| b["type"] }
+
+    expect(types).to include("image_url")
+  end
+end


### PR DESCRIPTION
## Problem
When the context contains an image and the user switches from a multimodal model (e.g. qwen3.6-plus) to a non-multimodal model of the same provider (e.g. qwen3.7-max), the next request fails with: `400 InternalError.Algo.InvalidParameter: The provided messages input is invalid. The error info is [Unexpected item type in content.]`

The conversion layer already strips `image_url` blocks for non-vision models, but `Client` resolved `@vision_supported` **once at construction time** from the model it was built with, and reused that stale value for every request. When the request's actual model differed from the construction model (runtime switch / fallback override), the stale `true` left `image_url` blocks intact for a non-vision model, so the upstream rejected them.

## Fix
Resolve vision support against the request's actual `model` at send time instead of caching it at construction. Removed the construction-time `@vision_supported` and compute `Providers.supports?(@provider_id, :vision, model_name: model)` inside `send_openai_request`, mirroring the existing per-request `caching_enabled` pattern. One source of truth eliminates the divergence across all paths (manual switch, fallback, restore).

## Test
- New `spec/clacky/client_vision_strip_model_switch_spec.rb`: a Client built on qwen3.6-plus (vision) sending with qwen3.7-max (non-vision) must strip `image_url` to a text placeholder; sending with qwen3.6-plus must keep it.
- Full suite: 2492 examples, 0 failures.