### PR TITLE
feat(media): add Volcengine Ark Seedance video provider with async submit+poll

### DIFF
--- a/lib/clacky/default_skills/media-gen/SKILL.md
+++ b/lib/clacky/default_skills/media-gen/SKILL.md
@@ -310,6 +310,175 @@ Rules & caveats:
   chaining is the practical option today; Veo's native server-side `extend`
   (148s) is not wired into this endpoint yet.
 
+### Seedance (Volcengine Ark) — multimodal video
+
+When the configured `type=video` model is a ByteDance **Doubao Seedance**
+model on Volcengine Ark (its Base URL is under `*.volces.com`, e.g.
+`https://ark.cn-beijing.volces.com/api/v3`), the **same**
+`POST /api/media/video` endpoint drives it. No separate endpoint — the server
+routes by Base URL automatically. Seedance adds richer inputs on top of the
+common fields; all are optional and only apply to Seedance:
+
+> **Cost gate — ask before EVERY generation.** Resolution is the main driver
+> of Seedance's price (4k costs far more than 720p). So **once you've confirmed
+> via `GET /api/media/types` that the `type=video` Base URL is under
+> `*.volces.com`, you MUST ask the user which resolution they want before EACH
+> AND EVERY billable call** — this covers not just a brand-new clip but also
+> editing, multimodal reference, and extending/continuing an existing video
+> (they all cost the same as a fresh render). Offer `480p` / `720p` / `1080p` /
+> `4k` and state the default is `720p`. Only after they answer (or explicitly
+> say "use the default") do you proceed, passing their choice as `resolution`.
+> **Ask again every single time — a resolution the user picked for one clip is
+> NEVER carried over to the next generation. Do not assume, do not reuse a
+> prior answer, do not batch. One generation = one fresh resolution question.**
+> **When editing or continuing/extending an existing video, default to that
+> source video's resolution — never silently upgrade it (e.g. don't turn a
+> 720p source into a 4k render).** If the user gave no answer and you didn't
+> ask, the server pins `720p`. **These Seedance-only fields (`resolution`,
+> `generate_audio`, `watermark`, `seed`, `first_frame`, `last_frame`,
+> `reference_*`) have NO effect on Veo or Qwen/DashScope backends — never send
+> them unless the Base URL is `*.volces.com`.**
+
+| Field              | Values                                   | Notes |
+|--------------------|------------------------------------------|-------|
+| `aspect_ratio`     | `landscape`/`portrait`/`square`, or a raw Ark ratio like `16:9`, `9:16`, `4:3`, `3:4`, `21:9`, `adaptive` | Raw ratios pass through unchanged. |
+| `duration_seconds` | integer, or `-1`                         | `-1` lets the model pick the length (Seedance 2.0 / 1.5 Pro). |
+| `resolution`       | `480p` / `720p` / `1080p` / `4k`         | **Defaults to `720p` when omitted** (cost control). Ask the user before every generation — never reuse a prior answer. See the cost gate above. Model-dependent; unsupported values are rejected upstream. |
+| `generate_audio`   | `true` / `false`                         | Seedance 2.0 / 1.5 Pro can synthesize a synced audio track. |
+| `watermark`        | `true` / `false`                         | |
+| `seed`             | integer                                  | Reproducibility. |
+| `first_frame`      | media ref (see below)                    | First frame → image-to-video. |
+| `last_frame`       | media ref                                | Together with `first_frame` → first+last-frame video. |
+| `reference_images` | array of media refs (0–9)                | Reference images. |
+| `reference_videos` | array of media refs (0–3)                | Reference videos. |
+| `reference_audios` | array of media refs (0–3)                | Reference audio (background music / voice). |
+
+**Which fields for which task** — Seedance covers six capabilities; pick the
+fields by intent, and never mix the two families below:
+
+| Task | What you want | Fields to send |
+|------|---------------|----------------|
+| Text-to-video | a clip from a prompt only | `prompt` (no media) |
+| Image-to-video (first frame) | animate a still image forward | `first_frame` |
+| Image-to-video (first + last frame) | interpolate between two stills | `first_frame` + `last_frame` |
+| Multimodal generation | new clip guided by reference images/videos/audio | `reference_images` / `reference_videos` / `reference_audios` |
+| **Edit an existing video** | replace/add/remove/repaint something *inside* a given video | `reference_videos: [<the video to edit>]` (+ optional `reference_images` / `reference_audios`) + a prompt describing the edit |
+| **Extend / continue a video** | prepend/append or stitch clips into one | `reference_videos: [<clip1>, <clip2>, ...]` (up to 3) + a prompt describing the join |
+
+> **🚫 Hard rule — the two families are mutually exclusive.**
+> `first_frame`/`last_frame` **cannot** be combined with any `reference_*`
+> field; Ark rejects the request. If the user wants to **edit or extend an
+> existing video, that is a `reference_videos` task — do NOT fall back to
+> extracting a frame and using `first_frame`** (that produces a brand-new clip
+> and silently loses the "edit the original" intent). The server also enforces
+> this and returns a clear `invalid_argument` error if you mix them.
+
+A **media ref** may be:
+- a public `http(s)://` URL, or a `data:` URL, or
+- a local file path (the server reads and base64-encodes it), or
+- a `{ "b64_json": "...", "mime_type": "image/png" }` hash.
+
+Note: audio cannot be sent alone — pair it with at least one image or video.
+Prefer passing large videos/audios as public URLs; base64-encoding a big local
+file can exceed upstream size limits.
+
+Example — **first + last frame** (image-to-video, no `reference_*`):
+
+```bash
+curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "First-person POV, a hand raises a cup of fruit tea toward the camera, bright and refreshing lighting",
+    "aspect_ratio": "9:16",
+    "duration_seconds": 8,
+    "resolution": "720p",
+    "first_frame": "'"$(pwd)"'/assets/frame_first.jpg",
+    "last_frame": "'"$(pwd)"'/assets/frame_last.jpg",
+    "output_dir": "'"$(pwd)"'",
+    "session_id": "<%= session_id %>"
+  }'
+```
+
+Example — **edit an existing video** (replace/add/remove something inside it;
+uses `reference_videos`, NOT `first_frame`):
+
+```bash
+curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Add a small wooden fishing boat with a warm lantern drifting slowly across the lake in the foreground, keep everything else unchanged",
+    "resolution": "720p",
+    "reference_videos": ["'"$(pwd)"'/assets/original.mp4"],
+    "output_dir": "'"$(pwd)"'",
+    "session_id": "<%= session_id %>"
+  }'
+```
+
+**Seedance is asynchronous — POST only submits, it does NOT return the video.**
+Unlike Veo (which blocks and returns the mp4 in one call), the Seedance POST
+returns immediately with a task id:
+
+```json
+{ "success": true, "status": "submitted", "task_id": "cgt-2024...-xxxx", "provider": "volcengine" }
+```
+
+`status: "submitted"` means the render is now running on Volcengine's servers
+and **is already being billed** — it does NOT mean it is done. You MUST now
+poll for completion: sleep ~15 seconds, then query the status endpoint, and
+repeat until it is `succeeded` (or `failed`):
+
+```bash
+curl -s "http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video/status?task_id=cgt-2024...-xxxx&output_dir=$(pwd)&session_id=<%= session_id %>"
+```
+
+Status responses:
+
+```json
+{ "success": true,  "status": "running" }                         // keep polling
+{ "success": true,  "status": "succeeded", "video": "/abs/path.mp4" }  // done — this is the file
+{ "success": false, "status": "failed", "error": "..." }          // give up, report to user
+```
+
+Only once you receive `status: "succeeded"` and the absolute `video` path may
+you present the result to the user. Do NOT end your turn while the task is
+still `submitted`/`running` — the user is waiting for the finished video.
+
+A minimal poll loop:
+
+```bash
+TASK_ID=$(curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"...","resolution":"720p","output_dir":"'"$(pwd)"'","session_id":"<%= session_id %>"}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin).get("task_id",""))')
+
+while true; do
+  sleep 15
+  RESP=$(curl -s "http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video/status?task_id=${TASK_ID}&output_dir=$(pwd)&session_id=<%= session_id %>")
+  STATUS=$(echo "$RESP" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))')
+  echo "poll: $STATUS"
+  [ "$STATUS" = "succeeded" ] && echo "$RESP" && break
+  [ "$STATUS" = "failed" ] && echo "$RESP" && break
+done
+```
+
+**Hard rules — a broken version of this once doubled a user's bill:**
+
+- ❌ **Never POST the same generation twice.** Once you have a `task_id`, the
+  only valid next action is polling `/api/media/video/status`. A slow render
+  is not a failed one.
+- ⚠️ **A timeout or error is NOT proof the task failed.** The task keeps
+  running and billing on Volcengine's side. Always query the status endpoint
+  to find out the real state before doing anything else — never resubmit.
+- ❌ **Never kill the poll to "cancel" the job.** Killing your curl/session
+  does not stop the Volcengine task; it keeps running and billing. A running
+  task also cannot be deleted upstream.
+- ❌ **Never bypass `/api/media/*` to call Volcengine's native API directly.**
+  All submission and status checks must go through this server (it meters
+  cost). There is no reason to touch the raw Ark API.
+- ⏱️ If polling exceeds ~15 minutes and status is still `running`, stop
+  polling and tell the user the task is still rendering in the background,
+  give them the `task_id`, and let them check again later — do NOT resubmit.
+
 ## Generating speech (Gemini TTS)
 
 The same `/api/media/` namespace serves text-to-speech. The user must

