### PR TITLE
feat(web): improve profile editor save feedback (C-5684)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -6999,6 +6999,10 @@ body {
 .code-editor-status-error {
   color: var(--color-error, #c0392b);
 }
+.code-editor-save--saved {
+  background: var(--color-success, #10b981) !important;
+  border-color: var(--color-success, #10b981) !important;
+}
 .code-editor-actions {
   display: flex;
   gap: 0.5rem;

--- a/lib/clacky/web/components/code-editor.js
+++ b/lib/clacky/web/components/code-editor.js
@@ -174,16 +174,26 @@
 
     async function doSave() {
       if (!onSave) return;
-      if (saveBtn) saveBtn.disabled = true;
-      status.textContent = I18n.t("modal.saving");
+      if (saveBtn) {
+        saveBtn.disabled = true;
+        saveBtn.textContent = I18n.t("modal.saving");
+      }
+      status.textContent = "";
       status.className = "code-editor-status";
       try {
         await onSave(getContent());
-        close();
+        if (saveBtn) {
+          saveBtn.textContent = I18n.t("modal.saved");
+          saveBtn.classList.add("code-editor-save--saved");
+        }
+        setTimeout(close, 1000);
       } catch (e) {
         status.textContent = e.message || "Save failed";
         status.className = "code-editor-status code-editor-status-error";
-        if (saveBtn) saveBtn.disabled = false;
+        if (saveBtn) {
+          saveBtn.disabled = false;
+          saveBtn.textContent = I18n.t("modal.save");
+        }
       }
     }
 

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -185,6 +185,7 @@ const I18n = (() => {
       "modal.close": "Close",
       "modal.save": "Save",
       "modal.saving": "Saving…",
+      "modal.saved": "Saved ✓",
 
       // ── Auth ──
       "auth.accessKeyRequired": "Access key required:",
@@ -1104,6 +1105,7 @@ const I18n = (() => {
       "modal.close": "关闭",
       "modal.save": "保存",
       "modal.saving": "保存中…",
+      "modal.saved": "已保存 ✓",
 
       // ── Auth ──
       "auth.accessKeyRequired": "请输入访问密钥：",


### PR DESCRIPTION
## Problem
Saving a SOUL / USER profile (and any file via the shared CodeEditor) completes almost instantly, then the editor closes immediately. The only success signal was a tiny status line in the footer's bottom-left corner, which flashed for a split second before the modal closed — users couldn't tell whether the save actually took effect.

## Fix
Reworked `doSave` in the shared `code-editor.js` so feedback lives on the save button itself, right where the user clicked:
- On click: button shows `Saving…` and is disabled.
- On success: button switches to `Saved ✓` with a green style (`.code-editor-save--saved`), stays visible for 1s, then auto-closes.
- The bottom-left status line is no longer used for the success path; it is kept only for error messages.
- On failure: existing error display is preserved and the button resets to `Save`.

Added `modal.saved` to i18n (en `Saved ✓` / zh `已保存 ✓`) and a `.code-editor-save--saved` style reusing `--color-success`.

This is a component-level change, so all CodeEditor save flows (profile, memory, skills) get the improved feedback consistently.

## Test
✅ Manual: edit a SOUL / USER profile in the Web UI → save → button shows `Saving…` then `Saved ✓` (green) for ~1s before the editor closes; the bottom-left status no longer flashes.
✅ Save failure still shows the error in the footer status and re-enables the button.