### PR TITLE
fix(media): associate generated media usage with sessions (C-5739)

### DIFF
--- a/lib/clacky/agent/skill_manager.rb
+++ b/lib/clacky/agent/skill_manager.rb
@@ -452,6 +452,7 @@ module Clacky
       # @return [Hash<String, Proc>]
       def build_template_context
         {
+          "session_id"      => -> { @session_id },
           "memories_meta"   => -> { load_memories_meta },
           "all_skills_meta" => -> { load_all_skills_meta }
         }

--- a/lib/clacky/default_skills/media-gen/SKILL.md
+++ b/lib/clacky/default_skills/media-gen/SKILL.md
@@ -60,7 +60,8 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/ima
   -d '{
     "prompt": "A clean, modern hero illustration for a tech startup landing page. Soft gradient background, abstract geometric shapes in blue and purple, minimal style, 4K quality.",
     "aspect_ratio": "landscape",
-    "output_dir": "'"$(pwd)"'"
+    "output_dir": "'"$(pwd)"'",
+    "session_id": "<%= session_id %>"
   }'
 ```
 
@@ -75,6 +76,7 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/ima
 | `prompt`       | yes      | string                              | Be detailed and concrete. See prompt tips below. |
 | `aspect_ratio` | no       | `landscape` / `square` / `portrait` | Defaults to `landscape`. |
 | `output_dir`   | yes      | absolute path                       | Always pass `$(pwd)` so files land in the current session workspace. The image is saved under `<output_dir>/assets/generated/`. |
+| `session_id`   | yes      | string                              | Current Clacky session ID. Always pass the rendered value shown in the request example. |
 | `image`        | no       | file path / base64 / data URL       | A single input image to **edit**. Triggers image-edit mode (see below). |
 | `images`       | no       | array of the above                  | Multiple input images for a multi-image edit. Takes precedence over `image`. |
 
@@ -90,7 +92,8 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/ima
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "change the background to a starry night sky, keep the cat unchanged",
-    "image": "/abs/path/to/input.png"
+    "image": "/abs/path/to/input.png",
+    "session_id": "<%= session_id %>"
   }'
 ```
 
@@ -206,7 +209,8 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/vid
     "prompt": "A cinematic drone shot flying over a misty mountain range at sunrise, golden light, 4K.",
     "aspect_ratio": "landscape",
     "duration_seconds": 8,
-    "output_dir": "'"$(pwd)"'"
+    "output_dir": "'"$(pwd)"'",
+    "session_id": "<%= session_id %>"
   }'
 ```
 
@@ -217,6 +221,7 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/vid
 | `duration_seconds` | no       | 4–8                             | Defaults to 8. |
 | `image`            | no       | `{ "b64_json": "...", "mime_type": "image/png" }` | Optional first frame for image-to-video. |
 | `output_dir`       | yes      | absolute path                   | Always pass `$(pwd)` so files land in the current session workspace. MP4 saved under `<output_dir>/assets/generated/`. |
+| `session_id`       | yes      | string                          | Current Clacky session ID. Always pass the rendered value shown in the request example. |
 
 ### Response (success)
 
@@ -278,11 +283,11 @@ Workflow for an N-segment continuous video:
    writes a ready-to-send JSON file:
    ```bash
    "$SEQ" payload /tmp/seg2.json /tmp/seg1_last.jpg 8 landscape "$OUT_DIR" \
