### PR TITLE
fix: backup success status no longer stays forever (C-5711)

### DIFF
--- a/lib/clacky/web/features/backup/view.js
+++ b/lib/clacky/web/features/backup/view.js
@@ -58,7 +58,8 @@ const BackupView = (() => {
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
-      if (statusEl) { statusEl.textContent = I18n.t("settings.backup.downloaded"); statusEl.className = "model-test-result success"; }
+      if (statusEl) { statusEl.textContent = ""; statusEl.className = "model-test-result"; }
+      Modal.toast(I18n.t("settings.backup.downloaded"), "success");
     } else if (statusEl) {
       statusEl.textContent = I18n.t("settings.backup.lastError", { msg: res.error });
       statusEl.className = "model-test-result error";
@@ -108,8 +109,8 @@ const BackupView = (() => {
       if (ev.type !== "_ws_connected" || !_restoreStatusEl) return;
       const el = _restoreStatusEl;
       _restoreStatusEl = null;
-      el.textContent = I18n.t("settings.backup.restartOk");
-      el.className = "model-test-result success";
+      if (el) { el.textContent = ""; el.className = "model-test-result"; }
+      Modal.toast(I18n.t("settings.backup.restartOk"), "success");
       if (typeof Settings !== "undefined") Settings.open();
     });
   }


### PR DESCRIPTION
## Problem
After downloading a backup or restoring + restarting, the success text ("备份已下载。" / "重启成功。") stayed permanently in the settings panel and never cleared, forcing a manual refresh.

## Fix
On success, clear the persistent status line and surface the message via the existing global `Modal.toast(..., "success")`, which auto-dismisses (~3.5s). In-progress (downloading/restoring) and error states keep the inline status line unchanged. Reuses the existing toast system — no new helper. (net +2 lines)

## Test
- ✅ `bundle exec rspec` — 2728 examples, 0 failures
- ✅ Manual (WSL + Edge): download → green toast "备份已下载。" auto-dismisses, no residual text; restore + restart → toast "重启成功。" auto-dismisses