### PR TITLE
fix(terminal): prevent Pass 1 echo-strip from swallowing real output (C-5701)

### DIFF
--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -607,9 +607,22 @@ module Clacky
           ""
         )
 
-        # Pass 1: anchored strip — the full wrapper echoed at the start,
-        # possibly spanning multiple real newlines.
-        text = text.sub(/\A\{.*?"\$__clacky_ec"\s*\n?/m, "")
+        # Pass 1: anchored strip — remove ONLY the wrapper's echoed head
+        # line (`{ USER_CMD`) at the very start of the buffer, and ONLY
+        # when a matching wrapper tail fingerprint (`}...; __clacky_ec=$?`)
+        # actually exists somewhere in the buffer. The guard is what keeps
+        # us from eating a real first line of user output that merely
+        # happens to start with `{` (e.g. JSON like `{"key": ...}`).
+        # We test the tail with a separate anchor-free `match?` (linear, no
+        # backtracking) rather than a lookahead, to avoid catastrophic
+        # regex backtracking on large `{`-prefixed output. We strip a
+        # single line (`[^\n]*`, not cross-line `.*?`): a multi-line command
+        # echoed in cooked mode puts the wrapper tail *after* the real
+        # output, so cross-line greed would swallow that output whole. The
+        # tail itself is removed by the fingerprint passes below.
+        if text.start_with?("{") && text.match?(/\}[^\n;]*; *__clacky_ec=\$\?/)
+          text = text.sub(/\A\{[^\n]*\n/, "")
+        end
 
         # Pass 2: token-aware global strip — remove any leftover wrapper
         # echo fragment, wherever it sits. Requires the session token so
@@ -629,9 +642,11 @@ module Clacky
           # 2b. Single-line shape: everything collapsed onto one line.
           # Strip from the wrapper's `}; __clacky_ec=$?` pivot (or the
           # opening `{` if still present on that line) through the end of
-          # the printf invocation (`"$__clacky_ec"`).
+          # the printf invocation (`"$__clacky_ec"`). The optional
+          # `[^\n;]*` between `}` and `;` absorbs a WSL `</dev/null`
+          # stdin redirect spliced onto the group.
           text = text.gsub(
-            /[^\n]*\}; *__clacky_ec=\$\?; *printf[^\n]*__CLACKY_DONE_#{token_re}_[^\n]*"\$__clacky_ec"[^\n]*\n?/,
+            /[^\n]*\}[^\n;]*; *__clacky_ec=\$\?; *printf[^\n]*__CLACKY_DONE_#{token_re}_[^\n]*"\$__clacky_ec"[^\n]*\n?/,
             ""
           )
 
@@ -653,9 +668,10 @@ module Clacky
         # private double-underscore var name that user code effectively
         # never emits — so we strip anything between them (non-greedy,
         # multiline-aware) to also handle width-wrap that inserted
-        # real \n breaks inside the echo.
+        # real \n breaks inside the echo. `[^\n;]*` between `}` and `;`
+        # absorbs a WSL `</dev/null` stdin redirect on the group.
         text = text.gsub(
-          /[^\n]*\}; *__clacky_ec=\$\?.*?"\$__clacky_ec"[^\n]*\n?/m,
+          /[^\n]*\}[^\n;]*; *__clacky_ec=\$\?.*?"\$__clacky_ec"[^\n]*\n?/m,
           ""
         )
 
@@ -663,7 +679,7 @@ module Clacky
         # truncation cut off everything after `__clacky_ec=$?`). Still a
         # reliable fingerprint thanks to the `__clacky_ec` var name.
         text = text.gsub(
-          /[^\n]*\}; *__clacky_ec=\$\?;?[^\n]*\n?/,
+          /[^\n]*\}[^\n;]*; *__clacky_ec=\$\?;?[^\n]*\n?/,
           ""
         )
 

--- a/spec/clacky/tools/terminal_spec.rb
+++ b/spec/clacky/tools/terminal_spec.rb
@@ -849,6 +849,41 @@ RSpec.describe Clacky::Tools::Terminal do
       expect(strip(input, token: token)).to eq("hi\n")
     end
 
