### PR TITLE
feat: add type:rewrite shell hook protocol with updatedInput support

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -143,8 +143,15 @@ module Clacky
       # Register built-in tools
       register_builtin_tools
 
-      # Load declarative shell hooks from ~/.clacky/hooks.yml
-      ShellHookLoader.load_into(@hooks)
+      # Load declarative shell hooks from ~/.clacky/hooks.yml. Entries with
+      # `type: rewrite` use the rich JSON protocol (updatedInput rewrite);
+      # entries without `type` use the simple exit-code protocol.
+      ShellHookLoader.load_into(
+        @hooks,
+        session_id_fn:      -> { @session_id },
+        cwd_fn:             -> { @working_dir },
+        permission_mode_fn: -> { @config.permission_mode.to_s }
+      )
 
       # Ensure user-space parsers are in place (~/.clacky/parsers/)
       Utils::ParserManager.setup!

--- a/lib/clacky/agent/hook_manager.rb
+++ b/lib/clacky/agent/hook_manager.rb
@@ -28,7 +28,16 @@ module Clacky
       @hooks[event].each do |hook|
         begin
           hook_result = hook.call(*args)
-          result.merge!(hook_result) if hook_result.is_a?(Hash)
+          next unless hook_result.is_a?(Hash)
+          # First deny wins and stops the chain: a weaker later verdict must
+          # never clobber a stronger earlier one, and the first deny's reason
+          # is the one that reaches the agent. Rewrite hooks mutate `call` in
+          # place (chained rewrite), so for non-deny results there's nothing to
+          # merge — we just keep going.
+          if hook_result[:action] == :deny
+            result = hook_result
+            break
+          end
         rescue StandardError => e
           # Log error but don't fail
           Clacky::Logger.error("Hook error", event: event, error: e)

--- a/lib/clacky/shell_hook_loader.rb
+++ b/lib/clacky/shell_hook_loader.rb
@@ -14,28 +14,48 @@ module Clacky
   # hooks.yml format:
   #   hooks:
   #     before_tool_use:
+  #       # Simple protocol — no `type` (or `type: command`). exit-code driven.
   #       - name: guard            # optional label for logs
   #         command: "~/.clacky/hook-scripts/guard.sh"
   #         timeout: 10            # optional, seconds (default 10)
+  #
+  #       # Rewrite protocol — `type: rewrite`. Rich JSON stdin/stdout, supports
+  #       # matcher, updatedInput rewrite. (before_tool_use only)
+  #       - type: rewrite
+  #         # matcher must be the CANONICAL tool name the agent dispatches
+  #         # (e.g. `terminal`), NOT an alias (`bash`/`shell`/`exec`): the
+  #         # agent resolves aliases to canonical names BEFORE firing hooks,
+  #         # so `matcher: bash` would never match. "*" or omitted = all tools.
+  #         matcher: terminal
+  #         command: "~/.clacky/hook-scripts/rewrite.sh"
+  #         timeout: 30             # optional, seconds (default 60)
   #     on_complete:
   #       - command: "notify-send done"
   #
   # Runtime contract (per invocation):
   #   - The event payload is passed to the command as JSON on STDIN.
-  #   - exit 0  → allow (default).
-  #   - exit 2  → deny; STDOUT becomes the denial reason. Only meaningful for
-  #               before_tool_use, which the agent checks for {action: :deny}.
+  #   - exit 0  → allow (default). Rewrite hooks parse STDOUT as hookSpecificOutput.
+  #   - exit 2  → deny; STDOUT (simple) or stderr/stdout (rewrite) is the reason.
+  #               Only before_tool_use is checked for {action: :deny}.
   #   - any other exit / timeout / crash → logged, treated as allow (a broken
   #     hook must never wedge the agent).
+  #
+  # Rewrite entries chain in config order: each applies its updatedInput IN
+  # PLACE on the tool call (complete replacement — no merge); the first deny
+  # stops the chain.
   class ShellHookLoader
-    DEFAULT_PATH    = File.expand_path("~/.clacky/hooks.yml")
-    DEFAULT_TIMEOUT = 10
-    DENY_EXIT_CODE  = 2
+    DEFAULT_PATH            = File.expand_path("~/.clacky/hooks.yml")
+    DEFAULT_TIMEOUT         = 10
+    REWRITE_DEFAULT_TIMEOUT = 60
+    DENY_EXIT_CODE          = 2
 
     Result = Struct.new(:registered, :skipped, keyword_init: true)
 
-    def self.load_into(hook_manager, path: DEFAULT_PATH)
-      new(path: path).load_into(hook_manager)
+    # The context procs supply rewrite-protocol context at run time; optional so
+    # simple-only callers (e.g. `clacky hook_verify`) can omit them.
+    def self.load_into(hook_manager, session_id_fn: nil, cwd_fn: nil, permission_mode_fn: nil, path: DEFAULT_PATH)
+      new(path: path, session_id_fn: session_id_fn, cwd_fn: cwd_fn, permission_mode_fn: permission_mode_fn)
+        .load_into(hook_manager)
     end
 
     # Create a starter hooks.yml plus an example guard script. Idempotent-ish:
