### PR TITLE
fix(web): invalidate cached preview when local image is overwritten (C-5703)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -53,7 +53,7 @@ module Clacky
             # encode + downscale on every history replay (2-3s lag for sessions
             # with downgraded text-model images). The proxy lets the browser
             # lazy-load + cache the image, keeping the replay response tiny.
-            "/api/local-image?path=#{CGI.escape(path.to_s)}"
+            "/api/local-image?path=#{CGI.escape(path.to_s)}&v=#{File.mtime(path.to_s).to_i}"
           elsif name
             type.to_s == "image" ? "expired:#{name}" : "pdf:#{name}"
           end
@@ -3730,6 +3730,20 @@ module Clacky
         file_size = File.size(path)
         mime = Utils::FileProcessor::MIME_TYPES[ext] || "application/octet-stream"
 
+        # ETag from mtime+size so an overwritten same-name file invalidates the
+        # browser cache. Use no-cache (revalidate every time) rather than
+        # max-age: unchanged files return 304 (no body), changed files return
+        # the new bytes.
+        stat = File.stat(path)
+        etag = %(W/"#{stat.mtime.to_i}-#{stat.size}")
+        res["Cache-Control"] = "private, no-cache"
+        res["ETag"] = etag
+        if req["If-None-Match"] == etag
+          res.status = 304
+          res.body = ""
+          return
+        end
+
         # Support HTTP Range requests for video seeking
         range_header = req["Range"]
         if range_header && range_header =~ /\Abytes=(\d*)-(\d*)\z/
@@ -3741,14 +3755,12 @@ module Clacky
           res["Content-Type"]  = mime
           res["Content-Range"] = "bytes #{start_byte}-#{end_byte}/#{file_size}"
           res["Accept-Ranges"] = "bytes"
-          res["Cache-Control"] = "private, max-age=3600"
           res["Content-Length"] = (end_byte - start_byte + 1).to_s
           IO.binread(path, end_byte - start_byte + 1, start_byte).then { |data| res.body = data }
         else
           res.status         = 200
           res["Content-Type"] = mime
           res["Accept-Ranges"] = "bytes"
-          res["Cache-Control"] = "private, max-age=3600"
           res.body = File.binread(path)
         end
       rescue => e

--- a/lib/clacky/utils/file_processor.rb
+++ b/lib/clacky/utils/file_processor.rb
@@ -604,8 +604,7 @@ module Clacky
 
         ext = File.extname(path).downcase
         if LOCAL_MEDIA_EXTENSIONS.include?(ext) && File.exist?(path)
-          encoded = CGI.escape(href)
-          "![#{alt}](/api/local-image?path=#{encoded})"
+          "![#{alt}](#{local_image_proxy_url(href, path)})"
         else
           _match
         end
@@ -622,8 +621,7 @@ module Clacky
 
         ext = File.extname(path).downcase
         if LOCAL_VIDEO_EXTENSIONS.include?(ext) && File.exist?(path)
-          encoded = CGI.escape(href)
-          "<video#{pre} src=\"/api/local-image?path=#{encoded}\"#{post}>"
+          "<video#{pre} src=\"#{local_image_proxy_url(href, path)}\"#{post}>"
         else
           _match
         end
@@ -640,8 +638,7 @@ module Clacky
 
         ext = File.extname(path).downcase
         if LOCAL_AUDIO_EXTENSIONS.include?(ext) && File.exist?(path)
-          encoded = CGI.escape(href)
-          "<audio#{pre} src=\"/api/local-image?path=#{encoded}\"#{post}>"
+          "<audio#{pre} src=\"#{local_image_proxy_url(href, path)}\"#{post}>"
         else
           _match
         end
@@ -658,8 +655,7 @@ module Clacky
         ext = File.extname(path).downcase
         if LOCAL_VIDEO_EXTENSIONS.include?(ext) || LOCAL_AUDIO_EXTENSIONS.include?(ext)
           if File.exist?(path)
-            encoded = CGI.escape(href)
-            "[#{text}](/api/local-image?path=#{encoded})"
+            "[#{text}](#{local_image_proxy_url(href, path)})"
           else
             _match
           end
@@ -669,6 +665,15 @@ module Clacky
       end
 
       content
+    end
+
+    # Build a proxy URL for a local media file, appending a version param
+    # derived from the file mtime so an overwritten same-name file produces a
+    # different URL and defeats the browser's in-memory image cache.
+    def self.local_image_proxy_url(href, path)
+      encoded = CGI.escape(href)
+      version = File.mtime(path).to_i
+      "/api/local-image?path=#{encoded}&v=#{version}"
     end
   end
   end