+    it "keeps real output that sits between the echoed wrapper head and tail" do
+      # Multi-line command echoed in cooked mode: the shell echoes `{ CMD`,
+      # then the command runs and its output lands *before* the echoed
+      # wrapper tail. A cross-line strip would swallow that output whole.
+      input = "{ ls\n" \
+              "file_a.txt\n" \
+              "file_b.txt\n" \
+              "}; __clacky_ec=$?; printf \"\n__CLACKY_DONE_#{token}_%s__\n\" \"$__clacky_ec\"\n"
+      expect(strip(input, token: token)).to eq("file_a.txt\nfile_b.txt\n")
+    end
+
+    it "strips a WSL wrapper tail carrying a </dev/null stdin redirect" do
+      # On WSL, `.exe` commands get `</dev/null` spliced between the group's
+      # `}` and the `; __clacky_ec=$?` pivot. The fingerprint passes must
+      # still recognise the tail so it doesn't leak into user-visible output.
+      input = "{ ipconfig.exe\n" \
+              "Windows IP Configuration\n" \
+              "IPv4 Address: 192.168.1.5\n" \
+              "} </dev/null; __clacky_ec=$?; printf \"\n__CLACKY_DONE_#{token}_%s__\n\" \"$__clacky_ec\"\n"
+      expect(strip(input, token: token)).to eq("Windows IP Configuration\nIPv4 Address: 192.168.1.5\n")
+    end
+
+    it "never eats a real first line that merely starts with `{` (JSON output)" do
+      # stty -echo working: no wrapper echo, just real output whose first
+      # line is `{"key": ...}`. Pass 1 must NOT strip it — the lookahead
+      # guard only fires when a wrapper tail fingerprint is present.
+      input = "{\"key\": \"value\"}\n{\"a\": 1}\n"
+      expect(strip(input, token: token)).to eq(input)
+    end
+
+    it "leaves a `{`-prefixed multi-line JSON blob untouched when there is no wrapper" do
+      input = "{\n  \"a\": 1,\n  \"b\": 2\n}\n"
+      expect(strip(input, token: token)).to eq(input)
+    end
+
     it "strips a wrapper echo that appears mid-stream, not anchored to the start" do
       input = "previous output\n" \
               "{ echo hi\n}; __clacky_ec=$?; printf \"\n__CLACKY_DONE_#{token}_%s__\n\" \"$__clacky_ec\"\nhi\n"


### PR DESCRIPTION
## Problem
The terminal tool intermittently returned empty output despite the command producing real output. When `stty -echo` was defeated (zsh ZLE re-enabling echo on a reused shell) and a multi-line command was echoed in cooked mode, the buffer became `{ CMD` → real output → `}; __clacky_ec=$?; printf ... "$__clacky_ec"`. Pass 1 used a cross-line non-greedy strip (`/\A\{.*?"\$__clacky_ec"\s*\n?/m`) that swallowed the real output sitting in between. Auditing the fix across macOS/Linux/WSL surfaced two more latent hazards: on WSL the tail fingerprint `}; __clacky_ec=$?` didn't match the `.exe` variant `} </dev/null; __clacky_ec=$?` (so the tail leaked once output survived), and naively stripping any leading `{` line would eat real JSON output whose first line starts with `{`.

## Fix
- Pass 1 now strips ONLY the echoed wrapper head line, and ONLY when a wrapper tail fingerprint (`}...; __clacky_ec=$?`) is actually present — guarded by a cheap `start_with?("{") && match?(...)` check (linear, no backtracking) so a real `{`-prefixed JSON blob is never touched and large output can't trigger catastrophic regex backtracking (ReDoS).
- Widened the tail-fingerprint pivot from `}; ` to `}[^\n;]*; ` in Passes 2b/3/4 so a WSL `} </dev/null` stdin redirect on the group is absorbed.

## Test
Added specs: real output between the echoed head and tail survives; a WSL `} </dev/null` tail is stripped; `{`-prefixed JSON (single- and multi-line) is left untouched. Verified on WSL (Ruby 3.0.2 x86_64) against the real `strip_command_echo` — all cases pass, JSON first line preserved, large-buffer strip stays linear (~1.2s for 1.6MB). `bundle exec rspec` → 2727 examples, 0 failures. ✅