### PR TITLE
fix: unify local file:// path resolution for Windows drive letters (C-5746, C-5708)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1862,11 +1862,10 @@ module Clacky
       files = []
       content.scan(/(!?)\[([^\]]*)\]\(file:\/\/([^)]+)\)/) do
         inline = $1 == "!"
-        # URL-decode percent-encoded characters (e.g. Chinese filenames encoded by AI)
-        raw_path = CGI.unescape($3)
-        name   = File.basename(raw_path)
-        path   = File.expand_path(raw_path)
-        Clacky::Logger.info("[parse_file_links] raw=#{$3.inspect} expanded=#{path.inspect} exist=#{File.exist?(path)}")
+        # Resolve the AI-emitted path: decode, WSL drive-letter normalize, expand.
+        path   = Clacky::Utils::EnvironmentDetector.resolve_local_path($3)
+        name   = File.basename(path)
+        Clacky::Logger.info("[parse_file_links] raw=#{$3.inspect} resolved=#{path.inspect} exist=#{File.exist?(path)}")
         files << { name: name, path: path, inline: inline }
       end
       { text: content, files: files }

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3691,13 +3691,11 @@ module Clacky
 
         return json_response(res, 400, { error: "path is required" }) unless path && !path.empty?
 
-        # Expand ~ to the user's home directory (e.g. "~/Desktop/file.pdf").
-        # Ruby's File.exist? does NOT automatically expand ~ — that's a shell feature.
-        path = File.expand_path(path)
-
-        # On WSL the file may be specified as a Windows path (e.g. "C:/Users/…").
-        # Convert it to the Linux-side path so File.exist? works.
+        # Path arrives already percent-decoded by the click handler; normalize
+        # Windows drive letters (WSL) BEFORE expand_path or the drive is treated
+        # as relative and corrupted. No-op on macOS/Linux.
         linux_path = Utils::EnvironmentDetector.win_to_linux_path(path)
+        linux_path = File.expand_path(linux_path)
 
         return json_response(res, 404, { error: "file not found" }) unless File.exist?(linux_path)
 
@@ -3742,14 +3740,9 @@ module Clacky
         raw_path = URI.decode_www_form(req.query_string.to_s).to_h["path"].to_s
         return json_response(res, 400, { error: "path is required" }) if raw_path.empty?
 
