### PR TITLE
fix(ui2): restore original terminal settings via stty on TUI exit (C-5724)

### DIFF
--- a/lib/clacky/ui2/layout_manager.rb
+++ b/lib/clacky/ui2/layout_manager.rb
@@ -402,6 +402,10 @@ module Clacky
           screen.show_cursor
           screen.flush
         end
+        # Restore cooked mode so the terminal is usable after exit, regardless
+        # of which exit path was taken (some call exit(0) and bypass the
+        # input_loop ensure). Idempotent; safe to call more than once.
+        screen.disable_raw_mode
       end
 
       # /clear: wipe output area + buffer, keep fixed area.

--- a/lib/clacky/ui2/screen_buffer.rb
+++ b/lib/clacky/ui2/screen_buffer.rb
@@ -118,14 +118,42 @@ module Clacky
         @height = TTY::Screen.height
       end
 
-      # Enable raw mode (disable line buffering)
+      # Enable raw mode (disable line buffering). The very first time it runs it
+      # snapshots the terminal's original settings (via `stty -g`) so the exact
+      # pre-clacky state can be restored on exit — `IO#cooked!` only applies a
+      # generic cooked profile and does not restore flow-control (IXON) and other
+      # bits, which on macOS leaves the shell in a broken input state.
       def enable_raw_mode
+        return unless $stdin.tty?
+
+        @original_stty ||= capture_stty
         $stdin.raw!
       end
 
-      # Disable raw mode
+      # Disable raw mode. Idempotent and tty-guarded so it can be safely called
+      # from any exit path. Restores the exact original terminal settings when a
+      # snapshot exists, then flushes pending input so stray bytes don't leak to
+      # the shell. Falls back to `IO#cooked!` when no snapshot is available.
       def disable_raw_mode
-        $stdin.cooked!
+        return unless $stdin.tty?
+
+        $stdin.cooked! unless @original_stty && restore_stty(@original_stty)
+        $stdin.ioflush
+      rescue IOError, Errno::ENOTTY
+        nil
+      end
+
+      private def capture_stty
+        out = Clacky::Utils::Encoding.cmd_to_utf8(`stty -g 2>/dev/null`).strip
+        out.empty? ? nil : out
+      rescue StandardError
+        nil
+      end
+
+      private def restore_stty(state)
+        system("stty", state, out: File::NULL, err: File::NULL)
+      rescue StandardError
+        false
       end
 
       # Read a single character without echo


### PR DESCRIPTION
## Problem

On macOS, after starting `openclacky tui` and exiting (Ctrl+C), the terminal was left in a broken state: typing Chinese failed, the IME candidate popup was mispositioned, and a subsequent CLI session rendered Chinese AI output as garbage. WSL did not reproduce it (its default termios differs less from the raw profile).

Root cause: the UI2 read loop enters raw mode with `$stdin.raw!` but restores with `$stdin.cooked!`. `cooked!` only applies io/console's generic cooked profile — it does **not** replay the terminal's *original* termios snapshot (flow-control `IXON`, and several `lflag`/`iflag` bits differ from the user's real shell). So the terminal never returns to its pre-TUI state.

This is not a regression: `raw!`/`cooked!` have been this way since UI2 was first introduced (`566a6ff feat: uiv2`) and were never changed afterwards. The bug stayed dormant while `rich` was the default UI and only surfaced once `ui2` became the default.

## Fix

- On first entry to raw mode, snapshot the terminal with `stty -g` and keep it.
- On exit, restore that exact snapshot with `stty <snapshot>` (falling back to `cooked!` only if the snapshot is unavailable), then `$stdin.ioflush`.
- `LayoutManager#cleanup_screen` now calls `disable_raw_mode`, so the two exit paths that call `exit(0)` from within `handle_key` (bypassing the read loop's `ensure`) still restore the terminal.
- Guarded with `$stdin.tty?` (idempotent, no-op on non-tty) and wrapped in `Clacky::Utils::Encoding.cmd_to_utf8` for the backtick output.

This is the same `stty -g` snapshot/restore mechanism the `rich` UI already relies on via the `ruby_rich` gem (`terminal.rb`), so UI2 now uses the proven approach instead of the lossy `cooked!`.

## Test

- ✅ `ruby -c` syntax check on both modified files
- ✅ Verified on a real tty: captured termios before raw, entered raw, restored from snapshot — `iflag`/`oflag`/`cflag`/`lflag` matched the original (including `IXON`); the only residual diff was the kernel-private `EXTPROC` bit, which `stty` cannot set and is unrelated to raw mode
- ✅ macOS real-device: after exiting the TUI, Chinese input, IME candidate positioning, and Chinese CLI output all work correctly