@@ -67,12 +87,18 @@ module Clacky
       File.write(path, <<~YAML)
         # Declarative shell hooks. Each command receives the event payload as JSON
         # on STDIN. For before_tool_use: exit 2 = deny (STDOUT = reason), exit 0 = allow.
+        # Add `type: rewrite` to a before_tool_use entry to use the rich JSON
+        # protocol (updatedInput rewrite, matcher).
         # Events: #{HookManager::HOOK_EVENTS.join(", ")}
         hooks:
           before_tool_use:
             - name: deny-example
               command: "#{guard}"
               timeout: 10
+        #    - type: rewrite
+        #      matcher: terminal
+        #      command: "~/.clacky/hook-scripts/rewrite.sh"
+        #      timeout: 30
         #  on_complete:
         #    - command: "echo task finished"
       YAML
@@ -80,8 +106,11 @@ module Clacky
       path
     end
 
-    def initialize(path: DEFAULT_PATH)
-      @path = path
+    def initialize(path: DEFAULT_PATH, session_id_fn: nil, cwd_fn: nil, permission_mode_fn: nil)
+      @path               = path
+      @session_id_fn      = session_id_fn
+      @cwd_fn             = cwd_fn
+      @permission_mode_fn = permission_mode_fn
     end
 
     # @return [Result] counts of registered hooks and skipped (with reasons)
@@ -106,14 +135,37 @@ module Clacky
     end
 
     private def register_one(hook_manager, event, spec, result)
+      if spec["type"] == "rewrite" && event != :before_tool_use
+        # type: rewrite only makes sense under before_tool_use (it rewrites tool
+        # input); elsewhere matcher/updatedInput would be silently ignored —
+        # skip + warn so the misconfiguration is visible.
+        name = (spec["name"] || spec["command"] || "rewrite hook").to_s
+        result.skipped << [name, "type: rewrite is only valid under before_tool_use"]
+      elsif spec["type"] == "rewrite"
+        register_rewrite(hook_manager, spec, result)
+      else
+        register_simple(hook_manager, event, spec, result)
+      end
+    end
+
+    # Returns [name, command] for a spec, or nil (after recording a skip) when
+    # the command is missing. Shared by the simple and rewrite registrars.
+    private def resolve_command(spec, result)
       command = spec["command"].to_s.strip
       name    = spec["name"] || command
-      timeout = (spec["timeout"] || DEFAULT_TIMEOUT).to_i
-
       if command.empty?
         result.skipped << [name, "missing command"]
-        return
+        nil
+      else
+        [name, command]
       end
+    end
+
+    private def register_simple(hook_manager, event, spec, result)
+      resolved = resolve_command(spec, result)
+      return unless resolved
+      name, command = resolved
+      timeout = (spec["timeout"] || DEFAULT_TIMEOUT).to_i
 
       unless HookManager::HOOK_EVENTS.include?(event)
         result.skipped << [name, "unknown event: #{event}"]
@@ -126,25 +178,123 @@ module Clacky
       result.registered << [event, name]
     end
 
-    private def run_command(event, command, timeout, args)
-      payload = JSON.generate(build_payload(event, args))
+    # Rewrite protocol (before_tool_use only): rich JSON stdin/stdout.
+    private def register_rewrite(hook_manager, spec, result)
+      resolved = resolve_command(spec, result)
+      return unless resolved
+      name, command = resolved
+      timeout = (spec["timeout"] || REWRITE_DEFAULT_TIMEOUT).to_i
+      matcher = spec["matcher"]
 
-      out = +""
+      hook_manager.add(:before_tool_use) do |call|
+        tool_name = (call[:name] || call["name"]).to_s
+        next { action: :allow } unless matcher_applies?(matcher, tool_name)
+        run_rewrite(command, timeout, call, tool_name)
+      end
+      result.registered << [:before_tool_use, name]
+    end
+
+    # "*" or omitted matches every tool; otherwise the matcher must equal the
+    # canonical tool name exactly (no aliases, regex, or lists).
+    private def matcher_applies?(matcher, tool_name)
+      matcher.nil? || matcher == "*" || matcher == tool_name
+    end
+
+    # Cap on bytes buffered per stream: before_tool_use fires on every tool
+    # call, so a runaway/malicious hook could otherwise OOM the agent.
+    MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+
+    # Spawn `command` in its own process group, feed `payload` on STDIN, and
+    # return [stdout, stderr, status]. stdout and stderr are drained on parallel
+    # reader threads — a single sequential reader deadlocks once a child fills
+    # the 64KB stderr pipe while keeping stdout open. The dedicated process
+    # group lets us SIGKILL the whole tree on timeout (including grandchildren
+    # that inherit the fds), so a hook that traps TERM can't hang the agent.
+    # Output is scrubbed to valid UTF-8 so a stray non-UTF-8 byte can't turn a
+    # deny into an allow via a .strip / JSON.parse raise.
+    private def capture_streams(command, payload, timeout)
+      stdout = +""
+      stderr = +""
+      # Declared here so the block assigns this var, not a block-local one
+      # (else every deny silently becomes an allow).
       status = nil