--- a/spec/clacky/server/http_server_local_image_spec.rb
+++ b/spec/clacky/server/http_server_local_image_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "clacky/server/http_server"
+require "clacky/agent_config"
+
+require_relative "http_server_spec"
+
+RSpec.describe Clacky::Server::HttpServer, "GET /api/local-image caching" do
+  include HttpServerSpecHelpers
+
+  let(:tmpdir) { Dir.mktmpdir("clacky_local_image_spec") }
+  let(:config_file) { File.join(tmpdir, "config.yml") }
+  let(:image_path) { File.join(tmpdir, "puppy.png") }
+
+  let(:agent_config) do
+    cfg = Clacky::AgentConfig.new(models: [
+      { "model" => "test-model", "api_key" => "k",
+        "base_url" => "https://example.invalid/v1", "type" => "default" }
+    ])
+    stub_const("Clacky::AgentConfig::CONFIG_FILE", config_file)
+    cfg
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  # A response double that captures headers set via res["Key"] = value.
+  def capturing_res
+    res = double("res").as_null_object
+    headers = {}
+    allow(res).to receive(:status=) { |v| res.instance_variable_set(:@status, v) }
+    allow(res).to receive(:body=)   { |v| res.instance_variable_set(:@body, v) }
+    allow(res).to receive(:[]=)     { |k, v| headers[k] = v }
+    allow(res).to receive(:[])      { |k| headers[k] }
+    allow(res).to receive(:status)  { res.instance_variable_get(:@status) }
+    allow(res).to receive(:body)    { res.instance_variable_get(:@body) }
+    res
+  end
+
+  def request_image(server, headers: {})
+    req = fake_req(
+      method:       "GET",
+      path:         "/api/local-image",
+      query_string: "path=#{CGI.escape(image_path)}",
+      headers:      headers
+    )
+    res = capturing_res
+    dispatch(server, req, res)
+    res
+  end
+
+  before { File.binwrite(image_path, "PNGDATA-v1") }
+
+  it "returns 200 with an ETag and no-cache on first request" do
+    with_server(agent_config: agent_config) do |server|
+      res = request_image(server)
+      expect(res.status).to eq(200)
+      expect(res["ETag"]).to be_a(String).and(match(/\A\S+\z/))
+      expect(res["Cache-Control"]).to eq("private, no-cache")
+      expect(res.body).to eq("PNGDATA-v1")
+    end
+  end
+
+  it "returns 304 with no body when If-None-Match matches the current ETag" do
+    with_server(agent_config: agent_config) do |server|
+      etag = request_image(server)["ETag"]
+      res = request_image(server, headers: { "If-None-Match" => etag })
+      expect(res.status).to eq(304)
+      expect(res.body).to eq("")
+    end
+  end
+
+  it "returns 200 with a new ETag when the same-name file is overwritten" do
+    with_server(agent_config: agent_config) do |server|
+      old_etag = request_image(server)["ETag"]
+
+      # Overwrite with different content + size; bump mtime to guarantee change
+      # even on coarse-grained filesystems.
+      File.binwrite(image_path, "PNGDATA-version-2-longer")
+      File.utime(Time.now + 2, Time.now + 2, image_path)
+
+      res = request_image(server, headers: { "If-None-Match" => old_etag })
+      expect(res.status).to eq(200)
+      expect(res["ETag"]).not_to eq(old_etag)
+      expect(res.body).to eq("PNGDATA-version-2-longer")
+    end
+  end
+end

--- a/spec/clacky/utils/file_processor_spec.rb
+++ b/spec/clacky/utils/file_processor_spec.rb
@@ -405,7 +405,8 @@ RSpec.describe Clacky::Utils::FileProcessor do
         result = described_class.rewrite_local_image_urls(content)
 
         expected_path = CGI.escape("file://#{img}")
-        expect(result).to eq("Check this: ![pic](/api/local-image?path=#{expected_path})")
+        expect(result).to include("![pic](/api/local-image?path=#{expected_path}&v=")
+        expect(result).to match(/&v=\d+\)/)
       end
     end
 
@@ -418,7 +419,24 @@ RSpec.describe Clacky::Utils::FileProcessor do
         result = described_class.rewrite_local_image_urls(content)
 
         expected_path = CGI.escape(img)
-        expect(result).to eq("See: ![img](/api/local-image?path=#{expected_path})")
+        expect(result).to include("![img](/api/local-image?path=#{expected_path}&v=")
+        expect(result).to match(/&v=\d+\)/)
+      end
+    end
+
+    it "changes the version param when the same-name file is overwritten" do
+      Dir.mktmpdir do |dir|
+        img = File.join(dir, "cover.png")
+        File.binwrite(img, "v1")
+        first = described_class.rewrite_local_image_urls("![c](#{img})")
+
+        File.binwrite(img, "version-two")
+        File.utime(Time.now + 2, Time.now + 2, img)
+        second = described_class.rewrite_local_image_urls("![c](#{img})")
+
+        v1 = first[/&v=(\d+)/, 1]
+        v2 = second[/&v=(\d+)/, 1]
+        expect(v2).not_to eq(v1)
       end
     end
 


### PR DESCRIPTION
## Problem

When media-gen regenerated an image under the same filename, the chat bubble kept showing the stale image. Local images were served through a fixed `/api/local-image?path=...` URL, so after an overwrite the URL was unchanged. An earlier ETag + `no-cache` attempt did not fix it: for an `<img>` with an unchanged URL the browser reuses its in-memory cache and never sends the `If-None-Match` conditional request, so ETag revalidation never fires. Verified in a real browser — the fixed URL still rendered the old pixels after the file was overwritten.

## Fix

- Append `&v=<file mtime>` to every `/api/local-image` URL. When the file is overwritten its mtime changes, the URL changes, and the browser treats it as a brand-new resource and refetches — defeating the in-memory image cache.
- Centralize URL generation in `FileProcessor.local_image_proxy_url`, covering the image / video / audio / link rewrite paths.
- Apply the same versioned URL to history user-message images in `http_server.rb`.
- Keep the existing ETag + `no-cache` logic as a second-layer safeguard; the backend ignores the extra `v` param when resolving the path.

## Test

- New `http_server_local_image_spec.rb` (first request → `200` + ETag + `no-cache`; matching `If-None-Match` → `304` empty body; overwrite → new ETag + `200` + new bytes). ✅
- `file_processor_spec.rb` asserts URLs carry `&v=` and that the version param changes after a same-name overwrite. ✅
- Real-browser verification against a live server: after overwriting a same-name file, the old fixed URL rendered stale pixels while the `&v=mtime` URL rendered the new pixels. ✅
- Full suite: `2686 examples, 0 failures`. ✅