### PR TITLE
fix(session): preserve attachment badges across compression (C-5658)

### DIFF
--- a/lib/clacky/agent/message_compressor_helper.rb
+++ b/lib/clacky/agent/message_compressor_helper.rb
@@ -620,6 +620,12 @@ module Clacky
             lines << ""
             lines << format_message_content(content)
             lines << ""
+            # Serialize attachment metadata (badges) as an HTML comment so it
+            # survives compression yet stays invisible to MD readers and the LLM.
+            if msg[:display_files]&.any?
+              lines << "<!-- clacky:display_files #{msg[:display_files].to_json} -->"
+              lines << ""
+            end
           when "assistant"
             # If this message is itself a compressed summary, annotate the header
             # so the reader knows the original conversation is in the referenced chunk

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -471,15 +471,24 @@ module Clacky
 
           if sec[:role] == "user"
             round_index += 1
+            # Extract serialized attachment metadata (badges) from the HTML comment
+            # emitted by render_message_sections, and strip it from the visible text.
+            display_files = nil
+            if (m = text.match(/^<!-- clacky:display_files (.+?) -->$/))
+              display_files = JSON.parse(m[1]) rescue nil
+              text = text.sub(/\n*^<!-- clacky:display_files .+? -->$/, "").strip
+            end
             # Synthetic timestamp: spread rounds backwards from archived_at
             synthetic_ts = base_time - (sections.size - round_index) * 1.0
+            user_msg = {
+              role: "user",
+              content: text,
+              created_at: synthetic_ts,
+              _from_chunk: true
+            }
+            user_msg[:display_files] = display_files if display_files
             current_round = {
-              user_msg: {
-                role: "user",
-                content: text,
-                created_at: synthetic_ts,
-                _from_chunk: true
-              },
+              user_msg: user_msg,
               events: []
             }
             rounds << current_round

--- a/spec/clacky/agent/chunk_display_files_spec.rb
+++ b/spec/clacky/agent/chunk_display_files_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "time"
+require "json"
+
+RSpec.describe "Chunk MD attachment badge (display_files) round-trip" do
+  let(:sessions_dir) { Dir.mktmpdir }
+  let(:session_id) { "abc12345-0000-0000-0000-000000000000" }
+
+  before { stub_const("Clacky::SessionManager::SESSIONS_DIR", sessions_dir) }
+  after { FileUtils.rm_rf(sessions_dir) }
+
+  # Agent stub that can both build and parse chunk MD.
+  let(:agent) do
+    klass = Class.new do
+      include Clacky::Agent::MessageCompressorHelper
+      include Clacky::Agent::SessionSerializer
+
+      attr_accessor :session_id
+
+      def initialize
+        @skill_loader = Object.new.tap { |sl| sl.define_singleton_method(:load_all) {} }
+      end
+    end
+    obj = klass.new
+    obj.session_id = session_id
+    obj
+  end
+
+  def write_and_parse(messages)
+    md = agent.send(:build_chunk_md, messages, chunk_index: 1, compression_level: 1)
+    path = File.join(sessions_dir, "2026-01-01-00-00-00-abc12345-chunk-1.md")
+    File.write(path, md)
+    agent.send(:parse_chunk_md_to_rounds, path)
+  end
+
+  it "preserves display_files across build → parse" do
+    files = [{ name: "report.xlsx", type: "file", path: "/tmp/report.xlsx", preview_path: "/tmp/report.preview" }]
+    rounds = write_and_parse([{ role: "user", content: "check this", display_files: files }])
+
+    df = rounds.first[:user_msg][:display_files]
+    expect(df).to be_an(Array)
+    expect(df.first["name"]).to eq("report.xlsx")
+    expect(df.first["type"]).to eq("file")
+    expect(df.first["path"]).to eq("/tmp/report.xlsx")
+    expect(df.first["preview_path"]).to eq("/tmp/report.preview")
+  end
+
+  it "strips the display_files comment from the visible user text" do
+    files = [{ name: "a.xlsx", type: "file", path: "/tmp/a.xlsx" }]
+    rounds = write_and_parse([{ role: "user", content: "look here", display_files: files }])
+
+    expect(rounds.first[:user_msg][:content]).to eq("look here")
+    expect(rounds.first[:user_msg][:content]).not_to include("clacky:display_files")
+  end
+
+  it "handles user messages without attachments (backward compatible)" do
+    rounds = write_and_parse([{ role: "user", content: "no files here" }])
+
+    expect(rounds.first[:user_msg]).not_to have_key(:display_files)
+    expect(rounds.first[:user_msg][:content]).to eq("no files here")
+  end
+
+  it "does not write a comment line when display_files is empty" do
+    md = agent.send(:build_chunk_md, [{ role: "user", content: "hi", display_files: [] }],
+                    chunk_index: 1, compression_level: 1)
+    expect(md).not_to include("clacky:display_files")
+  end
+
+  it "preserves non-ASCII (CJK) file names via JSON escaping" do
+    files = [{ name: "季度报表.xlsx", type: "file", path: "/tmp/季度报表.xlsx" }]
+    rounds = write_and_parse([{ role: "user", content: "报表", display_files: files }])
+
+    expect(rounds.first[:user_msg][:display_files].first["name"]).to eq("季度报表.xlsx")
+  end
+
+  it "tolerates a corrupt display_files comment without breaking replay" do
+    md = <<~MD
+      ---
+      session_id: #{session_id}
+      chunk: 1
+      archived_at: 2026-01-01T00:00:00+08:00
+      ---
+      # Session Chunk 1
+
+      ## User
+
+      broken attachment
+      <!-- clacky:display_files {not valid json -->
+
+      ## Assistant
+
+      ok
+    MD
+    path = File.join(sessions_dir, "2026-01-01-00-00-00-abc12345-chunk-1.md")
+    File.write(path, md)
+
+    rounds = agent.send(:parse_chunk_md_to_rounds, path)
+    expect(rounds.first[:user_msg]).not_to have_key(:display_files)
+    expect(rounds.first[:user_msg][:content]).to include("broken attachment")
+  end
+end


### PR DESCRIPTION
## Problem

When a session is compressed, user messages carrying attachments (XLSX, PDF, images) are archived into a chunk MD file as plain text. The `## User` section only wrote the message text and discarded `display_files`, and on replay `parse_chunk_md_to_rounds` rebuilt the round from that plain text with no place for `display_files` — so attachment badges silently disappeared after compression + reload, for every file type.

## Fix

Data-driven, two spots, no front-end or downstream changes:

- **Write side** (`message_compressor_helper.rb`, `render_message_sections`): when a user message has `display_files`, append its metadata as an HTML comment (`<!-- clacky:display_files [...] -->`). HTML comments survive compression yet stay invisible to MD readers and the LLM, mirroring the existing `_Tool calls:_` metadata-line technique.

- **Read side** (`session_serializer.rb`, `parse_chunk_md_to_rounds`): extract and `JSON.parse` that comment back into `user_msg[:display_files]`, and strip the comment line from the visible text.

Downstream `replay_history` already tolerates string keys, so badges recover automatically. When temp files are gone the existing sentinel path still shows the "was sent xxx.xlsx" badge.

## Test

New `spec/clacky/agent/chunk_display_files_spec.rb` (6 examples): build→parse round-trip plus edge cases (no attachments / empty array / corrupt JSON / CJK file names). Full suite: 2764 examples, 0 failures.