-      Open3.popen3(command) do |stdin, stdout, _stderr, wait_thr|
-        stdin.write(payload)
-        stdin.close
+
+      Open3.popen3(command, pgroup: true) do |stdin, out, err, wait_thr|
+        pgid = wait_thr.pid
+
+        out_reader = Thread.new { drain_stream(out, stdout) }
+        err_reader = Thread.new { drain_stream(err, stderr) }
+
+        # Write stdin on its own thread: a child that doesn't read stdin (or a
+        # payload larger than the ~64KB pipe buffer) would otherwise block the
+        # main thread before it reaches wait_thr.join(timeout) — the only thing
+        # enforcing the timeout — and wedge capture_streams forever.
+        writer = Thread.new do
+          begin
+            stdin.write(payload)
+          rescue Errno::EPIPE
+            # Child already exited / stopped reading; its stdout may still be readable.
+          rescue IOError
+            # Pipes closed (timeout path) — nothing more to write.
+          ensure
+            stdin.close rescue nil
+          end
+        end
+
         if wait_thr.join(timeout)
-          out = stdout.read
           status = wait_thr.value
+          # Child exited; drain the readers (bounded join — a grandchild
+          # holding the pipe fd can keep them from EOF; see drain_stream).
+          out_reader.join(2)
+          err_reader.join(2)
         else
-          Process.kill("TERM", wait_thr.pid) rescue nil
+          # SIGTERM, then SIGKILL the whole group if it won't die. popen3's
+          # ensure joins wait_thr without a timeout, so the child MUST be dead
+          # before we leave the block — a hook that traps/ignores TERM can't be
+          # allowed to hang here.
+          Process.kill("TERM", -pgid) rescue nil
+          unless wait_thr.join(1)
+            Process.kill("KILL", -pgid) rescue nil
+            wait_thr.join
+          end
+          out_reader.join(1)
+          err_reader.join(1)
+          writer.kill rescue nil
           raise Timeout::Error
         end
       end
 
+      [stdout.scrub!, stderr.scrub!, status]
+    end
+
+    # Read `io` into `buf` in readpartial chunks until EOF, instead of a single
+    # IO#read. readpartial returns whatever is currently available, so a
+    # grandchild that inherited the pipe fd (and thus keeps it from EOF) can no
+    # longer block us forever — already-read bytes are preserved in `buf`.
+    # Appending stops at MAX_OUTPUT_BYTES so a runaway hook can't OOM the agent;
+    # we keep draining past the cap so the child doesn't block on a full pipe.
+    private def drain_stream(io, buf)
+      loop do
+        chunk = io.readpartial(4096)
+        buf << chunk if buf.bytesize < MAX_OUTPUT_BYTES
+      end
+    rescue EOFError, IOError
+      # EOFError: pipe closed (normal end). IOError: pipes closed on block exit.
+    end
+
+    # Strip + default, so a deny never has a blank reason.
+    private def deny_reason(raw)
+      s = raw.to_s.strip
+      s.empty? ? "Denied by hook" : s
+    end
+
+    private def run_command(event, command, timeout, args)
+      payload = JSON.generate(build_payload(event, args))
+
+      out, _err, status = capture_streams(command, payload, timeout)
+
       if status&.exitstatus == DENY_EXIT_CODE
-        { action: :deny, reason: out.strip.empty? ? "Denied by hook" : out.strip }
+        { action: :deny, reason: deny_reason(out) }
       else
         { action: :allow }
       end
@@ -176,6 +326,100 @@ module Clacky
       end
 
       base
