### PR TITLE
fix(web): toast on profile/memory save success (C-5684)

### DIFF
--- a/lib/clacky/web/features/profile/view.js
+++ b/lib/clacky/web/features/profile/view.js
@@ -311,6 +311,7 @@ const ProfileView = (() => {
       onSave: async (newContent) => {
         const r = await Profile.updateMemory(m.filename, newContent);
         if (!r.ok) throw new Error(r.error);
+        Modal.toast(_t("profile.savedOk"), "success");
       }
     });
   }
@@ -341,7 +342,10 @@ const ProfileView = (() => {
       content: file.content || "",
       title,
       language: "markdown",
-      onSave: (newContent) => Profile.updateProfile(kind, newContent)
+      onSave: async (newContent) => {
+        await Profile.updateProfile(kind, newContent);
+        Modal.toast(_t("profile.savedOk"), "success");
+      }
     });
   }
 


### PR DESCRIPTION
<img width="1512" height="864" alt="Snapzy_2026-06-29_15-37-18_517" src="https://github.com/user-attachments/assets/1e8f8f90-fae2-4ee0-8560-6fe5e3133b8d" />

## Problem
Saving a profile (SOUL/USER) or memory file in the Web UI closed the editor with no confirmation, leaving the user unsure whether the save actually succeeded.

## Fix
Show a non-blocking success toast ("Saved ✓" / "已保存 ✓") in the bottom-right after a profile or memory save resolves, reusing the existing `Modal.toast` helper and the `profile.savedOk` i18n key. Failures still surface as an inline error inside the editor.

## Test
Edited SOUL.md, USER.md and a memory file via the profile editor and saved each — confirmed the green "已保存 ✓" toast appears bottom-right and auto-dismisses, and that a failing save still shows the inline error.