### PR TITLE
fix: align mobile header search action (C-5733)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -12398,9 +12398,46 @@ body.setup-mode[data-theme="dark"] {
     display: none;
   }
 
+  /* Collapse session search into the right-side header actions */
+  #header-center {
+    justify-content: flex-end;
+    padding: 0;
+  }
+  #header-cmdbar {
+    flex: 0 0 1.875rem;
+    width: 1.875rem;
+    max-width: 1.875rem;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    justify-content: center;
+    gap: 0;
+    margin-right: 0.125rem;
+  }
+  #header-cmdbar:hover {
+    color: var(--color-text-primary);
+  }
+  #header-cmdbar svg {
+    width: 1rem;
+    height: 1rem;
+    opacity: 1;
+  }
+  #header-cmdbar .cmdbar-ph,
+  #header-cmdbar .cmdbar-kbd,
+  #ext-slot-header-right:empty {
+    display: none;
+  }
+
   /* Tighten right-side icon gap on mobile */
   #header-right {
     gap: 0.125rem;
+  }
+
+  @media (max-width: 360px) {
+    #top-header {
+      padding: 0 0.375rem;
+    }
   }
 
   /* Session info bar: single-line, no hover-expand, font smaller */

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -46,7 +46,7 @@
     </div>
     <div id="header-center">
       <button id="header-cmdbar" type="button" title="Search sessions">
-        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.3-4.3"/></svg>
         <span class="cmdbar-ph" data-i18n="header.cmdbar.placeholder">Search sessions…</span>
         <span class="cmdbar-kbd">Ctrl + K</span>
       </button>


### PR DESCRIPTION

<img width="1440" height="3120" alt="Screenshot_20260713_113149_Samsung Browser" src="https://github.com/user-attachments/assets/cd5e414e-9b19-47cb-8719-7ac157e538f1" />


## Problem

On mobile viewports, the full session search bar competed with the right-side header actions for limited space, causing overlap and misalignment.

## Fix

- Collapse the session search bar into a search icon on mobile.
- Align the search icon with the refresh, share, notification, and theme actions.
- Preserve the existing search element and event handling.
- Exclude the empty header extension slot from mobile spacing.
- Tighten header padding on very narrow viewports to prevent overlap when the owner badge is visible.
- Keep the desktop search layout unchanged.

## Test

✅ Ran `bundle exec rspec spec/clacky/web/syntax_spec.rb` (`19 examples, 0 failures`)
✅ Verified the header layout at 320px and 390px widths
✅ Verified the full search bar remains unchanged at desktop width
✅ Verified clicking the mobile search icon opens the search overlay