### PR TITLE
fix(extension): exclude OS metadata files from packed extension zips (C-5728)

### DIFF
--- a/lib/clacky/extension/packager.rb
+++ b/lib/clacky/extension/packager.rb
@@ -17,6 +17,9 @@ module Clacky
     MANIFEST     = "ext.yml"
     MAX_ZIP_SIZE = 50 * 1024 * 1024
 
+    # Platform metadata that leaks in from the developer's OS; never ship it.
+    SYSTEM_METADATA = [".DS_Store", "__MACOSX", "Thumbs.db", "desktop.ini"].freeze
+
     Result = Struct.new(:ext_id, :path, :units, keyword_init: true)
 
     class Error < StandardError; end
@@ -111,6 +114,8 @@ module Clacky
             next if base == "." || base == ".."
 
             rel = relative(container_dir, abs)
+            next if system_metadata?(rel)
+
             entry = File.join(File.basename(container_dir), rel)
             if File.directory?(abs)
               zip.mkdir(entry) unless zip.find_entry(entry)
@@ -119,6 +124,12 @@ module Clacky
             end
           end
         end
+      end
+
+      # True if any path segment is a platform metadata file/dir (e.g. a nested
+      # agents/.DS_Store or a whole __MACOSX/ tree).
+      private def system_metadata?(rel)
+        rel.split(File::SEPARATOR).any? { |seg| SYSTEM_METADATA.include?(seg) }
       end
 
       private def local_zip_for(source, tmp)

--- a/spec/clacky/extension_packager_spec.rb
+++ b/spec/clacky/extension_packager_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe Clacky::ExtensionPackager do
       expect { described_class.pack("broken", source_dir: local, out_dir: out) }
         .to raise_error(described_class::Error, /verify found errors/)
     end
+
+    it "excludes platform metadata files and dirs from the archive" do
+      dir = scaffold("demo")
+      FileUtils.touch(File.join(dir, ".DS_Store"))
+      FileUtils.touch(File.join(dir, "panels", ".DS_Store"))
+      FileUtils.touch(File.join(dir, "panels", "hello", "Thumbs.db"))
+      FileUtils.touch(File.join(dir, "desktop.ini"))
+      FileUtils.mkdir_p(File.join(dir, "__MACOSX", "panels"))
+      FileUtils.touch(File.join(dir, "__MACOSX", "panels", "junk"))
+
+      res = described_class.pack("demo", source_dir: local, out_dir: out)
+
+      names = []
+      Zip::File.open(res.path) { |z| z.each { |e| names << e.name } }
+      expect(names).to include("demo/ext.yml")
+      expect(names).to include("demo/panels/hello/view.js")
+      expect(names).not_to(include(a_string_matching(%r{(\.DS_Store|Thumbs\.db|desktop\.ini|__MACOSX)})))
+    end
   end
 
   describe ".install" do


### PR DESCRIPTION
## Problem
When packaging an extension ("打包 zip") or publishing it to the marketplace, macOS/Windows system metadata files were bundled into the zip. Both the root and nested subdirectories (agents/, panels/) carried `.DS_Store`, and `__MACOSX/`, `Thumbs.db`, `desktop.ini` could also leak in. This bloats the package, interferes with cross-platform installs, and exposes the developer's local directory structure.

## Fix
Filter platform metadata during packing. `ExtensionPackager.write_zip` now skips any path whose segment matches a blocklist (`.DS_Store`, `__MACOSX`, `Thumbs.db`, `desktop.ini`), covering nested files and whole `__MACOSX/` trees. The check lives at the packing boundary, so both "package" and "publish" (which share `pack`) are covered. Extraction/install is untouched.

## Test
Added a spec that seeds root/nested metadata plus a `__MACOSX/` dir before packing and asserts none appear in the archive while legitimate files remain.
`bundle exec rspec` → 2724 examples, 0 failures. ✅