### PR TITLE
fix: render file:// links with spaces & non-ASCII paths

### DIFF
--- a/lib/clacky/prompts/base.md
+++ b/lib/clacky/prompts/base.md
@@ -3,7 +3,7 @@
 - Ask clarifying questions if requirements are unclear.
 - Break down complex tasks into manageable steps.
 - **USE TOOLS to create/modify files** — don't just return content.
-- When the user asks to send/download a file or you generate one for them, append `[filename](file://~/path/to/file)` at the end of your reply.
+- When the user asks to send/download a file or you generate one for them, append `[filename](file://~/path/to/file)` at the end of your reply. Use the raw file path as-is (keep non-ASCII characters and spaces literal); never URL-encode it.
 
 ## Tool Usage Rules
 

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -113,6 +113,33 @@ const Sessions = (() => {
     return html;
   }
 
+  // Encode file:// URLs inside raw markdown BEFORE marked parses it. The AI
+  // emits raw paths (spaces / non-ASCII / % literal); marked's link tokenizer
+  // treats a space as the end of the URL, so links with spaces are never
+  // recognized. Re-encoding the path (decode then encode, idempotent) turns
+  // spaces into %20 and a literal % into %25 so marked sees a valid URL.
+  function _encodeFileUrlsInMarkdown(text) {
+    return text.replace(
+      /(!?\[[^\]]*\]\()(file:\/{2,3})([^)]+)(\))/g,
+      (_m, open, scheme, path, close) => {
+        try { path = decodeURI(path); } catch (_) { /* keep raw if malformed */ }
+        return open + scheme + encodeURI(path) + close;
+      }
+    );
+  }
+
+  // Normalize a file:// href for use in <a href>. The AI emits raw paths
+  // (Chinese chars / spaces literal); encode them to a valid percent-encoded
+  // URL. Idempotent: an already-encoded path is decoded first so it isn't
+  // double-encoded. Non file:// links pass through untouched.
+  function _normalizeFileHref(href) {
+    if (typeof href !== "string" || !href.startsWith("file://")) return href;
+    const prefix = href.match(/^file:\/{2,3}/)[0];
+    let path = href.slice(prefix.length);
+    try { path = decodeURI(path); } catch (_) { /* keep raw if malformed */ }
+    return prefix + encodeURI(path);
+  }
+
   // Run marked on a text string. Returns HTML. Falls back to escaped plain text
   // if the marked library is unavailable.
   function _markedParse(text) {
@@ -122,6 +149,7 @@ const Sessions = (() => {
     const math = [];
     const PLACEHOLDER = (i) => `\u0000KTX${i}\u0000`;
     let prepared = _extractMath(text, math, PLACEHOLDER);
+    prepared = _encodeFileUrlsInMarkdown(prepared);
 
     let html;
     if (typeof marked !== "undefined") {
@@ -138,7 +166,7 @@ const Sessions = (() => {
       const renderer = new marked.Renderer();
       renderer.link = function({ href, title, text }) {
         const titleAttr = title ? ` title="${title}"` : "";
-        return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+        return `<a href="${_normalizeFileHref(href)}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
       };
       // Override code block rendering: apply syntax highlighting + header with
       // language label and copy button.
@@ -2307,7 +2335,9 @@ const Sessions = (() => {
         const link = e.target.closest("a[href^='file://']");
         if (!link) return;
         e.preventDefault();
-        let filePath = decodeURIComponent(link.getAttribute("href").replace(/^file:\/\//, ""));
+        const rawHref = link.getAttribute("href").replace(/^file:\/\//, "");
+        let filePath;
+        try { filePath = decodeURIComponent(rawHref); } catch (_) { filePath = rawHref; }
         // file:///C:/foo → /C:/foo after replace; strip the leading slash for Windows drive letters
         if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.substring(1);
         if (!filePath) return;


### PR DESCRIPTION
## Problem

File links pointing to local paths were unclickable or corrupted in the Web UI:

- Paths with **spaces** (e.g. `AI 产品需求评审/...`) were never recognized as links at all — marked's link tokenizer treats a space as the end of the URL, so the markdown fell through to plain text (or a broken image when the model emitted `![...]`).
- Paths with **non-ASCII characters** (e.g. Chinese) could be corrupted: the model, faced with an un-encodable path, hand-wrote the percent-encoding byte by byte and occasionally transposed a hex digit ("测" → "浸").
- The click handler ran `decodeURIComponent` unguarded, so a path containing a literal `%` (e.g. `50%off`) threw "URI malformed" and failed to open.

## Fix

Move URL encoding off the probabilistic model and into deterministic frontend code — the model emits a readable raw path, the frontend encodes it correctly:

- ✅ `prompts/base.md`: instruct the model to emit the raw file path as-is (keep non-ASCII chars and spaces literal) and never URL-encode it.
- ✅ `web/sessions.js` — new `_encodeFileUrlsInMarkdown`, run **before** marked parses: re-encodes the path in every `[...](file://...)` / `![...](file://...)` (decode then encode, idempotent) so spaces become `%20`, literal `%` becomes `%25`, and marked sees a valid URL. This is the key fix for spaces, which break at marked's tokenizer stage — too early for any renderer-level patch.
- ✅ `web/sessions.js` — `renderer.link` normalizes the href as a defensive second pass; click handler wraps `decodeURIComponent` in try/catch, falling back to the raw href so a literal `%` no longer crashes.

Backend link/image parsing is untouched: it consumes decoded paths and `CGI.unescape` is idempotent on raw paths.

Known limitation (pre-existing markdown syntax constraint, not introduced here): a path with an **unbalanced** `)` still truncates; balanced `()` is handled.

## Test

- ✅ Frontend probe against the vendored marked build — bare space → valid encoded link; non-ASCII → correct `%xx`; literal `%` → `%25` → decodes back to `%off`; balanced `()` → handled via marked paren-balancing; already-encoded legacy path → idempotent (no double-encode); non-file:// links → untouched.
- ✅ Click-decode round-trips every case back to the original raw path.
- ✅ `bundle exec rspec` — 2678 examples, 0 failures.