-     "Continuing the same scene, the camera keeps pushing forward…"
+     "Continuing the same scene, the camera keeps pushing forward…" "<%= session_id %>"
    curl -s -X POST .../api/media/video -H "Content-Type: application/json" \
      --data @/tmp/seg2.json
    ```
-   (`payload <out.json> <frame> <duration_seconds> <aspect_ratio> <output_dir> <prompt>`)
+   (`payload <out.json> <frame> <duration_seconds> <aspect_ratio> <output_dir> <prompt> [session_id]`)
 5. **Repeat** steps 3–4 for each subsequent segment, always chaining off the
    *previous* segment's last frame.
 6. **Stitch** all clips in order into one file:
@@ -328,7 +333,8 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/aud
   -d '{
     "input": "Hello and welcome to openclacky. Today we will explore...",
     "voice": "Kore",
-    "output_dir": "'"$(pwd)"'"
+    "output_dir": "'"$(pwd)"'",
+    "session_id": "<%= session_id %>"
   }'
 ```
 
@@ -337,6 +343,7 @@ curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/aud
 | `input`      | yes      | string                          | The text to speak. Plain prose works best; you can prefix with style cues like "Say cheerfully:" or "In a calm tone:". |
 | `voice`      | no       | string voice name               | Defaults to `Kore`. Common Gemini voices: `Kore`, `Puck`, `Charon`, `Fenrir`, `Aoede`. |
 | `output_dir` | yes      | absolute path                   | Always pass `$(pwd)` so files land in the current session workspace. WAV saved under `<output_dir>/assets/generated/`. |
+| `session_id` | yes      | string                          | Current Clacky session ID. Always pass the rendered value shown in the request example. |
 
 Generation typically takes 2–10 seconds depending on length. The request
 blocks until the WAV is ready.
@@ -388,4 +395,3 @@ Same shape and `error_type` values as image generation, but with `"audio": null`
 - Voice consistency: Gemini TTS does not currently support voice cloning;
   use the same `voice` name across calls in one project to keep the
   narrator consistent.
-

--- a/lib/clacky/default_skills/media-gen/scripts/video_seq.sh
+++ b/lib/clacky/default_skills/media-gen/scripts/video_seq.sh
@@ -10,7 +10,7 @@
 # Subcommands:
 #   lastframe  <video.mp4> <out.jpg>           extract the final frame (JPEG by default)
 #   tob64      <image>                          print base64 (no newlines) to stdout
-#   payload    <out.json> <frame.jpg> <dur> <aspect> <output_dir> <prompt>
+#   payload    <out.json> <frame.jpg> <dur> <aspect> <output_dir> <prompt> [session_id]
 #                                               build an image-to-video JSON body
 #                                               for `curl --data @out.json`
 #   concat     <out.mp4> <clip1.mp4> [clip2 …]  losslessly join clips in order