+    end
+
+    # --- Rewrite protocol (type: rewrite) -------------------------------------
+
+    private def run_rewrite(command, timeout, call, tool_name)
+      tool_input = parse_tool_args(call)
+      payload    = build_rewrite_payload(tool_name, tool_input)
+
+      stdout, stderr, status = capture_streams(command, payload, timeout)
+
+      # nil exitstatus = killed by signal (SIGKILL/OOM) — a crash, not a clean
+      # exit. Treat as allow so a partial deny payload can't deny from garbage.
+      if status&.exitstatus.nil?
+        Clacky::Logger.warn("[ShellHookLoader] Rewrite hook '#{command}' died (signal) — allowing")
+        return { action: :allow }
+      end
+      exit_code = status.exitstatus
+
+      if exit_code == DENY_EXIT_CODE
+        source = stderr.strip.empty? ? stdout : stderr
+        return { action: :deny, reason: deny_reason(source) }
+      end
+
+      if exit_code != 0
+        Clacky::Logger.warn("[ShellHookLoader] Rewrite hook '#{command}' exited #{exit_code} (non-blocking) — allowing")
+        return { action: :allow }
+      end
+
+      result = parse_hook_output(stdout)
+      # Chained rewrite: apply updatedInput IN PLACE on `call` so the next
+      # rewrite sees it. updatedInput is a complete replacement (no merge);
+      # empty/absent means "no rewrite this time" — leave `call` untouched.
+      updated = result.delete(:updated_input)
+      call[:arguments] = JSON.generate(updated) if updated.is_a?(Hash) && !updated.empty?
+      result
+    rescue Timeout::Error
+      Clacky::Logger.warn("[ShellHookLoader] Rewrite hook '#{command}' timed out after #{timeout}s — allowing")
+      { action: :allow }
+    rescue StandardError => e
+      Clacky::Logger.warn("[ShellHookLoader] Rewrite hook '#{command}' failed: #{e.message} — allowing")
+      { action: :allow }
+    end
+
+    private def build_rewrite_payload(tool_name, tool_input)
+      JSON.generate({
+        session_id:      @session_id_fn&.call,
+        cwd:             @cwd_fn&.call || Dir.pwd,
+        permission_mode: @permission_mode_fn&.call || "default",
+        hook_event_name: "PreToolUse",
+        tool_name:       tool_name,
+        tool_input:      tool_input
+      })
+    end
+
+    # Parse the tool arguments the hook should see. Unparseable JSON is logged
+    # (not silently swallowed) but defers to an empty Hash so a broken payload
+    # doesn't wedge the agent.
+    private def parse_tool_args(call)
+      args = call[:arguments] || call["arguments"]
+      case args
+      when String then JSON.parse(args)
+      when Hash   then args
+      else             {}
+      end
+    rescue JSON::ParserError => e
+      Clacky::Logger.warn("[ShellHookLoader] Unparseable tool arguments (#{e.message}); hook sees empty input")
+      {}
+    end
+
+    # Missing or unparseable hookSpecificOutput defers to allow.
+    private def parse_hook_output(stdout)
+      return { action: :allow } if stdout.nil? || stdout.strip.empty?
+
+      parsed   = JSON.parse(stdout.strip)
+      specific = parsed.is_a?(Hash) && parsed["hookSpecificOutput"]
+      return { action: :allow } unless specific.is_a?(Hash)
+
+      decision      = specific["permissionDecision"]
+      reason        = specific["permissionDecisionReason"]
+      updated_input = specific["updatedInput"]
+
+      # Permission decision other than "deny" is treated as allow: the agent's
+      # own permission_mode governs confirmation, not the hook.
+      result = case decision
+               when "deny"
+                 { action: :deny, reason: deny_reason(reason) }
+               else
+                 { action: :allow }   # "allow", "ask", "defer", unknown
+               end
+
+      result[:updated_input] = updated_input if updated_input.is_a?(Hash)
+      result
+    rescue JSON::ParserError
+      { action: :allow }
     end
   end
 end

--- a/spec/clacky/shell_hook_loader_spec.rb
+++ b/spec/clacky/shell_hook_loader_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "securerandom"
 
 RSpec.describe Clacky::ShellHookLoader do
   let(:tmp) { Dir.mktmpdir }
@@ -12,11 +13,36 @@ RSpec.describe Clacky::ShellHookLoader do
     File.write(yml, content)
   end
 
+  # Generate an executable bash script under tmp.
+  def make_script(body, executable: true)
+    path = File.join(tmp, "hook_#{SecureRandom.hex(4)}.sh")
+    File.write(path, "#!/usr/bin/env bash\n#{body}\n")
+    FileUtils.chmod("+x", path) if executable
+    path
+  end
+
+  # Build a HookManager with the loader applied. Extra kwargs (session_id_fn,
+  # cwd_fn, permission_mode_fn) forward to load_into for rewrite-protocol context.
+  def build_hm(**opts)
+    hm = Clacky::HookManager.new
+    described_class.load_into(hm, path: yml, **opts)
+    hm
+  end
+
+  def trigger(hm, tool_name, arguments = {})
+    hm.trigger(:before_tool_use, { name: tool_name, arguments: JSON.generate(arguments) })
+  end
+
   describe ".load_into" do
     it "returns empty when the file is absent" do
       result = described_class.load_into(Clacky::HookManager.new, path: File.join(tmp, "none.yml"))
       expect(result.registered).to be_empty
       expect(result.skipped).to be_empty
+    end
+
+    it "is a no-op when the file is invalid YAML" do
+      File.write(yml, "{ bad: yaml: content: [")
+      expect { described_class.load_into(Clacky::HookManager.new, path: yml) }.not_to raise_error
     end
 
     it "registers a hook for a valid event" do
@@ -52,9 +78,77 @@ RSpec.describe Clacky::ShellHookLoader do
       result = described_class.load_into(Clacky::HookManager.new, path: yml)
       expect(result.skipped.first[1]).to include("missing command")
     end
+
+    it "skips a rewrite entry with no command" do
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              name: empty
+      YAML
+      result = described_class.load_into(Clacky::HookManager.new, path: yml)
+      expect(result.skipped.first[1]).to include("missing command")
+      expect(result.registered).to be_empty
+    end
+
+    it "skips a type: rewrite entry under a non-before_tool_use event" do
+      script = make_script("exit 0")
+      write_yml(<<~YAML)
+        hooks:
+          on_complete:
+            - type: rewrite
+              name: misplaced
+              command: "#{script}"
+      YAML
+      result = described_class.load_into(Clacky::HookManager.new, path: yml)
+      expect(result.registered).to be_empty
+      expect(result.skipped.first[1]).to include("before_tool_use")
+    end
   end
 
