### PR TITLE
fix: reopen Windows drive-letter file links (file:///C:/...) on WSL (C-5708)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3691,13 +3691,14 @@ module Clacky
 
         return json_response(res, 400, { error: "path is required" }) unless path && !path.empty?
 
-        # Expand ~ to the user's home directory (e.g. "~/Desktop/file.pdf").
-        # Ruby's File.exist? does NOT automatically expand ~ — that's a shell feature.
-        path = File.expand_path(path)
-
         # On WSL the file may be specified as a Windows path (e.g. "C:/Users/…").
-        # Convert it to the Linux-side path so File.exist? works.
+        # Convert it to the Linux-side path first — otherwise File.expand_path
+        # would treat the drive letter as a relative path and corrupt it.
         linux_path = Utils::EnvironmentDetector.win_to_linux_path(path)
+
+        # Expand ~ and relative paths. Safe now that any drive-letter path has
+        # already been rewritten to an absolute Linux path.
+        linux_path = File.expand_path(linux_path)
 
         return json_response(res, 404, { error: "file not found" }) unless File.exist?(linux_path)
 

--- a/spec/clacky/server/http_server_file_action_spec.rb
+++ b/spec/clacky/server/http_server_file_action_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "clacky/server/http_server"
+require "clacky/agent_config"
+require "clacky/utils/environment_detector"
+
+require_relative "http_server_spec"
+
+RSpec.describe Clacky::Server::HttpServer, "POST /api/file-action" do
+  include HttpServerSpecHelpers
+
+  let(:tmpdir) { Dir.mktmpdir("clacky_file_action_spec") }
+  let(:config_file) { File.join(tmpdir, "config.yml") }
+  let(:target_file) { File.join(tmpdir, "test_presentation.pptx") }
+
+  let(:agent_config) do
+    cfg = Clacky::AgentConfig.new(models: [
+      { "model" => "test-model", "api_key" => "k",
+        "base_url" => "https://example.invalid/v1", "type" => "default" }
+    ])
+    stub_const("Clacky::AgentConfig::CONFIG_FILE", config_file)
+    cfg
+  end
+
+  before { File.write(target_file, "deck") }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  def file_action(server, path:, action: "open")
+    req = fake_req(method: "POST", path: "/api/file-action", body: { path: path, action: action })
+    res = fake_res
+    dispatch(server, req, res)
+    res
+  end
+
+  it "opens a Windows drive-letter path on WSL (does not corrupt it via expand_path)" do
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:wsl)
+    # Remap the drive-letter path onto the real tmp file so File.exist? passes.
+    allow(Clacky::Utils::EnvironmentDetector)
+      .to receive(:win_to_linux_path)
+      .and_wrap_original { |orig, arg| arg.match?(%r{\A[A-Za-z]:[/\\]}) ? target_file : orig.call(arg) }
+    captured = nil
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:open_file) { |p| captured = p; true }
+
+    with_server(agent_config: agent_config) do |server|
+      res = file_action(server, path: "C:/Users/liuzh/Desktop/test_presentation.pptx")
+      expect(res.status).to eq(200)
+      expect(captured).to eq(target_file)
+    end
+  end
+
+  it "still opens a WSL mount path (/mnt/c/...) — regression guard" do
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:wsl)
+    captured = nil
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:open_file) { |p| captured = p; true }
+
+    with_server(agent_config: agent_config) do |server|
+      res = file_action(server, path: target_file)
+      expect(res.status).to eq(200)
+      expect(captured).to eq(target_file)
+    end
+  end
+
+  it "expands ~ for a home-relative path" do
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:linux)
+    captured = nil
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:open_file) { |p| captured = p; true }
+    allow(File).to receive(:expand_path).and_wrap_original do |orig, arg, *rest|
+      arg == "~/deck.pptx" ? target_file : orig.call(arg, *rest)
+    end
+
+    with_server(agent_config: agent_config) do |server|
+      res = file_action(server, path: "~/deck.pptx")
+      expect(res.status).to eq(200)
+      expect(captured).to eq(target_file)
+    end
+  end
+
+  it "returns 404 when the file does not exist" do
+    allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:linux)
+
+    with_server(agent_config: agent_config) do |server|
+      res = file_action(server, path: File.join(tmpdir, "missing.pptx"))
+      expect(res.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
On WSL, clicking a file link with a native Windows drive-letter path (`file:///C:/Users/.../test.pptx`) failed to open the file, while WSL mount paths (`/mnt/c/...`) worked. A regression: both used to work.

Root cause is the step order in `api_file_action`. `File.expand_path` ran *before* `win_to_linux_path`. On Linux/WSL, `File.expand_path("C:/Users/...")` treats the drive letter as a relative path and prepends the cwd (`/some/cwd/C:/Users/...`), destroying the drive prefix. The subsequent `win_to_linux_path` regex (`\A[A-Za-z]:`) then no longer matches, so no `/mnt/c/...` conversion happens and `File.exist?` fails. Mount paths are already absolute, so `expand_path` left them untouched — which is why only they worked.

## Fix
Swap the order: run `win_to_linux_path` first (rewriting any drive path to an absolute `/mnt/<drive>/...` path), then `File.expand_path` (which now only expands `~`/relative paths and can no longer corrupt a drive prefix). The pure `win_to_linux_path` util is unchanged. All cases hold: Windows drive path, WSL mount path, `~`, relative, and non-WSL hosts.

## Test
- ✅ `bundle exec rspec` — 2732 examples, 0 failures
- ✅ New `http_server_file_action_spec.rb`: WSL drive-letter path opens the real file; `/mnt/c/...` still opens (regression guard); `~` expands; missing file → 404. Verified the drive-path spec goes red if the old order is restored.