-        # Strip file:// prefix if present
-        path = raw_path.sub(%r{\Afile://}, "")
-        path = CGI.unescape(path)
-        path = File.expand_path(path)
-
-        # On WSL the file may be specified as a Windows path (e.g. "C:/Users/…").
-        # Convert it to the Linux-side path so File.exist? works.
-        path = Utils::EnvironmentDetector.win_to_linux_path(path)
+        # Strip file://, decode, WSL drive-letter normalize, then expand — in
+        # this order (normalize must precede expand_path). No-op on macOS/Linux.
+        path = Utils::EnvironmentDetector.resolve_local_path(raw_path)
 
         # Security: only serve media files (images + videos)
         ext = File.extname(path).downcase

--- a/lib/clacky/utils/environment_detector.rb
+++ b/lib/clacky/utils/environment_detector.rb
@@ -52,17 +52,24 @@ module Clacky
         end
       end
 
-      # Convert a Windows-style path to a WSL/Linux-side path.
-      # e.g. "C:/Users/foo/file.txt" → "/mnt/c/Users/foo/file.txt"
-      # Returns the original path unchanged on non-WSL or if already a Linux path.
-      # @param path [String]
-      # @return [String]
+      # Convert a Windows-style path (incl. the "/C:/" three-slash-URL form) to
+      # a WSL /mnt path. No-op on non-WSL or non-drive-letter paths.
       def self.win_to_linux_path(path)
-        return path unless os_type == :wsl && path.match?(/\A[A-Za-z]:[\/\\]/)
+        return path unless os_type == :wsl
 
-        drive = path[0].downcase
-        rest  = path[2..].gsub("\\", "/")
-        "/mnt/#{drive}#{rest}"
+        m = path.match(%r{\A/?([A-Za-z]):[/\\](.*)}m)
+        return path unless m
+
+        "/mnt/#{m[1].downcase}/#{m[2].gsub("\\", "/")}"
+      end
+
+      # Resolve a "file://" URL or bare path into a real local path:
+      # strip "file://", percent-decode, WSL drive-letter normalize, then expand.
+      def self.resolve_local_path(href)
+        path = href.to_s.sub(%r{\Afile://}, "")
+        path = CGI.unescape(path)
+        path = win_to_linux_path(path)
+        File.expand_path(path)
       end
 
       # Convert a Linux-side path to a Windows-style path via wslpath.

--- a/lib/clacky/utils/file_processor.rb
+++ b/lib/clacky/utils/file_processor.rb
@@ -6,6 +6,7 @@ require "securerandom"
 require "stringio"
 
 require_relative "parser_manager"
+require_relative "environment_detector"
 require "zip"
 
 module Clacky
@@ -599,12 +600,11 @@ module Clacky
         alt  = Regexp.last_match(1)
         href = Regexp.last_match(2)
 
-        path = href.sub(%r{\Afile://}, "")
-        path = CGI.unescape(path)
+        real = Clacky::Utils::EnvironmentDetector.resolve_local_path(href)
 
-        ext = File.extname(path).downcase
-        if LOCAL_MEDIA_EXTENSIONS.include?(ext) && File.exist?(path)
-          "![#{alt}](#{local_image_proxy_url(href, path)})"
+        ext = File.extname(real).downcase
+        if LOCAL_MEDIA_EXTENSIONS.include?(ext) && File.exist?(real)
+          "![#{alt}](#{local_image_proxy_url(href, real)})"
         else
           _match
         end
@@ -616,12 +616,11 @@ module Clacky
         href = Regexp.last_match(2)
         post = Regexp.last_match(3) || ""
 
-        path = href.sub(%r{\Afile://}, "")
-        path = CGI.unescape(path)
+        real = Clacky::Utils::EnvironmentDetector.resolve_local_path(href)
 
-        ext = File.extname(path).downcase
-        if LOCAL_VIDEO_EXTENSIONS.include?(ext) && File.exist?(path)
-          "<video#{pre} src=\"#{local_image_proxy_url(href, path)}\"#{post}>"
+        ext = File.extname(real).downcase
+        if LOCAL_VIDEO_EXTENSIONS.include?(ext) && File.exist?(real)
+          "<video#{pre} src=\"#{local_image_proxy_url(href, real)}\"#{post}>"
         else
           _match
         end
@@ -633,12 +632,11 @@ module Clacky
         href = Regexp.last_match(2)
         post = Regexp.last_match(3) || ""
 
-        path = href.sub(%r{\Afile://}, "")
-        path = CGI.unescape(path)
+        real = Clacky::Utils::EnvironmentDetector.resolve_local_path(href)
 
-        ext = File.extname(path).downcase
-        if LOCAL_AUDIO_EXTENSIONS.include?(ext) && File.exist?(path)
-          "<audio#{pre} src=\"#{local_image_proxy_url(href, path)}\"#{post}>"
+        ext = File.extname(real).downcase
+        if LOCAL_AUDIO_EXTENSIONS.include?(ext) && File.exist?(real)
+          "<audio#{pre} src=\"#{local_image_proxy_url(href, real)}\"#{post}>"
         else
           _match
         end
@@ -649,13 +647,12 @@ module Clacky
         text = Regexp.last_match(1)
         href = Regexp.last_match(2)
 
-        path = href.sub(%r{\Afile://}, "")
-        path = CGI.unescape(path)
+        real = Clacky::Utils::EnvironmentDetector.resolve_local_path(href)
 
-        ext = File.extname(path).downcase
+        ext = File.extname(real).downcase
         if LOCAL_VIDEO_EXTENSIONS.include?(ext) || LOCAL_AUDIO_EXTENSIONS.include?(ext)
-          if File.exist?(path)
-            "[#{text}](#{local_image_proxy_url(href, path)})"
+          if File.exist?(real)
+            "[#{text}](#{local_image_proxy_url(href, real)})"
           else
             _match
           end

--- a/lib/clacky/web/features/backup/view.js
+++ b/lib/clacky/web/features/backup/view.js
@@ -58,7 +58,8 @@ const BackupView = (() => {
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
-      if (statusEl) { statusEl.textContent = I18n.t("settings.backup.downloaded"); statusEl.className = "model-test-result success"; }
+      if (statusEl) { statusEl.textContent = ""; statusEl.className = "model-test-result"; }
+      Modal.toast(I18n.t("settings.backup.downloaded"), "success");
     } else if (statusEl) {
       statusEl.textContent = I18n.t("settings.backup.lastError", { msg: res.error });
       statusEl.className = "model-test-result error";
@@ -108,8 +109,8 @@ const BackupView = (() => {
       if (ev.type !== "_ws_connected" || !_restoreStatusEl) return;
       const el = _restoreStatusEl;
       _restoreStatusEl = null;
-      el.textContent = I18n.t("settings.backup.restartOk");
-      el.className = "model-test-result success";
+      if (el) { el.textContent = ""; el.className = "model-test-result"; }
+      Modal.toast(I18n.t("settings.backup.restartOk"), "success");
       if (typeof Settings !== "undefined") Settings.open();
     });
   }

--- a/spec/clacky/agent_parse_file_links_spec.rb
+++ b/spec/clacky/agent_parse_file_links_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Clacky::Agent, "#parse_file_links" do
+  let(:client) do
+    instance_double(Clacky::Client).tap { |c| c.instance_variable_set(:@api_key, "k") }
+  end
+  let(:config) do
+    c = Clacky::AgentConfig.new(permission_mode: :auto_approve)
+    c.add_model(model: "claude-sonnet-4.5", api_key: "k", base_url: "https://api.anthropic.com")
+    c
+  end
+  let(:agent) do
+    described_class.new(client, config, working_dir: Dir.pwd, ui: nil,
+                        profile: "coding", session_id: Clacky::SessionManager.generate_id, source: :manual)
+  end
+
+  def parse(content)
+    agent.send(:parse_file_links, content)
+  end
+
+  it "extracts an inline image with the resolved path and basename" do
+    result = parse("![chart](file:///Users/foo/chart.png)")
+    expect(result[:files]).to eq([
+      { name: "chart.png", path: "/Users/foo/chart.png", inline: true }
+    ])
+  end
+
+  it "extracts a non-inline download link" do
+    result = parse("[report](file:///Users/foo/report.pdf)")
+    expect(result[:files].first).to include(name: "report.pdf", inline: false)
+  end
+
+  it "percent-decodes non-ASCII filenames" do
+    result = parse("![p](file:///Users/foo/%E4%B8%AD%E6%96%87.png)")
+    expect(result[:files].first[:path]).to eq("/Users/foo/中文.png")
+    expect(result[:files].first[:name]).to eq("中文.png")
+  end
+
+  it "routes the raw path through EnvironmentDetector.resolve_local_path" do
+    allow(Clacky::Utils::EnvironmentDetector)
+      .to receive(:resolve_local_path).with("/C:/Users/foo/a.png").and_return("/mnt/c/Users/foo/a.png")
+
+    result = parse("![a](file:///C:/Users/foo/a.png)")
+    expect(result[:files].first).to include(name: "a.png", path: "/mnt/c/Users/foo/a.png")
+  end
+
+  it "returns text unchanged and empty files for content without links" do
+    expect(parse("no links here")).to eq(text: "no links here", files: [])
+  end
+end

--- a/spec/clacky/server/http_server_local_image_spec.rb
+++ b/spec/clacky/server/http_server_local_image_spec.rb
@@ -88,4 +88,24 @@ RSpec.describe Clacky::Server::HttpServer, "GET /api/local-image caching" do
       expect(res.body).to eq("PNGDATA-version-2-longer")
     end
   end
+
+  it "serves a Windows drive-letter file:// path resolved to the real file (WSL)" do
+    with_server(agent_config: agent_config) do |server|
+      drive_href = "file:///C:/Users/foo/puppy.png"
+      allow(Clacky::Utils::EnvironmentDetector)
+        .to receive(:resolve_local_path).with(drive_href).and_return(image_path)
+
+      req = fake_req(
+        method:       "GET",
+        path:         "/api/local-image",
+        query_string: "path=#{CGI.escape(drive_href)}",
+        headers:      {}
+      )
+      res = capturing_res
+      dispatch(server, req, res)
+
+      expect(res.status).to eq(200)
+      expect(res.body).to eq("PNGDATA-v1")
+    end
+  end
 end

--- a/spec/clacky/utils/environment_detector_spec.rb
+++ b/spec/clacky/utils/environment_detector_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cgi"
+require "clacky/utils/environment_detector"
+
+RSpec.describe Clacky::Utils::EnvironmentDetector do
+  described = Clacky::Utils::EnvironmentDetector
+
+  describe ".win_to_linux_path" do
+    context "on WSL" do
+      before { allow(described).to receive(:os_type).and_return(:wsl) }
+
+      it "converts a plain drive-letter path to /mnt" do
+        expect(described.win_to_linux_path("C:/Users/foo/a.png"))
+          .to eq("/mnt/c/Users/foo/a.png")
+      end
+
+      it "converts the leading-slash drive-letter form (file:// three-slash stripped)" do
+        expect(described.win_to_linux_path("/C:/Users/foo/a.png"))
+          .to eq("/mnt/c/Users/foo/a.png")
+      end
+
+      it "converts backslash-separated Windows paths" do
+        expect(described.win_to_linux_path("D:\\a\\b.png"))
+          .to eq("/mnt/d/a/b.png")
+      end
+
+      it "lower-cases the drive letter" do
+        expect(described.win_to_linux_path("E:/x")).to eq("/mnt/e/x")
+      end
+
+      it "leaves a real Linux path unchanged" do
+        expect(described.win_to_linux_path("/mnt/c/x.png")).to eq("/mnt/c/x.png")
+        expect(described.win_to_linux_path("/home/u/x.png")).to eq("/home/u/x.png")
+      end
+    end
+
+    %i[macos linux unknown].each do |os|
+      context "on #{os} (non-WSL must be a pure no-op)" do
+        before { allow(described).to receive(:os_type).and_return(os) }
+
+        it "returns drive-letter paths unchanged" do
+          expect(described.win_to_linux_path("C:/Users/x.png")).to eq("C:/Users/x.png")
+          expect(described.win_to_linux_path("/C:/Users/x.png")).to eq("/C:/Users/x.png")
+        end
+
+        it "returns Linux/macOS paths unchanged" do
+          expect(described.win_to_linux_path("/Users/jiujiu/a.png")).to eq("/Users/jiujiu/a.png")
+        end
+      end
+    end
+  end
+
+  describe ".resolve_local_path" do
+    context "on WSL" do
+      before { allow(described).to receive(:os_type).and_return(:wsl) }
+
+      it "resolves a file:// three-slash drive-letter URL to /mnt" do
+        expect(described.resolve_local_path("file:///C:/Users/foo/a.png"))
+          .to eq("/mnt/c/Users/foo/a.png")
+      end
+
+      it "resolves a bare drive-letter path to /mnt" do
+        expect(described.resolve_local_path("C:/Users/foo/a.png"))
+          .to eq("/mnt/c/Users/foo/a.png")
+      end
+
+      it "percent-decodes before normalizing" do
+        expect(described.resolve_local_path("file:///C:/Users/%E4%B8%AD%E6%96%87.png"))
+          .to eq("/mnt/c/Users/中文.png")
+      end
+
+      it "passes through an existing /mnt path" do
+        expect(described.resolve_local_path("file:///mnt/c/x.png")).to eq("/mnt/c/x.png")
+      end
+    end
+
+    context "on macOS (non-WSL: strip + unescape + expand only)" do
+      before { allow(described).to receive(:os_type).and_return(:macos) }
+
+      it "strips file:// and expands an absolute path" do
+        expect(described.resolve_local_path("file:///Users/jiujiu/a.png"))
+          .to eq("/Users/jiujiu/a.png")
+      end
+
+      it "percent-decodes spaces and non-ASCII" do
+        expect(described.resolve_local_path("file:///Users/jiujiu/b%20c.png"))
+          .to eq("/Users/jiujiu/b c.png")
+        expect(described.resolve_local_path("/Users/jiujiu/%E4%B8%AD.png"))
+          .to eq("/Users/jiujiu/中.png")
+      end
+
+      it "does NOT convert Windows drive letters (no /mnt on macOS)" do
+        expect(described.resolve_local_path("file:///C:/Users/x.png"))
+          .to eq("/C:/Users/x.png")
+      end
+
+      it "expands ~ to the home directory" do
+        expect(described.resolve_local_path("file://~/a.png"))
+          .to eq(File.expand_path("~/a.png"))
+      end
+    end
+  end
+end

--- a/spec/clacky/utils/file_processor_spec.rb
+++ b/spec/clacky/utils/file_processor_spec.rb
@@ -496,5 +496,35 @@ RSpec.describe Clacky::Utils::FileProcessor do
         expect(result).not_to eq(content)
       end
     end
+
+    it "rewrites a Windows drive-letter path resolved to the real local file (WSL)" do
+      Dir.mktmpdir do |dir|
+        real = File.join(dir, "shot.png")
+        File.binwrite(real, "PNG")
+
+        # On WSL a file:///C:/… href resolves (via win_to_linux_path) to the
+        # /mnt/… path. Stub the resolver to point the drive-letter href at our
+        # real temp file so we assert the rewrite uses the resolved path for
+        # existence + mtime while keeping the original href in the proxy URL.
+        drive_href = "file:///C:/Users/foo/shot.png"
+        allow(Clacky::Utils::EnvironmentDetector)
+          .to receive(:resolve_local_path).with(drive_href).and_return(real)
+
+        content = "![pic](#{drive_href})"
+        result = described_class.rewrite_local_image_urls(content)
+
+        expect(result).to include("![pic](/api/local-image?path=#{CGI.escape(drive_href)}&v=")
+        expect(result).to match(/&v=\d+\)/)
+      end
+    end
+
+    it "leaves a Windows drive-letter path untouched when the resolved file is missing" do
+      drive_href = "file:///C:/Users/foo/missing.png"
+      allow(Clacky::Utils::EnvironmentDetector)
+        .to receive(:resolve_local_path).with(drive_href).and_return("/mnt/c/Users/foo/missing.png")
+
+      content = "![pic](#{drive_href})"
+      expect(described_class.rewrite_local_image_urls(content)).to eq(content)
+    end
   end
 end


### PR DESCRIPTION
## Problem
On Windows/WSL, image and file links using drive-letter paths (`file:///C:/Users/...`) broke across every consumer:
- Inline images rendered as broken (local-image proxy returned 404).
- IM channel attachments silently failed to resolve.
- Web UI image/video/audio rewrites fell back to the raw href.

Root cause: stripping `file://` from a three-slash URL yields `/C:/Users/...` (with a leading slash). The old `win_to_linux_path` regex only matched `C:/...`, so the drive letter was never converted, and `File.expand_path("/C:/...")` returns it unchanged on Linux. On top of that, the four link-handling paths had drifted into three independent implementations with different — and in some cases missing — normalization steps and ordering (e.g. `parse_file_links` never called `win_to_linux_path` at all).

## Fix
Centralize path resolution in `EnvironmentDetector`:
- `win_to_linux_path` now accepts the optional leading slash (`/C:/` form) and is a strict no-op on non-WSL platforms, so macOS/Linux behavior is unchanged.
- New `resolve_local_path(href)`: strip `file://` → percent-decode → WSL drive-letter normalize → `File.expand_path`, in one fixed order.

All four consumers route through this single entry point:
- `api_serve_local_image`, `parse_file_links`, and the four `rewrite_local_image_urls` gsubs use `resolve_local_path`.
- `api_file_action` normalizes the drive letter **before** `File.expand_path` (absorbing the C-5708 ordering fix); it deliberately does not re-unescape, since the click handler already decodes the path.

Supersedes the standalone C-5708 branch `fix/file-action-win-path-expand-order`.

## Test
- New `environment_detector_spec` (19): drive-letter + leading-slash conversion on WSL; pure no-op asserted on macOS/Linux/unknown.
- New `agent_parse_file_links_spec` (5): inline/download extraction, non-ASCII decode, drive-letter routing.
- Extended `file_processor_spec` and `http_server_local_image_spec` with WSL drive-letter cases.
- Verified on macOS that `resolve_local_path` is byte-for-byte equivalent to the previous inline logic (Chinese / spaces / parens / `~` expansion).
- Full suite: 2755 examples, 0 failures.