@@ -43,7 +43,7 @@ cmd_tob64() {
 # Build the image-to-video request body as a file so curl can send it with
 # `--data @file`, avoiding "Argument list too long" from inlining base64.
 cmd_payload() {
-  local out="$1" frame="$2" dur="$3" aspect="$4" odir="$5" prompt="$6"
+  local out="$1" frame="$2" dur="$3" aspect="$4" odir="$5" prompt="$6" session_id="${7:-}"
   [[ -f "$frame" ]] || die "no such frame: $frame"
   need ffprobe
   local mime b64
@@ -53,7 +53,7 @@ cmd_payload() {
   esac
   b64="$(base64 < "$frame" | tr -d '\n')"
   FRAME_B64="$b64" FRAME_MIME="$mime" P_PROMPT="$prompt" P_DUR="$dur" \
-  P_ASPECT="$aspect" P_ODIR="$odir" python3 - "$out" <<'PY'
+  P_ASPECT="$aspect" P_ODIR="$odir" P_SESSION_ID="$session_id" python3 - "$out" <<'PY'
 import json, os, sys
 body = {
   "prompt": os.environ["P_PROMPT"],
@@ -62,6 +62,8 @@ body = {
   "output_dir": os.environ["P_ODIR"],
   "image": {"b64_json": os.environ["FRAME_B64"], "mime_type": os.environ["FRAME_MIME"]},
 }
+if os.environ["P_SESSION_ID"]:
+  body["session_id"] = os.environ["P_SESSION_ID"]
 open(sys.argv[1], "w").write(json.dumps(body))
 PY
   [[ -f "$out" ]] || die "failed to write payload"

--- a/spec/clacky/agent/inject_skill_command_spec.rb
+++ b/spec/clacky/agent/inject_skill_command_spec.rb
@@ -188,6 +188,19 @@ RSpec.describe "Agent#inject_skill_as_assistant_message" do
     end
   end
 
+  it "expands the current session ID in skill content" do
+    Dir.mktmpdir do |tmpdir|
+      create_skill(tmpdir, name: "session-skill", content: "Session: <%= session_id %>")
+      agent = build_agent(tmpdir)
+      skill = agent.instance_variable_get(:@skill_loader).find_by_name("session-skill")
+
+      agent.send(:inject_skill_as_assistant_message, skill, "", 1)
+
+      injected = agent.history.to_a.find { |m| m[:role] == "assistant" && m[:system_injected] }
+      expect(injected[:content]).to include("Session: #{agent.session_id}")
+    end
+  end
+
   it "does NOT mark injected messages as transient for plain skills" do
     Dir.mktmpdir do |tmpdir|
       create_skill(tmpdir, name: "my-skill", content: "Plain content.")

--- a/spec/clacky/default_skills/media_gen_spec.rb
+++ b/spec/clacky/default_skills/media_gen_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe "media-gen default skill" do
+  let(:skill_dir) do
+    File.expand_path("../../../lib/clacky/default_skills/media-gen", __dir__)
+  end
+
+  it "includes the current session ID in every media request" do
+    skill = Clacky::Skill.new(skill_dir)
+    result = skill.process_content(template_context: { "session_id" => "session-123" })
+
+    expect(result.scan('"session_id": "session-123"').size).to eq(4)
+    expect(result).to include('"Continuing the same scene, the camera keeps pushing forward…" "session-123"')
+  end
+
+  it "includes the session ID in chained-video payloads" do
+    Dir.mktmpdir do |tmpdir|
+      bin_dir = File.join(tmpdir, "bin")
+      frame = File.join(tmpdir, "frame.jpg")
+      payload = File.join(tmpdir, "payload.json")
+      FileUtils.mkdir_p(bin_dir)
+      File.write(File.join(bin_dir, "ffprobe"), "#!/bin/sh\nexit 0\n")
+      FileUtils.chmod(0o755, File.join(bin_dir, "ffprobe"))
+      File.binwrite(frame, "frame-data")
+
+      script = File.join(skill_dir, "scripts", "video_seq.sh")
+      env = { "PATH" => "#{bin_dir}:#{ENV.fetch("PATH", "")}" }
+      success = system(env, "/bin/bash", script, "payload", payload, frame,
+                       "8", "landscape", tmpdir, "continue scene", "session-123",
+                       out: File::NULL, err: File::NULL)
+
+      expect(success).to be true
+      expect(JSON.parse(File.read(payload))["session_id"]).to eq("session-123")
+    end
+  end
+end


### PR DESCRIPTION

<img width="1114" height="917" alt="Snapzy_2026-07-13_16-32-39_312" src="https://github.com/user-attachments/assets/522737f7-c85a-42aa-ae31-9791d0f77511" />


## Problem

Media generation usage from image, video, and TTS requests was recorded without the originating session ID, causing active-session costs to appear under "Deleted sessions".

## Fix

- Expose the current session ID to skill templates.
- Include the session ID in image, video, and TTS requests.
- Preserve the session ID in chained-video payloads.
- Add regression coverage for skill rendering and media payload generation.

## Test

✅ `bundle exec rspec spec/clacky/agent/inject_skill_command_spec.rb spec/clacky/default_skills/media_gen_spec.rb`
✅ `bundle exec rspec spec/clacky/server/http_server_media_spec.rb`
✅ `bash -n lib/clacky/default_skills/media-gen/scripts/video_seq.sh`