### PR TITLE
fix(web): preserve memory card expand state across re-render (C-5694)

### DIFF
--- a/lib/clacky/web/features/profile/view.js
+++ b/lib/clacky/web/features/profile/view.js
@@ -152,11 +152,17 @@ const ProfileView = (() => {
       return;
     }
 
+    const openSet = new Set(
+      [...list.querySelectorAll(".memory-card")]
+        .filter(c => c.querySelector(".memory-card-body")?.style.display !== "none")
+        .map(c => c.dataset.filename)
+    );
+
     list.innerHTML = "";
-    memories.forEach(m => list.appendChild(_buildMemoryCard(m)));
+    memories.forEach(m => list.appendChild(_buildMemoryCard(m, openSet.has(m.filename))));
   }
 
-  function _buildMemoryCard(m) {
+  function _buildMemoryCard(m, expanded = false) {
     const card = document.createElement("div");
     card.className = "memory-card";
     card.dataset.filename = m.filename;
@@ -253,6 +259,8 @@ const ProfileView = (() => {
     }
     expandBtn.addEventListener("click", (e) => { e.stopPropagation(); toggle(); });
     head.querySelector(".memory-card-info").addEventListener("click", toggle);
+
+    if (expanded) toggle();
 
     return card;
   }


### PR DESCRIPTION
## Problem
In Profile → Memory management, expanding a memory card and then editing & saving it caused the card to collapse back automatically. Users had to manually re-expand it to verify their changes.

Root cause: expand state lives only in the DOM (`body.style.display` + button class) and is never preserved. Saving a memory triggers `updateMemory` → `_loadMemories()` → `profile:memoriesChanged` → `_renderMemories()`, which wipes the list (`innerHTML = ""`) and rebuilds every card in the default collapsed state, dropping all expand state.

## Fix
View-only change in `profile/view.js`:
- Before rebuilding the list, snapshot the filenames of currently expanded cards.
- Pass an `expanded` flag into `_buildMemoryCard`, which replays the existing `toggle()` on build to restore the open state.

Because the rebuilt card has no cached body, `toggle()` re-fetches the memory, so an expanded card automatically shows the latest saved content. Collapsed cards stay collapsed. This covers every re-render path (edit, curate, delete, manual refresh). No store, event, or backend changes.

## Test
Verified in the Profile editor: expand a memory → edit and save → the card stays expanded and displays the updated content. Collapsed cards remain collapsed after the save.