### PR TITLE
fix(web): refresh time machine on task complete (C-5691)

### DIFF
--- a/lib/clacky/default_agents/_panels/time_machine/panel.js
+++ b/lib/clacky/default_agents/_panels/time_machine/panel.js
@@ -19,6 +19,25 @@
 (() => {
   if (!window.Clacky || !Clacky.ext) return;
 
+  // The currently mounted panel's state, refreshed on every mount. A single WS
+  // hook (registered once below) reloads it when the active session completes a
+  // task, so new snapshots appear without a manual refresh. Kept as a closure
+  // singleton because WS.onEvent has no unsubscribe and the panel re-mounts on
+  // each session switch.
+  let _activeState = null;
+  let _wsHooked = false;
+
+  function _hookWs() {
+    if (_wsHooked || typeof WS === "undefined") return;
+    _wsHooked = true;
+    WS.onEvent((ev) => {
+      if (ev && ev.type === "complete" && _activeState &&
+          ev.session_id === _activeState.sessionId) {
+        loadHistory(_activeState);
+      }
+    });
+  }
+
   const t = (k, fallback) => {
     const v = (typeof I18n !== "undefined") ? I18n.t(k) : null;
     return (v && v !== k) ? v : fallback;
@@ -629,6 +648,9 @@
     d.confirmYes.onclick = onGoClick;
     d.mask.onclick = onMaskClick;
     document.addEventListener("keydown", onKey);
+
+    _activeState = state;
+    _hookWs();
 
     loadHistory(state);
     return root;


### PR DESCRIPTION
## Problem
The time machine panel only loaded its snapshot list once at mount time. When the agent finished a task and produced a new snapshot, the list stayed stale — users had to switch sessions or refresh to see it.

## Fix
Subscribe to the raw WS `complete` event via the existing public `WS.onEvent` API (same pattern already used by the version store) and reload the timeline for the active session. The hook is registered once as a closure singleton and reads the latest mounted state, so it stays leak-free across session switches despite `WS.onEvent` having no unsubscribe.

## Test
Manually verified in the Web UI: running a task makes the new snapshot appear in the time machine list immediately, without switching sessions or refreshing.