--- a/lib/clacky/default_skills/media-gen/SKILL.md
+++ b/lib/clacky/default_skills/media-gen/SKILL.md
@@ -449,12 +449,12 @@ A minimal poll loop:
 TASK_ID=$(curl -s -X POST http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video \
   -H "Content-Type: application/json" \
   -d '{"prompt":"...","resolution":"720p","output_dir":"'"$(pwd)"'","session_id":"<%= session_id %>"}' \
-  | python3 -c 'import sys,json;print(json.load(sys.stdin).get("task_id",""))')
+  | sed -n 's/.*"task_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 while true; do
   sleep 15
   RESP=$(curl -s "http://${CLACKY_SERVER_HOST}:${CLACKY_SERVER_PORT}/api/media/video/status?task_id=${TASK_ID}&output_dir=$(pwd)&session_id=<%= session_id %>")
-  STATUS=$(echo "$RESP" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))')
+  STATUS=$(echo "$RESP" | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
   echo "poll: $STATUS"
   [ "$STATUS" = "succeeded" ] && echo "$RESP" && break
   [ "$STATUS" = "failed" ] && echo "$RESP" && break

--- a/lib/clacky/media/generator.rb
+++ b/lib/clacky/media/generator.rb
@@ -3,6 +3,7 @@
 require_relative "openai_compat"
 require_relative "gemini"
 require_relative "dashscope"
+require_relative "volcengine"
 
 module Clacky
   module Media
@@ -32,6 +33,13 @@ module Clacky
       # they correctly keep going through OpenAICompat.
       DASHSCOPE_NATIVE_HOSTS = [
         "aliyuncs.com"
+      ].freeze
+
+      # Hosts that speak Volcengine Ark's native async video-task API
+      # (ByteDance Doubao Seedance) instead of an OpenAI-compatible facade.
+      # Matched as a substring so regional variants are caught.
+      VOLCENGINE_NATIVE_HOSTS = [
+        "volces.com"
       ].freeze
 
       # @param agent_config [Clacky::AgentConfig]
@@ -99,6 +107,34 @@ module Clacky
           output_dir: output_dir,
           **kwargs
         )
+      end
+
+      def video_status(task_id:, output_dir: nil)
+        entry = video_model_entry
+        if entry.nil?
+          return {
+            "success"    => false,
+            "status"     => "failed",
+            "error"      => "No video model configured. Add a model with type=video in settings.",
+            "error_type" => "not_configured",
+            "provider"   => "",
+            "model"      => ""
+          }
+        end
+
+        provider = build_provider_for(entry)
+        unless provider.respond_to?(:video_status)
+          return {
+            "success"    => false,
+            "status"     => "failed",
+            "error"      => "Status queries are only supported for Volcengine (Seedance) video; this provider generates synchronously.",
+            "error_type" => "unsupported",
+            "provider"   => "",
+            "model"      => ""
+          }
+        end
+
+        provider.video_status(task_id: task_id, output_dir: output_dir)
       end
 
       def generate_speech(input:, voice: nil, output_dir: nil, **kwargs)
@@ -185,6 +221,9 @@ module Clacky
       #     DashScope (native /api/v1/.../multimodal-generation schema for
       #     Qwen-Image). Third-party aggregators re-exposing qwen-image behind
       #     an OpenAI-compatible facade are NOT on aliyuncs.com and fall through.
