### PR TITLE
fix: brand extension installs under its real id, not unpacked (C-5735)

### DIFF
--- a/lib/clacky/extension/packager.rb
+++ b/lib/clacky/extension/packager.rb
@@ -195,7 +195,9 @@ module Clacky
         dirs = children.select { |c| File.directory?(File.join(root, c)) }
 
         if File.file?(File.join(root, MANIFEST))
-          return [File.basename(File.expand_path(root)), root]
+          id = manifest_id(File.join(root, MANIFEST))
+          raise Error, "archive has no top-level container and #{MANIFEST} declares no id" if id.empty?
+          return [id, root]
         end
 
         if dirs.size == 1 && File.file?(File.join(root, dirs.first, MANIFEST))
@@ -203,6 +205,13 @@ module Clacky
         end
 
         raise Error, "archive does not contain a single container with #{MANIFEST}"
+      end
+
+      private def manifest_id(manifest_path)
+        data = YAMLCompat.load_file(manifest_path)
+        data.is_a?(Hash) ? data["id"].to_s.strip : ""
+      rescue StandardError
+        ""
       end
 
       private def verify_installed(ext_id, installed_dir)

--- a/spec/clacky/extension_packager_spec.rb
+++ b/spec/clacky/extension_packager_spec.rb
@@ -132,5 +132,38 @@ RSpec.describe Clacky::ExtensionPackager do
       expect { described_class.install(evil, installed_dir: installed) }
         .to raise_error(described_class::Error, /unsafe path/)
     end
+
+    def rootless_zip(name, manifest)
+      path = File.join(out, name)
+      Zip::File.open(path, create: true) do |z|
+        z.get_output_stream("ext.yml") { |f| f.write(manifest) }
+        z.get_output_stream("panels/hello/view.js") { |f| f.write("export default {}") }
+      end
+      path
+    end
+
+    it "names the install dir after the manifest id when the zip has no top-level container" do
+      zip = rootless_zip("brand.zip", "id: orchestrator\nname: Orchestrator\nversion: 1.0.0\n")
+      res = described_class.install(zip, installed_dir: installed)
+
+      expect(res.ext_id).to eq("orchestrator")
+      expect(File).to exist(File.join(installed, "orchestrator", "ext.yml"))
+      expect(Dir.exist?(File.join(installed, "unpacked"))).to be(false)
+    end
+
+    it "rejects a rootless archive whose manifest declares no id" do
+      zip = rootless_zip("noid.zip", "name: Orchestrator\nversion: 1.0.0\n")
+
+      expect { described_class.install(zip, installed_dir: installed) }
+        .to raise_error(described_class::Error, /declares no id/)
+    end
+
+    it "keeps using the top-level dir name when the archive has a container dir" do
+      zip = packed("demo")
+      res = described_class.install(zip, installed_dir: installed)
+
+      expect(res.ext_id).to eq("demo")
+      expect(File).to exist(File.join(installed, "demo", "ext.yml"))
+    end
   end
 end


### PR DESCRIPTION
## Problem
When a brand (built-in) extension is installed by OpenClacky, its folder under `~/.clacky/ext/installed/` was named the literal string `unpacked` instead of the extension's own id (e.g. `orchestrator`). Brand zips get repacked by the platform's encryption pipeline so `ext.yml` lands at the zip root with no top-level container dir; `locate_container` then fell back to `File.basename(extract_root)`, which is the hard-coded temp name `unpacked`. This produced two downstream bugs: the extension could be re-installed from the marketplace (local `unpacked` never matched `orchestrator`, so dedup failed), and the Web UI showed two identical entries — one working built-in and one empty duplicate.

## Fix
When an archive has `ext.yml` at its root (no top-level container dir), `locate_container` now reads the `id` field from `ext.yml` and uses it as the install dir name, aligning the folder name with the loader's "dir name is the ext id" contract. If a rootless archive declares no id, the install is rejected instead of creating a stale `unpacked/` dir. Archives that carry a proper top-level container dir are unchanged. No new require (reuses the already-loaded `YAMLCompat`).

Out of scope (tracked separately): platform-side validation that extension ids are globally unique.

## Test
- ✅ `bundle exec rspec` — 2731 examples, 0 failures
- ✅ New packager specs: rootless zip with `id: orchestrator` → installs to `installed/orchestrator/` (no `unpacked/`); rootless zip with no id → raises; container-dir archive → unchanged (regression guard)