### PR TITLE
fix(web): preserve single line breaks in profile/memory preview (C-5689)

### DIFF
--- a/lib/clacky/web/features/profile/view.js
+++ b/lib/clacky/web/features/profile/view.js
@@ -49,7 +49,7 @@ const ProfileView = (() => {
 
     function flushPara() {
       if (paraBuf.length === 0) return;
-      out.push("<p>" + _renderInline(paraBuf.join(" ")) + "</p>");
+      out.push("<p>" + _renderInline(paraBuf.join("<br>")) + "</p>");
       paraBuf = [];
     }
     function openList(type) {


### PR DESCRIPTION
## Problem
In the Profile / memory editor, two lines separated by a single Enter (e.g. line 23 "写入测试" and line 24 "写入测试2") were merged into one line "写入测试 写入测试2" in the rendered preview.

The profile renderer (`profile/view.js` `_renderMarkdown`) follows the CommonMark soft-break rule where a single newline inside a paragraph becomes a space. But the Profile/memory editor is plain-text WYSIWYG to the user — every line break is expected to be preserved.

## Fix
In `flushPara()`, join paragraph buffer lines with `<br>` instead of a space, so single newlines render as actual line breaks. Blank-line paragraph separation, headings, lists, and CSS spacing are untouched.

## Test
Extracted `_renderMarkdown` and ran it against the real SOUL.md: the two HTML outputs are structurally identical (same `<h2>`/`<p>`/`<ul>` tags), the only diff being intra-paragraph ` ` → `<br>`. No extra blank lines are introduced. The chat renderer (`sessions.js` `_renderMarkdown`) is a separate function and is not affected. Verified the preview in the Profile editor.