+      #   • base_url points at a Volcengine Ark host (*.volces.com) →
+      #     Volcengine (native async /api/v3/contents/generations/tasks schema
+      #     for Doubao Seedance video).
       #   • everything else → OpenAICompat. This covers OpenAI itself, the
       #     openclacky gateway, OpenRouter, and any third-party proxy that
       #     re-exposes Gemini / Imagen / DALL-E behind /v1/images/generations.
@@ -196,6 +235,8 @@ module Clacky
           Gemini.new(entry)
         elsif DASHSCOPE_NATIVE_HOSTS.any? { |host| url.include?(host) }
           DashScope.new(entry)
+        elsif VOLCENGINE_NATIVE_HOSTS.any? { |host| url.include?(host) }
+          Volcengine.new(entry)
         else
           OpenAICompat.new(entry)
         end

--- a/lib/clacky/media/volcengine.rb
+++ b/lib/clacky/media/volcengine.rb
@@ -1,0 +1,394 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+require "uri"
+require "base64"
+require_relative "base"
+
+module Clacky
+  module Media
+    # Volcengine Ark (ByteDance Doubao Seedance) video generation provider.
+    #
+    # Ark is NOT OpenAI-compatible for video. It uses an asynchronous task
+    # model with its own request envelope: submit a task to
+    # POST /api/v3/contents/generations/tasks, then poll
+    # GET /api/v3/contents/generations/tasks/{id} until it succeeds, fails,
+    # or expires. Unlike the blocking Veo path, we surface that async model
+    # end to end: #generate_video submits and returns the task id immediately,
+    # and #video_status polls a single time (downloading the MP4 once the task
+    # has succeeded). This keeps a slow (e.g. 4k) render from blocking the HTTP
+    # request past its timeout and dropping the task id.
+    #
+    # Routing: Generator sends any base_url under *.volces.com here. We
+    # derive the API root from the host so users can paste the standard
+    # base_url they use for Ark chat models (…/api/v3) and still get working
+    # video generation.
+    #
+    # Seedance content is multimodal: alongside the text prompt, callers may
+    # attach a first frame, a last frame, reference images (0-9), reference
+    # videos (0-3) and reference audios (0-3). Each media item may be a
+    # public http(s) URL, a data URL, a local file path (encoded to a data
+    # URL), or a { "b64_json" => ..., "mime_type" => ... } hash.
+    class Volcengine < Base
+      TASKS_PATH  = "/api/v3/contents/generations/tasks"
+      PROVIDER_ID = "volcengine"
+
+      # aspect_ratio -> Ark ratio. Ark also accepts more granular ratios and
+      # "adaptive"; when the caller passes one of those verbatim we forward it
+      # unchanged (see #resolve_ratio).
+      ASPECT_TO_RATIO = {
+        "landscape" => "16:9",
+        "portrait"  => "9:16",
+        "square"    => "1:1"
+      }.freeze
+
+      # Ratios Ark accepts directly. Anything else falls back to the
+      # aspect_ratio mapping / default.
+      ARK_RATIOS = %w[16:9 4:3 1:1 3:4 9:16 21:9 adaptive].freeze
+
+      DEFAULT_RATIO = "16:9"
+
+      # Explicit cost-control default: when the caller omits resolution we pin
+      # 720p rather than relying on Ark's server-side default (which could
+      # change and silently raise the user's bill).
+      DEFAULT_RESOLUTION = "720p"
+
+      # @param prompt [String] the video prompt (may be empty when driven
+      #   purely by reference media, but Ark still recommends text)
+      # @param aspect_ratio [String] "landscape"/"portrait"/"square", or an
+      #   Ark ratio string ("16:9", "9:16", "adaptive", ...)
+      # @param duration_seconds [Integer, nil] target duration; -1 lets the
+      #   model choose (Seedance 2.0 / 1.5 Pro only)
+      # @param first_frame [String, Hash, nil] first frame image
+      # @param last_frame [String, Hash, nil] last frame image
+      # @param reference_images [Array, String, Hash, nil] reference images
+      # @param reference_videos [Array, String, Hash, nil] reference videos
+      # @param reference_audios [Array, String, Hash, nil] reference audios
+      # @param resolution [String, nil] "480p"/"720p"/"1080p"/"4k"
+      # @param generate_audio [Boolean, nil] whether to synthesize audio
+      # @param watermark [Boolean, nil] whether to add a watermark
+      # @param seed [Integer, nil] random seed
+      def generate_video(prompt:, aspect_ratio: "landscape", duration_seconds: nil, output_dir: nil,
+                         image: nil, first_frame: nil, last_frame: nil,
+                         reference_images: nil, reference_videos: nil, reference_audios: nil,
+                         resolution: nil, generate_audio: nil, watermark: nil, seed: nil, **_kwargs)
+        # `image` is the legacy single first-frame field used across the media
+        # stack; treat it as first_frame when no explicit first_frame is given.
+        first_frame ||= image
+
+        content, build_err = build_content(
+          prompt: prompt,
+          first_frame: first_frame,
+          last_frame: last_frame,
+          reference_images: reference_images,
+          reference_videos: reference_videos,
+          reference_audios: reference_audios
+        )
+        if build_err
+          return video_error_response(
+            error: build_err, error_type: "invalid_argument",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        has_text  = prompt.to_s.strip != ""
+        has_media = content.length > (has_text ? 1 : 0)
+        if !has_text && !has_media
+          return video_error_response(
+            error: "A text prompt or at least one reference image/video is required",
+            error_type: "invalid_argument",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        if @api_key.to_s.empty?
+          return video_error_response(
+            error: "api_key not configured for video model '#{@model}'",
+            error_type: "auth_required",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        ratio   = resolve_ratio(aspect_ratio)
+        payload = { model: @model, content: content }
+        payload[:ratio]          = ratio unless ratio.nil?
+        payload[:duration]       = duration_seconds.to_i if duration_seconds
+        payload[:resolution]     = (resolution && !resolution.to_s.empty?) ? resolution.to_s : DEFAULT_RESOLUTION
+        payload[:generate_audio] = generate_audio unless generate_audio.nil?
+        payload[:watermark]      = watermark unless watermark.nil?
+        payload[:seed]           = seed.to_i if seed
+
+        begin
+          response = connection.post(TASKS_PATH) do |req|
+            req.headers["Content-Type"]  = "application/json"
+            req.headers["Authorization"] = "Bearer #{@api_key}"
+            req.body = JSON.generate(payload)
+          end
+        rescue Faraday::Error => e
+          return video_error_response(
+            error: "HTTP request failed: #{e.message}",
+            error_type: "network_error",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        body = parse_json(response.body)
+        unless body.is_a?(Hash)
+          return video_error_response(
+            error: "Invalid JSON response from upstream",
+            error_type: "invalid_response",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        # Ark reports submission errors via a nested "error" object.
+        if body["error"].is_a?(Hash)
+          err = body["error"]
+          return video_error_response(
+            error: "Upstream error #{err["code"]}: #{err["message"]}",
+            error_type: "api_error",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        unless response.success?
+          return video_error_response(
+            error: "Upstream #{response.status}: #{truncate(response.body, 500)}",
+            error_type: "api_error",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        task_id = body["id"]
+        if task_id.nil? || task_id.to_s.empty?
+          return video_error_response(
+            error: "Upstream did not return a task id",
+            error_type: "empty_response",
+            provider: PROVIDER_ID, prompt: prompt, aspect_ratio: aspect_ratio
+          )
+        end
+
+        # Submit only: return the task id immediately. The caller polls
+        # GET /api/media/video/status so a long (e.g. 4k) render never blocks
+        # the HTTP request past its timeout — which used to drop the task id
+        # and push the model into resubmitting, doubling the bill.
+        {
+          "success"      => true,
+          "status"       => "submitted",
+          "task_id"      => task_id,
+          "provider"     => PROVIDER_ID,
+          "model"        => @model,
+          "prompt"       => prompt,
+          "aspect_ratio" => aspect_ratio,
+          "ratio"        => ratio,
+          "duration_seconds" => (duration_seconds ? duration_seconds.to_i : nil)
+        }.compact
+      end
+
+      # Poll a previously submitted task once. On "succeeded" the MP4 is
+      # downloaded and a local path is returned; other states map to
+      # running / failed without blocking.
+      def video_status(task_id:, output_dir: nil)
+        if task_id.to_s.strip.empty?
+          return video_error_response(
+            error: "task_id is required", error_type: "invalid_argument",
+            provider: PROVIDER_ID
+          )
+        end
+
+        state, detail = fetch_task(task_id)
+        case state
+        when :running
+          { "success" => true, "status" => "running", "task_id" => task_id, "provider" => PROVIDER_ID, "model" => @model }
+        when :succeeded
+          local_path = save_image_from_url(detail, output_dir: output_dir || Dir.pwd, prefix: "vid", extension: "mp4")
+          if local_path.nil?
+            return {
+              "success" => false, "status" => "failed", "task_id" => task_id, "provider" => PROVIDER_ID,
+              "model" => @model, "error" => "Failed to download generated video from #{detail}",
+              "error_type" => "download_failed"
+            }
+          end
+          {
+            "success" => true, "status" => "succeeded", "video" => local_path,
+            "task_id" => task_id, "provider" => PROVIDER_ID, "model" => @model
+          }
+        else # :failed
+          {
+            "success" => false, "status" => "failed", "task_id" => task_id, "provider" => PROVIDER_ID,
+            "model" => @model, "error" => detail, "error_type" => "task_failed"
+          }
+        end
+      end
+
+      # Query a task once (no sleeping/looping). Returns one of:
+      #   [:running, nil]
+      #   [:succeeded, video_url]
+      #   [:failed, error_message]
+      private def fetch_task(task_id)
+        begin
+          resp = connection.get("#{TASKS_PATH}/#{task_id}") do |req|
+            req.headers["Authorization"] = "Bearer #{@api_key}"
+          end
+        rescue Faraday::Error => e
+          return [:failed, "Polling request failed: #{e.message}"]
+        end
+
+        task = parse_json(resp.body)
+        return [:failed, "Invalid polling response JSON"] unless task.is_a?(Hash)
+
+        case task["status"]
+        when "succeeded"
+          url = task.dig("content", "video_url")
+          return [:failed, "Task succeeded but returned no video_url"] if url.nil? || url.empty?
+          [:succeeded, url]
+        when "failed"
+          msg = task.dig("error", "message") || task["error"] || "Unknown error"
+          [:failed, "Task failed: #{msg}"]
+        when "cancelled", "canceled"
+          [:failed, "Task was cancelled"]
+        when "expired"
+          [:failed, "Task expired before completion"]
+        else # "queued" / "running"
+          [:running, nil]
+        end
+      end
+
+      # Build the Ark content[] array. Returns [content, nil] on success or
+      # [nil, error_message] when a media item can't be resolved.
+      private def build_content(prompt:, first_frame:, last_frame:, reference_images:, reference_videos:, reference_audios:)
+        has_frame     = !normalize_list(first_frame).empty? || !normalize_list(last_frame).empty?
+        has_reference = !normalize_list(reference_images).empty? ||
+                        !normalize_list(reference_videos).empty? ||
+                        !normalize_list(reference_audios).empty?
+        if has_frame && has_reference
+          return [nil, "first_frame/last_frame cannot be combined with reference_images/videos/audios. " \
+                       "Use first_frame (and optionally last_frame) for first/last-frame image-to-video, " \
+                       "OR use reference_* for multimodal / video editing / video extension — not both."]
+        end
+
+        content = []
+        content << { type: "text", text: prompt.to_s } unless prompt.to_s.strip.empty?
+
+        {
+          "first_frame"     => normalize_list(first_frame),
+          "last_frame"      => normalize_list(last_frame),
+          "reference_image" => normalize_list(reference_images)
+        }.each do |role, items|
+          items.each do |item|
+            url, err = to_media_url(item, kind: :image)
+            return [nil, err] if err
+            content << { type: "image_url", image_url: { url: url }, role: role }
+          end
+        end
+
+        normalize_list(reference_videos).each do |item|
+          url, err = to_media_url(item, kind: :video)
+          return [nil, err] if err
+          content << { type: "video_url", video_url: { url: url }, role: "reference_video" }
+        end
+
+        normalize_list(reference_audios).each do |item|
+          url, err = to_media_url(item, kind: :audio)
+          return [nil, err] if err
+          content << { type: "audio_url", audio_url: { url: url }, role: "reference_audio" }
+        end
+
+        [content, nil]
+      end
+
+      # Accept a single value or an array; drop nils/blanks.
+      private def normalize_list(value)
+        list = value.is_a?(Array) ? value : [value]
+        list.reject { |v| v.nil? || (v.is_a?(String) && v.strip.empty?) }
+      end
+
+      # Resolve one media item into a URL Ark accepts (http(s) URL or data
+      # URL). Accepts: an http(s)/data URL string, a local file path, or a
+      # { "b64_json" => ..., "mime_type" => ... } hash. Returns [url, nil] or
+      # [nil, error_message].
+      private def to_media_url(item, kind:)
+        if item.is_a?(Hash)
+          b64  = item["b64_json"] || item[:b64_json]
+          mime = (item["mime_type"] || item[:mime_type]).to_s
+          return [nil, "media hash is missing b64_json"] if b64.to_s.empty?
+          mime = default_mime(kind) if mime.empty?
+          return ["data:#{mime};base64,#{b64}", nil]
+        end
+
+        s = item.to_s.strip
+        return [nil, "empty media reference"] if s.empty?
+        return [s, nil] if s.start_with?("http://", "https://", "data:")
+
+        unless File.file?(s)
+          return [nil, "media reference is neither an existing file path, a URL, nor base64 data: #{s}"]
+        end
+        bytes = File.binread(s)
+        mime  = mime_for_path(s, kind)
+        ["data:#{mime};base64,#{Base64.strict_encode64(bytes)}", nil]
+      end
+
+      private def resolve_ratio(aspect_ratio)
+        s = aspect_ratio.to_s
+        return s if ARK_RATIOS.include?(s)
+        ASPECT_TO_RATIO[s] || DEFAULT_RATIO
+      end
+
+      private def default_mime(kind)
+        case kind
+        when :video then "video/mp4"
+        when :audio then "audio/mpeg"
+        else "image/png"
+        end
+      end
+
+      private def mime_for_path(path, kind)
+        case File.extname(path).downcase
+        when ".jpg", ".jpeg" then "image/jpeg"
+        when ".webp"         then "image/webp"
+        when ".gif"          then "image/gif"
+        when ".mp4"          then "video/mp4"
+        when ".mov"          then "video/quicktime"
+        when ".webm"         then "video/webm"
+        when ".mp3"          then "audio/mpeg"
+        when ".wav"          then "audio/wav"
+        when ".m4a"          then "audio/mp4"
+        else default_mime(kind)
+        end
+      end
+
+      private def connection
+        Faraday.new(url: endpoint_base) do |f|
+          f.options.timeout      = 240
+          f.options.open_timeout = 10
+        end
+      end
+
+      # Derive the API root (scheme + host) from the configured base_url,
+      # discarding any path the user pasted (e.g. /api/v3). The task path is
+      # appended by the request methods. Falls back to the Beijing host.
+      private def endpoint_base
+        uri = URI.parse(@base_url.to_s)
+        if uri.scheme && uri.host
+          "#{uri.scheme}://#{uri.host}"
+        else
+          "https://ark.cn-beijing.volces.com"
+        end
+      rescue URI::InvalidURIError
+        "https://ark.cn-beijing.volces.com"
+      end
+
+      private def parse_json(body)
+        JSON.parse(body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      private def truncate(str, max)
+        s = str.to_s
+        s.length > max ? "#{s[0, max]}..." : s
+      end
+    end
+  end
+end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -463,6 +463,9 @@ module Clacky
           # with modalities:["image"]); end-to-end latency is commonly
           # 20-60s and can exceed 2 minutes for or-gpt-image-2 under load.
           300
+        elsif path == "/api/media/video/status"
+          # Single upstream task lookup; returns in well under a second.
+          30
         elsif path == "/api/media/video"
           # Video generation (Veo via the gateway) runs an async submit+poll
           # cycle that routinely takes 1-3 minutes and can approach the
@@ -572,6 +575,7 @@ module Clacky
         when ["GET",    "/api/local-image"]       then api_serve_local_image(req, res)
         when ["POST",   "/api/media/image"]       then api_media_image(req, res)
         when ["POST",   "/api/media/video"]       then api_media_video(req, res)
+        when ["GET",    "/api/media/video/status"] then api_media_video_status(req, res)
         when ["POST",   "/api/media/audio/speech"] then api_media_audio_speech(req, res)
         when ["POST",   "/api/media/audio/transcriptions"] then api_media_audio_transcriptions(req, res)
         when ["POST",   "/api/media/video/understand"]     then api_media_video_understand(req, res)
@@ -1539,13 +1543,41 @@ module Clacky
           aspect_ratio: aspect_ratio,
           duration_seconds: duration,
           output_dir: output_dir,
-          image: image
+          image: image,
+          first_frame: body["first_frame"],
+          last_frame: body["last_frame"],
+          reference_images: body["reference_images"],
+          reference_videos: body["reference_videos"],
+          reference_audios: body["reference_audios"],
+          resolution: body["resolution"],
+          generate_audio: body["generate_audio"],
+          watermark: body["watermark"],
+          seed: body["seed"]
         )
         if result["success"]
           log_media_usage(result, prompt: prompt, session_id: session_id)
         end
         status = result["success"] ? 200 : 422
         json_response(res, status, result)
+      rescue StandardError => e
+        json_response(res, 500, { error: e.message })
+      end
+
+      def api_media_video_status(req, res)
+        query   = URI.decode_www_form(req.query_string.to_s).to_h
+        task_id = query["task_id"].to_s
+        if task_id.strip.empty?
+          return json_response(res, 422, { error: "task_id is required" })
+        end
+
+        output_dir = query["output_dir"].to_s
+        output_dir = @agent_config.default_working_dir || Dir.pwd if output_dir.empty?
+
+        result = Clacky::Media::Generator.new(@agent_config).video_status(
+          task_id: task_id,
+          output_dir: output_dir
+        )
+        json_response(res, 200, result)
       rescue StandardError => e
         json_response(res, 500, { error: e.message })
       end

--- a/spec/clacky/default_skills/media_gen_spec.rb
+++ b/spec/clacky/default_skills/media_gen_spec.rb
@@ -11,8 +11,40 @@ RSpec.describe "media-gen default skill" do
     skill = Clacky::Skill.new(skill_dir)
     result = skill.process_content(template_context: { "session_id" => "session-123" })
 
-    expect(result.scan('"session_id": "session-123"').size).to eq(4)
+    expect(result.scan('"session_id": "session-123"').size).to eq(6)
     expect(result).to include('"Continuing the same scene, the camera keeps pushing forward…" "session-123"')
+  end
+
+  it "documents the Seedance async submit-then-poll flow with anti-resubmit guards" do
+    skill = Clacky::Skill.new(skill_dir)
+    result = skill.process_content(template_context: { "session_id" => "session-123" })
+
+    expect(result).to include("/api/media/video/status")
+    expect(result).to include('"status": "submitted"')
+    expect(result).to match(/Never POST the same generation twice/i)
+    expect(result).to match(/never bypass .*api\/media/i)
+    expect(result).to match(/timeout or error is NOT proof/i)
+  end
+
+  it "documents editing/extending a video via reference_videos, not first_frame" do
+    skill = Clacky::Skill.new(skill_dir)
+    result = skill.process_content(template_context: { "session_id" => "session-123" })
+
+    expect(result).to match(/Edit an existing video/i)
+    expect(result).to match(/Extend \/ continue a video/i)
+    expect(result).to match(/mutually exclusive/i)
+    expect(result).to match(/do NOT fall back to/i)
+    expect(result).to include('"reference_videos":')
+    expect(result).to match(/reference_videos.*original\.mp4/)
+  end
+
+  it "extends the resolution cost gate to edits and continuations" do
+    skill = Clacky::Skill.new(skill_dir)
+    result = skill.process_content(template_context: { "session_id" => "session-123" })
+
+    expect(result).to match(/before EACH/i)
+    expect(result).to match(/never reuse a prior answer|NEVER carried over/i)
+    expect(result).to match(/never silently upgrade it/i)
   end
 
   it "includes the session ID in chained-video payloads" do

--- a/spec/clacky/media/generator_spec.rb
+++ b/spec/clacky/media/generator_spec.rb
@@ -81,6 +81,61 @@ RSpec.describe Clacky::Media::Generator do
     end
   end
 
+  describe "video provider routing" do
+    it "routes a volces.com base_url to Volcengine" do
+      video_entry = {
+        "model"    => "doubao-seedance-2-0-260128",
+        "type"     => "video",
+        "base_url" => "https://ark.cn-beijing.volces.com/api/v3",
+        "api_key"  => "ark-test"
+      }
+      config = Clacky::AgentConfig.new(models: [video_entry])
+
+      fake_provider = instance_double(Clacky::Media::Volcengine)
+      expect(Clacky::Media::Volcengine).to receive(:new).and_return(fake_provider)
+      expect(fake_provider).to receive(:generate_video).and_return({ "success" => true })
+
+      described_class.new(config).generate_video(prompt: "a cat", output_dir: "/tmp/work")
+    end
+  end
+
+  describe "#video_status" do
+    it "delegates to Volcengine for a volces.com base_url" do
+      config = Clacky::AgentConfig.new(models: [{
+        "model" => "doubao-seedance-2-0-260128", "type" => "video",
+        "base_url" => "https://ark.cn-beijing.volces.com/api/v3", "api_key" => "ark-test"
+      }])
+
+      fake_provider = instance_double(Clacky::Media::Volcengine)
+      expect(Clacky::Media::Volcengine).to receive(:new).and_return(fake_provider)
+      expect(fake_provider).to receive(:video_status).with(task_id: "cgt-1", output_dir: "/tmp/work")
+        .and_return({ "success" => true, "status" => "running" })
+
+      result = described_class.new(config).video_status(task_id: "cgt-1", output_dir: "/tmp/work")
+      expect(result["status"]).to eq("running")
+    end
+
+    it "returns unsupported for a synchronous provider (Veo)" do
+      config = Clacky::AgentConfig.new(models: [{
+        "model" => "or-veo-3-1", "type" => "video",
+        "base_url" => "https://api.openclacky.com", "api_key" => "clacky-test"
+      }])
+
+      result = described_class.new(config).video_status(task_id: "cgt-1")
+      expect(result["success"]).to be false
+      expect(result["error_type"]).to eq("unsupported")
+    end
+
+    it "returns not_configured when no video model is set" do
+      config = Clacky::AgentConfig.new(models: [
+        { "model" => "chat", "type" => "default", "base_url" => "https://example.invalid/v1", "api_key" => "k" }
+      ])
+      result = described_class.new(config).video_status(task_id: "cgt-1")
+      expect(result["success"]).to be false
+      expect(result["error_type"]).to eq("not_configured")
+    end
+  end
+
   describe "#generate_video" do
     context "when no type=video model is configured" do
       it "returns a not_configured error response" do

--- a/spec/clacky/media/volcengine_spec.rb
+++ b/spec/clacky/media/volcengine_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "base64"
+require "clacky/media/volcengine"
+
+RSpec.describe Clacky::Media::Volcengine do
+  let(:entry) do
+    {
+      "model"    => "doubao-seedance-2-0-260128",
+      "base_url" => "https://ark.cn-beijing.volces.com/api/v3",
+      "api_key"  => "ark-test-key"
+    }
+  end
+  let(:provider) { described_class.new(entry) }
+  let(:fake_conn) { instance_double(Faraday::Connection) }
+
+  let(:submit_response) { JSON.generate({ "id" => "cgt-123" }) }
+  let(:status_running)    { JSON.generate({ "id" => "cgt-123", "status" => "running" }) }
+  let(:status_succeeded) do
+    JSON.generate({
+      "id"      => "cgt-123",
+      "status"  => "succeeded",
+      "content" => { "video_url" => "https://tos.example.com/result.mp4" }
+    })
+  end
+
+  before do
+    allow(provider).to receive(:connection).and_return(fake_conn)
+    allow(provider).to receive(:download_url).and_return("VIDEO_BYTES")
+  end
+
+  # Capture the submitted POST body; the task id is returned immediately.
+  def stub_submit
+    allow(fake_conn).to receive(:post).with("/api/v3/contents/generations/tasks") do |&blk|
+      req = double("req")
+      allow(req).to receive(:headers).and_return({})
+      allow(req).to receive(:body=) { |body| @captured_body = body }
+      blk.call(req)
+      instance_double(Faraday::Response, success?: true, status: 200, body: submit_response)
+    end
+  end
+
+  # Drive the single status GET.
+  def stub_status(body)
+    allow(fake_conn).to receive(:get).with("/api/v3/contents/generations/tasks/cgt-123")
+      .and_return(instance_double(Faraday::Response, success?: true, status: 200, body: body))
+  end
+
+  describe "#generate_video" do
+    context "text-to-video" do
+      before { stub_submit }
+
+      it "submits the Ark task envelope and returns the task id without blocking" do
+        result = provider.generate_video(prompt: "a cat surfing", aspect_ratio: "portrait", duration_seconds: 8)
+
+        sent = JSON.parse(@captured_body)
+        expect(sent["model"]).to eq("doubao-seedance-2-0-260128")
+        expect(sent["ratio"]).to eq("9:16")
+        expect(sent["duration"]).to eq(8)
+        expect(sent["content"]).to eq([{ "type" => "text", "text" => "a cat surfing" }])
+
+        expect(result["success"]).to be true
+        expect(result["status"]).to eq("submitted")
+        expect(result["task_id"]).to eq("cgt-123")
+        expect(result["provider"]).to eq("volcengine")
+        expect(result).not_to have_key("video")
+      end
+
+      it "does not poll or download during submission" do
+        expect(fake_conn).not_to receive(:get)
+        provider.generate_video(prompt: "x")
+      end
+    end
+
+    context "aspect ratio handling" do
+      before { stub_submit }
+
+      it "maps landscape/portrait/square to Ark ratios" do
+        provider.generate_video(prompt: "x", aspect_ratio: "landscape")
+        expect(JSON.parse(@captured_body)["ratio"]).to eq("16:9")
+      end
+
+      it "passes a raw Ark ratio through unchanged" do
+        provider.generate_video(prompt: "x", aspect_ratio: "adaptive")
+        expect(JSON.parse(@captured_body)["ratio"]).to eq("adaptive")
+
+        provider.generate_video(prompt: "x", aspect_ratio: "21:9")
+        expect(JSON.parse(@captured_body)["ratio"]).to eq("21:9")
+      end
+
+      it "forwards optional Seedance params" do
+        provider.generate_video(prompt: "x", resolution: "1080p", generate_audio: true, watermark: false, seed: 42)
+        sent = JSON.parse(@captured_body)
+        expect(sent["resolution"]).to eq("1080p")
+        expect(sent["generate_audio"]).to be true
+        expect(sent["watermark"]).to be false
+        expect(sent["seed"]).to eq(42)
+      end
+
+      it "pins resolution to 720p when omitted" do
+        provider.generate_video(prompt: "x")
+        expect(JSON.parse(@captured_body)["resolution"]).to eq("720p")
+      end
+    end
+
+    context "multimodal content" do
+      before { stub_submit }
+
+      it "attaches first/last frame images with roles" do
+        provider.generate_video(
+          prompt: "morph",
+          first_frame: "https://img.example.com/a.jpg",
+          last_frame: "https://img.example.com/b.jpg"
+        )
+        content = JSON.parse(@captured_body)["content"]
+        expect(content).to include(
+          { "type" => "image_url", "image_url" => { "url" => "https://img.example.com/a.jpg" }, "role" => "first_frame" },
+          { "type" => "image_url", "image_url" => { "url" => "https://img.example.com/b.jpg" }, "role" => "last_frame" }
+        )
+      end
+
+      it "attaches reference images, videos and audios with roles" do
+        provider.generate_video(
+          prompt: "ad",
+          reference_images: ["https://img.example.com/1.jpg", "https://img.example.com/2.jpg"],
+          reference_videos: ["https://vid.example.com/v.mp4"],
+          reference_audios: ["https://aud.example.com/a.mp3"]
+        )
+        content = JSON.parse(@captured_body)["content"]
+        roles = content.map { |c| c["role"] }
+        expect(roles.count("reference_image")).to eq(2)
+        expect(content).to include(
+          { "type" => "video_url", "video_url" => { "url" => "https://vid.example.com/v.mp4" }, "role" => "reference_video" },
+          { "type" => "audio_url", "audio_url" => { "url" => "https://aud.example.com/a.mp3" }, "role" => "reference_audio" }
+        )
+      end
+
+      it "encodes a local file path into a data URL" do
+        Dir.mktmpdir do |tmp|
+          path = File.join(tmp, "frame.png")
+          File.binwrite(path, "PNGDATA")
+          provider.generate_video(prompt: "x", first_frame: path)
+          url = JSON.parse(@captured_body)["content"].find { |c| c["role"] == "first_frame" }["image_url"]["url"]
+          expect(url).to eq("data:image/png;base64,#{Base64.strict_encode64("PNGDATA")}")
+        end
+      end
+
+      it "accepts a b64_json hash for the legacy image field" do
+        provider.generate_video(prompt: "x", image: { "b64_json" => "QUJD", "mime_type" => "image/jpeg" })
+        url = JSON.parse(@captured_body)["content"].find { |c| c["role"] == "first_frame" }["image_url"]["url"]
+        expect(url).to eq("data:image/jpeg;base64,QUJD")
+      end
+
+      it "rejects a media reference that is neither a URL, file, nor hash" do
+        result = provider.generate_video(prompt: "x", reference_videos: ["/no/such/file.mp4"])
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("invalid_argument")
+      end
+    end
+
+    context "validation" do
+      it "requires a prompt or at least one media input" do
+        result = provider.generate_video(prompt: "  ")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("invalid_argument")
+      end
+
+      it "rejects mixing first_frame/last_frame with reference_* without submitting" do
+        expect(fake_conn).not_to receive(:post)
+        result = provider.generate_video(
+          prompt: "edit this",
+          first_frame: "https://img.example.com/a.jpg",
+          reference_videos: ["https://vid.example.com/v.mp4"]
+        )
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("invalid_argument")
+        expect(result["error"]).to match(/cannot be combined/)
+      end
+
+      it "allows an empty prompt when a reference image is provided" do
+        stub_submit
+        result = provider.generate_video(prompt: "", first_frame: "https://img.example.com/a.jpg")
+        expect(result["success"]).to be true
+        expect(result["status"]).to eq("submitted")
+      end
+
+      it "fails when api_key is missing" do
+        no_key = described_class.new(entry.merge("api_key" => ""))
+        result = no_key.generate_video(prompt: "x")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("auth_required")
+      end
+
+      it "fails when upstream returns no task id" do
+        allow(fake_conn).to receive(:post).and_return(
+          instance_double(Faraday::Response, success?: true, status: 200, body: JSON.generate({}))
+        )
+        result = provider.generate_video(prompt: "x")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("empty_response")
+      end
+    end
+
+    context "submission errors" do
+      it "surfaces a nested Ark error object" do
+        allow(fake_conn).to receive(:post).and_return(
+          instance_double(Faraday::Response, success?: false, status: 400,
+                          body: JSON.generate({ "error" => { "code" => "InvalidParameter", "message" => "bad model" } }))
+        )
+        result = provider.generate_video(prompt: "x")
+        expect(result["success"]).to be false
+        expect(result["error_type"]).to eq("api_error")
+        expect(result["error"]).to include("bad model")
+      end
+    end
+  end
+
+  describe "#video_status" do
+    it "requires a task id" do
+      result = provider.video_status(task_id: "  ")
+      expect(result["success"]).to be false
+      expect(result["error_type"]).to eq("invalid_argument")
+    end
+
+    it "reports a still-running task without downloading" do
+      stub_status(status_running)
+      expect(provider).not_to receive(:download_url)
+      result = provider.video_status(task_id: "cgt-123")
+      expect(result["success"]).to be true
+      expect(result["status"]).to eq("running")
+      expect(result["task_id"]).to eq("cgt-123")
+    end
+
+    it "downloads and returns a local path on success" do
+      stub_status(status_succeeded)
+      Dir.mktmpdir do |tmp|
+        result = provider.video_status(task_id: "cgt-123", output_dir: tmp)
+        expect(result["success"]).to be true
+        expect(result["status"]).to eq("succeeded")
+        expect(result["video"]).to start_with(File.join(tmp, "assets", "generated"))
+        expect(File.binread(result["video"])).to eq("VIDEO_BYTES")
+        expect(result["task_id"]).to eq("cgt-123")
+      end
+    end
+
+    it "treats a queued task as still running" do
+      stub_status(JSON.generate({ "id" => "cgt-123", "status" => "queued" }))
+      result = provider.video_status(task_id: "cgt-123")
+      expect(result["success"]).to be true
+      expect(result["status"]).to eq("running")
+    end
+
+    it "surfaces a failed task" do
+      stub_status(JSON.generate({ "status" => "failed", "error" => { "message" => "content blocked" } }))
+      result = provider.video_status(task_id: "cgt-123")
+      expect(result["success"]).to be false
+      expect(result["status"]).to eq("failed")
+      expect(result["error"]).to include("content blocked")
+    end
+
+    it "surfaces an expired task as failed" do
+      stub_status(JSON.generate({ "status" => "expired" }))
+      result = provider.video_status(task_id: "cgt-123")
+      expect(result["success"]).to be false
+      expect(result["error"]).to include("expired")
+    end
+  end
+end

--- a/spec/clacky/server/http_server_media_spec.rb
+++ b/spec/clacky/server/http_server_media_spec.rb
@@ -232,4 +232,55 @@ RSpec.describe Clacky::Server::HttpServer, "media routes" do
       end
     end
   end
+
+  describe "GET /api/media/video/status" do
+    let(:video_models) do
+      [{ "model" => "doubao-seedance-2-0-260128", "api_key" => "ark-x",
+         "base_url" => "https://ark.cn-beijing.volces.com/api/v3", "type" => "video" }]
+    end
+
+    it "rejects a missing task_id with 422" do
+      cfg = build_config(video_models)
+      with_server(agent_config: cfg) do |server|
+        req = fake_req(method: "GET", path: "/api/media/video/status", query_string: "")
+        res = fake_res
+        dispatch(server, req, res)
+        expect(res.status).to eq(422)
+        expect(parsed_body(res)["error"]).to include("task_id")
+      end
+    end
+
+    it "delegates to the Generator and returns 200 for a running task" do
+      cfg = build_config(video_models)
+      expect_any_instance_of(Clacky::Media::Generator).to receive(:video_status) do |_, **kwargs|
+        expect(kwargs[:task_id]).to eq("cgt-abc")
+        { "success" => true, "status" => "running", "task_id" => "cgt-abc" }
+      end
+
+      with_server(agent_config: cfg) do |server|
+        req = fake_req(method: "GET", path: "/api/media/video/status", query_string: "task_id=cgt-abc")
+        res = fake_res
+        dispatch(server, req, res)
+        expect(res.status).to eq(200)
+        body = parsed_body(res)
+        expect(body["status"]).to eq("running")
+      end
+    end
+
+    it "returns 200 with the local video path when the task has succeeded" do
+      cfg = build_config(video_models)
+      expect_any_instance_of(Clacky::Media::Generator).to receive(:video_status)
+        .and_return("success" => true, "status" => "succeeded", "video" => "/tmp/work/assets/generated/vid.mp4")
+
+      with_server(agent_config: cfg) do |server|
+        req = fake_req(method: "GET", path: "/api/media/video/status", query_string: "task_id=cgt-abc")
+        res = fake_res
+        dispatch(server, req, res)
+        expect(res.status).to eq(200)
+        body = parsed_body(res)
+        expect(body["status"]).to eq("succeeded")
+        expect(body["video"]).to eq("/tmp/work/assets/generated/vid.mp4")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem
openclacky had no native support for Volcengine Ark (Seedance) video generation. The generic OpenAI-compatible path could not handle Seedance's async submit+poll contract, its richer multimodal inputs (first/last frame, reference image/video/audio), or its cost-sensitive `resolution` parameter. Without a dedicated provider, Seedance-only fields could also leak into Veo / Qwen backends where they have no effect.

## Fix
- New `Clacky::Media::Volcengine` provider: two-phase `generate_video` (submit) + `video_status` (single-shot poll), full error layering (network / invalid_response / api_error / empty_response / task_failed / download_failed), and content construction for all 6 Seedance capabilities (text→video, first frame, first+last frame, multimodal reference, edit via `reference_videos`, extend/continue via multiple `reference_videos`).
- `first_frame`/`last_frame` are mutually exclusive with `reference_*` — this is enforced in code (`build_content`), not just prompt guidance.
- `Generator` routes `*.volces.com` base URLs to the new provider; other providers return `unsupported`, missing config returns `not_configured`.
- New `GET /api/media/video/status` endpoint (30s timeout, distinct from the 600s `/api/media/video` submit route).
- `resolution` defaults to `720p`; Seedance-only fields never reach non-volces backends.
- SKILL cost gate hardened to require a fresh resolution confirmation before **every** generation — a prior answer is never carried over or reused.

## Test
- ✅ `bundle exec rspec` — 2719 examples, 0 failures
- ✅ New specs cover provider routing, async delegation, `unsupported` / `not_configured` paths, 422 (missing task_id) / 200 (running / succeeded), mutual-exclusion guard, and the tightened cost-gate wording.
- ✅ Real-machine verified end-to-end (submit → poll → mp4 download) across text/frame/reference/edit/extend flows.