-  describe "runtime contract" do
+  describe "type dispatch" do
+    it "treats an entry with no type as the simple protocol (exit 2 → deny, STDOUT reason)" do
+      script = make_script("echo 'nope'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("nope")
+    end
+
+    it "treats type: command as the simple protocol" do
+      script = make_script("echo 'nope'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: command
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("nope")
+    end
+
+    it "routes type: rewrite to the rich JSON protocol" do
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"policy"}}'
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("policy")
+    end
+  end
+
+  describe "runtime contract (simple protocol)" do
     it "denies a tool when the command exits 2, using STDOUT as the reason" do
       script = File.join(tmp, "deny.sh")
       File.write(script, "#!/usr/bin/env bash\necho \"nope\"\nexit 2\n")
@@ -122,11 +216,510 @@ RSpec.describe Clacky::ShellHookLoader do
     end
   end
 
+  # ── Rewrite protocol (type: rewrite) ────────────────────────────────────────
+
+  describe "rewrite protocol — matcher" do
+    it "skips execution when matcher does not match the tool name" do
+      deny_script = make_script("echo 'blocked'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              matcher: terminal
+              command: "#{deny_script}"
+      YAML
+      result = trigger(build_hm, "file_reader")
+      expect(result[:action]).to eq(:allow)
+    end
+
+    it "runs the hook when matcher matches exactly" do
+      deny_script = make_script("echo 'blocked'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              matcher: terminal
+              command: "#{deny_script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+    end
+
+    it "runs for all tools when matcher is '*'" do
+      deny_script = make_script("echo 'blocked'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              matcher: "*"
+              command: "#{deny_script}"
+      YAML
+      result = trigger(build_hm, "anything")
+      expect(result[:action]).to eq(:deny)
+    end
+
+    it "runs for all tools when matcher is absent" do
+      deny_script = make_script("exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{deny_script}"
+      YAML
+      result = trigger(build_hm, "write")
+      expect(result[:action]).to eq(:deny)
+    end
+  end
+
+  describe "rewrite protocol — exit code semantics" do
+    it "denies when the script exits 2, using stderr as reason" do
+      script = make_script("echo 'bad' >&2; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("bad")
+    end
+
+    it "falls back to stdout as denial reason when stderr is empty on exit 2" do
+      script = make_script("echo 'reason from stdout'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("reason from stdout")
+    end
+
+    it "allows (non-blocking) when the script exits with a non-zero code other than 2" do
+      script = make_script("exit 1")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:allow)
+    end
+
+    it "allows when the script exits 0 with no stdout" do
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "true"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:allow)
+    end
+
+    it "allows when the script times out" do
+      script = make_script("sleep 10; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+              timeout: 1
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:allow)
+    end
+
+    it "treats a hook killed by a signal (nil exitstatus) as allow, not deny" do
+      # kill -9 $$ ends the shell via SIGKILL → exitstatus is nil. Even though
+      # the hook wrote a deny payload first, a crash must defer to allow rather
+      # than route through parse_hook_output's success path.
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"should-not-apply"}}'
+        kill -9 $$
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:allow)
+    end
+  end
+
+  describe "rewrite protocol — hookSpecificOutput" do
+    it "denies when permissionDecision is 'deny'" do
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"policy"}}'
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("policy")
+    end
+
+    it "denies with a default reason when 'deny' has no permissionDecisionReason" do
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"deny"}}'
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("Denied by hook")
+    end
+
+    it "uses the default reason when permissionDecisionReason is an empty string" do
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":""}}'
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("Denied by hook")
+    end
+
+    it "treats any non-deny decision as a bare allow" do
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result).to eq(action: :allow)
+    end
+
+    it "allows when valid JSON has no hookSpecificOutput" do
+      script = make_script("printf '{\"status\":\"ok\"}'")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result).to eq(action: :allow)
+    end
+
+    it "defers when stdout is empty on exit 0" do
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "true"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:allow)
+    end
+
+    it "defers when stdout is non-JSON on exit 0" do
+      script = make_script("echo 'some log'")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:allow)
+    end
+
+    it "applies updatedInput from hookSpecificOutput in place on the tool call" do
+      script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{"command":"rtk git status"}}}'
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+      hm = build_hm
+      call = { name: "terminal", arguments: JSON.generate({ "command" => "git status" }) }
+      result = hm.trigger(:before_tool_use, call)
+      expect(result[:action]).to eq(:allow)
+      expect(JSON.parse(call[:arguments])).to eq({ "command" => "rtk git status" })
+    end
+  end
+
+  describe "rewrite protocol — stdin payload" do
+    it "sends hook_event_name, tool_name, and tool_input as JSON on stdin" do
+      capture_file = File.join(tmp, "captured.json")
+      script = make_script("cat > '#{capture_file}'")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              matcher: terminal
+              command: "#{script}"
+      YAML
+
+      trigger(build_hm, "terminal", { "command" => "ls -la" })
+
+      payload = JSON.parse(File.read(capture_file))
+      expect(payload["hook_event_name"]).to eq("PreToolUse")
+      expect(payload["tool_name"]).to eq("terminal")
+      expect(payload["tool_input"]["command"]).to eq("ls -la")
+    end
+
+    it "injects session_id, cwd, and permission_mode from context lambdas" do
+      capture_file = File.join(tmp, "captured.json")
+      script = make_script("cat > '#{capture_file}'")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+      YAML
+
+      hm = build_hm(
+        session_id_fn:      -> { "sess-42" },
+        cwd_fn:             -> { "/project" },
+        permission_mode_fn: -> { "auto_approve" }
+      )
+      hm.trigger(:before_tool_use, { name: "terminal", arguments: "{}" })
+
+      payload = JSON.parse(File.read(capture_file))
+      expect(payload["session_id"]).to eq("sess-42")
+      expect(payload["cwd"]).to eq("/project")
+      expect(payload["permission_mode"]).to eq("auto_approve")
+    end
+  end
+
+  describe "coexistence and ordering" do
+    it "registers both a simple and a rewrite entry from one file (registration only)" do
+      rewrite_script = make_script("printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"allow\",\"updatedInput\":{\"command\":\"r\"}}}'")
+      simple_script = make_script("exit 0")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              name: rewriter
+              command: "#{rewrite_script}"
+            - name: simple
+              command: "#{simple_script}"
+      YAML
+      result = described_class.load_into(Clacky::HookManager.new, path: yml)
+      expect(result.registered).to eq([[:before_tool_use, "rewriter"], [:before_tool_use, "simple"]])
+    end
+
+    it "applies an earlier rewrite's updatedInput even when a later simple hook allows" do
+      rewrite_script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{"command":"rewritten"}}}'
+      BASH
+      simple_script = make_script("exit 0")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{rewrite_script}"
+            - command: "#{simple_script}"
+      YAML
+      hm = build_hm
+      call = { name: "terminal", arguments: JSON.generate({ "command" => "orig" }) }
+      result = hm.trigger(:before_tool_use, call)
+      expect(result[:action]).to eq(:allow)
+      expect(JSON.parse(call[:arguments])).to eq({ "command" => "rewritten" })
+    end
+
+    it "deny from a simple entry wins over a rewrite entry's updatedInput" do
+      rewrite_script = make_script(<<~BASH)
+        printf '{"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{"command":"rewritten"}}}'
+      BASH
+      deny_script = make_script("echo 'blocked'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{rewrite_script}"
+            - command: "#{deny_script}"
+      YAML
+      result = trigger(build_hm, "terminal", { "command" => "orig" })
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("blocked")
+      expect(result).not_to have_key(:updated_input)
+    end
+
+    it "keeps the first deny's reason when two hooks both deny (first-deny-wins)" do
+      first = make_script("echo 'first-reason'; exit 2")
+      second = make_script("echo 'second-reason'; exit 2")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - name: first
+              command: "#{first}"
+            - name: second
+              command: "#{second}"
+      YAML
+      result = trigger(build_hm, "terminal")
+      expect(result[:action]).to eq(:deny)
+      expect(result[:reason]).to eq("first-reason")
+    end
+
+    it "chains: a later rewrite sees the previous rewrite's updated input" do
+      # First rewrite: whatever it received → updatedInput {command: "first"}.
+      first = make_script("printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"allow\",\"updatedInput\":{\"command\":\"first\"}}}'")
+      # Second rewrite: echoes the command it RECEIVED on stdin into the
+      # rewritten value, proving it saw "first" (not the original "orig").
+      second = make_script(<<~'BASH')
+        payload="$(cat)"
+        cmd="$(printf '%s' "$payload" | ruby -rjson -e 'puts JSON.parse(STDIN.read).dig("tool_input","command")')"
+        printf '{"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{"command":"%s->second"}}}' "$cmd"
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{first}"
+            - type: rewrite
+              command: "#{second}"
+      YAML
+      hm = build_hm
+      call = { name: "terminal", arguments: JSON.generate({ "command" => "orig" }) }
+      hm.trigger(:before_tool_use, call)
+      expect(JSON.parse(call[:arguments])["command"]).to eq("first->second")
+    end
+
+    it "chains: updatedInput is a complete replacement, not a merge" do
+      # First rewrite sets {command: "x", cwd: "/a"}; second sets {command: "y"}
+      # only. The final input must be exactly {command: "y"} — cwd is gone.
+      first = make_script("printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"allow\",\"updatedInput\":{\"command\":\"x\",\"cwd\":\"/a\"}}}'")
+      second = make_script("printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"allow\",\"updatedInput\":{\"command\":\"y\"}}}'")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{first}"
+            - type: rewrite
+              command: "#{second}"
+      YAML
+      hm = build_hm
+      call = { name: "terminal", arguments: JSON.generate({ "command" => "orig" }) }
+      hm.trigger(:before_tool_use, call)
+      expect(JSON.parse(call[:arguments])).to eq({ "command" => "y" })
+    end
+  end
+
+  describe "robustness — process group, timeout, encoding" do
+    # Each of these mirrors a real hang / leak / wrong-decision found in
+    # capture_streams; they must stay green.
+
+    # Run the trigger on a side thread and assert it finishes within `within`
+    # seconds — a hang shows up as join returning nil. The thread is killed in
+    # an ensure so a hung hook can't outlive the example.
+    def trigger_within(within, hm, *args)
+      ran = Thread.new { hm.trigger(:before_tool_use, *args) }
+      yield ran.join(within), ran
+    ensure
+      ran.kill if ran&.alive?
+    end
+
+    it "does not hang when the hook backgrounds a process that inherits stdout" do
+      script = make_script("sleep 30 & exit 0")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - command: "#{script}"
+              timeout: 5
+      YAML
+      trigger_within(10, build_hm, { name: "terminal" }) do |joined, _|
+        expect(joined).to be_a(Thread)            # returned, didn't wait ~30s
+        expect(joined.value[:action]).to eq(:allow) # exit 0 → allow
+      end
+    end
+
+    it "does not hang when the hook ignores SIGTERM on timeout" do
+      script = make_script("trap '' TERM; sleep 30")
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - command: "#{script}"
+              timeout: 1
+      YAML
+      trigger_within(8, build_hm, { name: "terminal" }) do |joined, _|
+        expect(joined).to be_a(Thread)            # SIGKILL'd the group, not ~30s
+        expect(joined.value[:action]).to eq(:allow) # timeout → allow
+      end
+    end
+
+    it "scrubs non-UTF-8 bytes in a deny reason instead of degrading to allow" do
+      script = make_script(<<~'BASH')
+        printf '\x80denied'
+        exit 2
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - command: "#{script}"
+      YAML
+      # The bug only manifests when stdout is read as UTF-8 (the invalid byte
+      # makes .strip raise, escaping to a blanket allow); force that external
+      # encoding for this example and restore it after.
+      orig = Encoding.default_external
+      begin
+        Encoding.default_external = Encoding::UTF_8
+        result = build_hm.trigger(:before_tool_use, { name: "terminal" })
+        expect(result[:action]).to eq(:deny)
+        expect(result[:reason]).to include("denied")
+      ensure
+        Encoding.default_external = orig
+      end
+    end
+
+    it "does not deadlock on a hook that writes >64KB to stderr" do
+      # Sequential stdout-then-stderr reading deadlocks once stderr fills the
+      # 64KB pipe buffer; parallel readers drain both. Rewrite hooks take the
+      # deny reason from stderr, so it must be captured, not lost to a timeout.
+      script = make_script(<<~'BASH')
+        yes x | head -c 100000 >&2
+        echo 'reason-marker' >&2
+        exit 2
+      BASH
+      write_yml(<<~YAML)
+        hooks:
+          before_tool_use:
+            - type: rewrite
+              command: "#{script}"
+              timeout: 5
+      YAML
+      trigger_within(8, build_hm, { name: "terminal", arguments: JSON.generate({}) }) do |joined, _|
+        expect(joined).to be_a(Thread)             # didn't deadlock to timeout
+        expect(joined.value[:action]).to eq(:deny)
+        expect(joined.value[:reason]).to include("reason-marker")
+      end
+    end
+  end
+
   describe ".scaffold" do
     it "creates hooks.yml and an executable example script" do
       path = described_class.scaffold(path: yml)
       expect(File.exist?(path)).to be true
       expect(File.read(path)).to include("before_tool_use")
+      expect(File.read(path)).to include("type: rewrite")
 
       script = File.join(tmp, "hook-scripts", "deny-example.sh")
       expect(File.exist?(script)).to be true


### PR DESCRIPTION
<!-- Write this PR description in English. -->

## What

Adds a `type: rewrite` shell hook protocol for `before_tool_use` entries in `~/.clacky/hooks.yml`. Rewrite entries receive a rich JSON payload on stdin (`session_id`, `cwd`, `permission_mode`, `hook_event_name`, `tool_name`, `tool_input`) and can return a `hookSpecificOutput` containing `updatedInput` (rewrites the tool's arguments in place before execution) and/or a `permissionDecision` of `deny`. Entries without `type` keep the existing exit-code-driven protocol (now implicitly `type: command`) — fully backward compatible.

Rewrite entries chain in config order: each `updatedInput` is applied **in place** on the tool call as a complete replacement (no merge), so a later rewrite sees the previous one's output. The first `deny` stops the chain.

## Why

Shell hooks previously could only allow or deny a tool call via exit codes — they could not inspect or modify the call's arguments. This unlocks guardrail/normalization use cases (rewriting a `terminal` command to strip dangerous flags, enforcing path conventions on `write`) without a full Ruby plugin. The JSON schema mirrors the Claude Code `PreToolUse` hook contract, so existing hooks are portable.

## User-visible impact

- **New opt-in config**: `type: rewrite` (with optional `matcher`) on `before_tool_use` entries. No `type` continues to mean the simple exit-code protocol — fully backward compatible.
- **No breaking changes**: existing `hooks.yml` files behave identically.
- **New chain semantics in `HookManager`**: the first `deny` wins and stops the chain; a later weaker verdict can no longer clobber an earlier deny. Rewrite `updatedInput` is applied in place, so an earlier rewrite's output survives a later `allow`.

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [x] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [x] No new dependencies (or justified below)
- [x] Fits the existing design / naming / layering

> **New config knob justification**: this PR adds two optional fields to `before_tool_use` entries in `~/.clacky/hooks.yml` — `type: rewrite` (opt into the rich JSON protocol) and `matcher` (scope a hook to a tool name). They are strictly additive: entries without `type` keep the existing exit-code behavior, so no existing `hooks.yml` changes. The knob is necessary because the two protocols have incompatible stdin/stdout contracts (simple = exit-code + STDOUT reason; rewrite = JSON `hookSpecificOutput` with `updatedInput`), so they cannot share one path without a discriminator. `type` reuses the existing entry schema rather than adding a top-level key, keeping the surface minimal.
>
> Config example:
>
> ```yaml
> hooks:
>   before_tool_use:
>     # Simple protocol (unchanged) — exit-code driven.
>     - name: guard
>       command: "~/.clacky/hook-scripts/guard.sh"
>       timeout: 10
>
>     # Rewrite protocol (new) — rich JSON stdin/stdout, can rewrite tool input.
>     - type: rewrite
>       matcher: terminal        # canonical tool name; "*" or omitted = all tools
>       command: "~/.clacky/hook-scripts/rewrite.sh"
>       timeout: 30
> ```

### 2. Need

- [x] Common need that benefits most users, **or** scope and side effects are explained below
- [x] No unintended impact on other users' workflows or defaults

### 3. Code

- [x] All tests pass
- [x] Coverage does not drop; new code has new tests
- [x] Commit messages and this PR are written in English

### Bonus

- [x] This PR was authored using OpenClacky itself

---

## Notes for reviewers

Key areas to focus on:

- **`agent.rb` (~L143) — context procs**: `ShellHookLoader.load_into` now takes `session_id_fn` / `cwd_fn` / `permission_mode_fn` (lazy `-> {}` procs evaluated at hook fire time, so they reflect the live session). They are optional so simple-only callers (e.g. `clacky hook_verify`) can omit them; rewrite payloads fall back to `Dir.pwd` / `"default"` when absent.

- **`hook_manager.rb` (~L28) — first-deny-wins**: the old `result.merge!(hook_result)` is replaced with: on the first `:deny`, store it and `break` (its `reason` is the one that reaches the agent); for any non-deny result, keep iterating. Rewrite hooks mutate `call` in place inside `ShellHookLoader`, so at this layer there is nothing to merge for non-deny results. This is simpler and stronger than a priority map: a later `allow` can never drop an earlier rewrite's `updatedInput`, and the first deny's reason is the one reported.

- **`shell_hook_loader.rb` `capture_streams` — robustness core**: the simple protocol's `run_command` and the rewrite protocol's `run_rewrite` both funnel through one spawner:
  - `pgroup: true` puts the hook in its own process group; on timeout we `SIGTERM` then `SIGKILL` the whole group (`Process.kill("KILL", -pgid)`), so a hook that traps/ignores `TERM` — or a grandchild that inherited the fds — can't hang the agent.
  - stdout and stderr are drained on **parallel reader threads** using `readpartial`; a single sequential reader deadlocks once a child fills the 64KB stderr pipe while keeping stdout open, and `readpartial` (vs `IO#read`) keeps us from blocking forever when a grandchild holds the pipe fd past EOF.
  - stdin is written on its own thread: a child that doesn't read stdin (or a payload larger than the ~64KB pipe buffer) would otherwise block the main thread before it reaches the only `join(timeout)` that enforces the deadline.
  - `MAX_OUTPUT_BYTES` (8 MB) caps buffered output per stream to prevent OOM (before_tool_use fires on every tool call), while still draining past the cap so the child doesn't block on a full pipe.
  - `.scrub!` on both streams so a stray non-UTF-8 byte can't turn a deny into an allow via a `strip` / `JSON.parse` raise.

- **`run_rewrite` exit semantics**: signal kill (`nil` exitstatus) → allow (a partial deny payload can't deny from garbage); exit 2 → deny with reason from stderr, falling back to stdout; any other non-zero → logged and allow (non-blocking); exit 0 → parse `hookSpecificOutput`. `updatedInput` is applied in place on `call[:arguments]` as a **complete replacement** (no merge); empty/absent means "no rewrite this time".

- **`matcher` must be the canonical tool name**: the agent resolves aliases (`bash`/`shell`/`exec`) to canonical names (`terminal`) **before** firing hooks, so `matcher: bash` would never match. `"*"` or omitted matches all tools. Intentionally no regex or `|`/`,` lists, to keep the contract predictable.

- **`type: rewrite` is `before_tool_use`-only**: under any other event it is skipped with a warning, so a misconfiguration is visible rather than silently ignored.

- **Timeout default**: rewrite hooks default to 60s (vs 10s for simple) since input-rewriting scripts may do real work; timeout is logged and non-blocking (treated as allow).

`spec/clacky/shell_hook_loader_spec.rb` grows from ~10 to a full suite covering: type dispatch, matcher behavior, exit-code semantics, `hookSpecificOutput` parsing, `updatedInput` in-place rewrite, stdin payload shape, coexistence/ordering (first-deny-wins, chained rewrites, replacement-not-merge), and robustness (backgrounded process, ignored SIGTERM, non-UTF-8 scrub, >64KB stderr).
