### PR TITLE
fix(web): make text selection visible in profile/memory editor (C-5686)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -6979,10 +6979,10 @@ body {
   background: var(--color-bg-hover);
 }
 .code-editor-body .cm-activeLine {
-  background: var(--color-bg-hover);
+  background: color-mix(in srgb, var(--color-bg-hover) 60%, transparent);
 }
 .code-editor-body .cm-selectionBackground {
-  background: color-mix(in srgb, var(--color-accent-primary) 20%, transparent) !important;
+  background: color-mix(in srgb, var(--color-accent-primary) 40%, transparent) !important;
 }
 .code-editor-footer {
   display: flex;


### PR DESCRIPTION
## Problem
In the Profile / memory editor (CodeMirror 6), selecting text showed no visible highlight — the selected region had no background color, so users couldn't tell what they had selected. This risks accidental overwrite or deletion of content without the user noticing.

Two causes combined:
1. `.cm-activeLine` used an opaque grey background (`--color-bg-hover`), which is painted above the lower selection layer and completely covered the selection on the current line.
2. `.cm-selectionBackground` was only 20% of the accent color — too faint to notice even where it wasn't covered.

## Fix
CSS-only changes in `app.css`:
- Make `.cm-activeLine` semi-transparent (60%) so the selection layer underneath shows through.
- Raise `.cm-selectionBackground` opacity from 20% to 40% of the accent color for clear visibility in both light and dark themes.

No JS changes; selection logic, save behavior, and other editors are untouched.

## Test
Verified in the Profile editor: dragging to select text (including on the active line) now shows a clear accent-colored highlight. Confirmed the active-line indicator is still visible and headings/list spacing are unchanged.