### PR TITLE
fix(web): adapt session search shortcut hint (C-5734)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 CLAUDE.md
+AGENTS.md
 /.bundle/
 /.yardoc
 /_yardoc/

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -782,7 +782,7 @@ body {
   color: var(--color-accent-primary);
 }
 
-/* ── Command-palette search overlay (⌘K) ─────────────────────────────────── */
+/* ── Command-palette search overlay ──────────────────────────────────────── */
 .cmd-palette-overlay {
   position: fixed;
   inset: 0;
@@ -12778,4 +12778,3 @@ body.setup-mode[data-theme="dark"] {
     background: var(--color-bg-primary);
   }
 }
-

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -48,7 +48,7 @@
       <button id="header-cmdbar" type="button" title="Search sessions">
         <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
         <span class="cmdbar-ph" data-i18n="header.cmdbar.placeholder">Search sessions…</span>
-        <span class="cmdbar-kbd" data-shortcut-primary="K">Ctrl + K</span>
+        <span class="cmdbar-kbd">Ctrl + K</span>
       </button>
     </div>
     <div id="header-right">

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -48,7 +48,7 @@
       <button id="header-cmdbar" type="button" title="Search sessions">
         <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
         <span class="cmdbar-ph" data-i18n="header.cmdbar.placeholder">Search sessions…</span>
-        <span class="cmdbar-kbd">⌘K</span>
+        <span class="cmdbar-kbd" data-shortcut-primary="K">Ctrl + K</span>
       </button>
     </div>
     <div id="header-right">
@@ -79,7 +79,7 @@
     </div>
   </header>
 
-  <!-- ── Command-palette search overlay (⌘K / top cmdbar) ─────────────────── -->
+  <!-- ── Command-palette search overlay (platform shortcut / top cmdbar) ───── -->
   <!-- Search lives here, decoupled from the sidebar list: results render in
        #session-search-results and the left session list is never replaced. -->
   <div id="session-search-overlay" class="cmd-palette-overlay" hidden>

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -885,7 +885,9 @@ const Sessions = (() => {
   // Everything uses event delegation because some elements (e.g. the clear
   // buttons) are re-rendered as filter state changes.
   function _initSearch() {
-    // Open the palette: top cmdbar button (or ⌘K, bound below).
+    KeyboardShortcuts.applyLabels();
+
+    // Open the palette: top cmdbar button (or the keyboard shortcut, bound below).
     document.addEventListener("click", (e) => {
       if (e.target && e.target.closest("#header-cmdbar")) {
         if (!Sessions.searchOpen) Sessions.toggleSearch();

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -884,8 +884,15 @@ const Sessions = (() => {
   //
   // Everything uses event delegation because some elements (e.g. the clear
   // buttons) are re-rendered as filter state changes.
+  function _sessionSearchShortcutLabel() {
+    const uaDataPlatform = navigator.userAgentData && navigator.userAgentData.platform;
+    const platform = (uaDataPlatform || navigator.platform || "").toString();
+    return /mac/i.test(platform) ? "⌘ + K" : "Ctrl + K";
+  }
+
   function _initSearch() {
-    KeyboardShortcuts.applyLabels();
+    const cmdbarKbd = document.querySelector("#header-cmdbar .cmdbar-kbd");
+    if (cmdbarKbd) cmdbarKbd.textContent = _sessionSearchShortcutLabel();
 
     // Open the palette: top cmdbar button (or the keyboard shortcut, bound below).
     document.addEventListener("click", (e) => {

--- a/lib/clacky/web/utils.js
+++ b/lib/clacky/web/utils.js
@@ -1,27 +1,3 @@
-// Platform-aware keyboard shortcut labels.
-const KeyboardShortcuts = (() => {
-  function _platform() {
-    const uaDataPlatform = navigator.userAgentData && navigator.userAgentData.platform;
-    return (uaDataPlatform || navigator.platform || "").toString();
-  }
-
-  function isMac() {
-    return /mac/i.test(_platform());
-  }
-
-  function primaryLabel(key) {
-    return `${isMac() ? "⌘" : "Ctrl"} + ${String(key).toUpperCase()}`;
-  }
-
-  function applyLabels(root = document) {
-    root.querySelectorAll("[data-shortcut-primary]").forEach(el => {
-      el.textContent = primaryLabel(el.getAttribute("data-shortcut-primary"));
-    });
-  }
-
-  return { isMac, primaryLabel, applyLabels };
-})();
-
 // Cross-browser IME composition guard for Enter-to-submit inputs.
 //
 // Problem: pressing Enter to confirm an IME composition (e.g. selecting a

--- a/lib/clacky/web/utils.js
+++ b/lib/clacky/web/utils.js
@@ -1,3 +1,27 @@
+// Platform-aware keyboard shortcut labels.
+const KeyboardShortcuts = (() => {
+  function _platform() {
+    const uaDataPlatform = navigator.userAgentData && navigator.userAgentData.platform;
+    return (uaDataPlatform || navigator.platform || "").toString();
+  }
+
+  function isMac() {
+    return /mac/i.test(_platform());
+  }
+
+  function primaryLabel(key) {
+    return `${isMac() ? "⌘" : "Ctrl"} + ${String(key).toUpperCase()}`;
+  }
+
+  function applyLabels(root = document) {
+    root.querySelectorAll("[data-shortcut-primary]").forEach(el => {
+      el.textContent = primaryLabel(el.getAttribute("data-shortcut-primary"));
+    });
+  }
+
+  return { isMac, primaryLabel, applyLabels };
+})();
+
 // Cross-browser IME composition guard for Enter-to-submit inputs.
 //
 // Problem: pressing Enter to confirm an IME composition (e.g. selecting a


### PR DESCRIPTION
## Problem
The Web UI always showed the session search shortcut as a macOS-style hint, even on Windows/Linux where users expect `Ctrl + K`.

## Fix
Add platform-aware shortcut label rendering for the header session search hint.
Keep the existing `Ctrl/Cmd + K` behavior unchanged.
Add local Codex instructions to `AGENTS.md` and ignore it via `.gitignore`.

## Test
✅ `bundle exec rspec`
✅ 2682 examples, 0 failures