### PR TITLE
feat(providers): add kimi-k3 and k2.7-code models to kimi preset

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -260,8 +260,8 @@ module Clacky
         "name" => "Kimi (Moonshot)",
         "base_url" => "https://api.moonshot.cn/v1",
         "api" => "openai-completions",
-        "default_model" => "kimi-k2.6",
-        "models" => ["kimi-k2.6", "kimi-k2.5"],
+        "default_model" => "kimi-k3",
+        "models" => ["kimi-k3", "kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6", "kimi-k2.5"],
         # Moonshot operates two regional endpoints with identical APIs & model
         # lineup — mainland China (.cn) and international (.ai). These are the
         # pay-as-you-go Open Platform endpoints; the subscription-billed
@@ -277,9 +277,9 @@ module Clacky
           { "label" => "Mainland China", "label_key" => "settings.models.baseurl.variant.mainland_cn",   "base_url" => "https://api.moonshot.cn/v1", "region" => "cn"   }.freeze,
           { "label" => "International",  "label_key" => "settings.models.baseurl.variant.international", "base_url" => "https://api.moonshot.ai/v1", "region" => "intl" }.freeze
         ].freeze,
-        # k2.5 / k2.6 are multimodal; legacy k2 text-only models need model_capabilities override if added.
+        # k3 / k2.7-code / k2.5 / k2.6 are multimodal; legacy k2 text-only models need model_capabilities override if added.
         "capabilities" => { "vision" => true }.freeze,
-        "default_ocr_model" => "kimi-k2.5",
+        "default_ocr_model" => "kimi-k3",
         "website_url" => "https://platform.moonshot.cn/console/api-keys"
       }.freeze,
 

--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -237,6 +237,55 @@ module Clacky
         }
       },
 
+      # Kimi K3 flagship model (1M context, native vision, tool calling).
+      # Source: https://platform.moonshot.ai (USD / 1M tokens)
+      "kimi-k3" => {
+        input: {
+          default: 3.00,                   # $3.00/MTok cache miss
+          over_200k: 3.00
+        },
+        output: {
+          default: 15.00,                  # $15.00/MTok
+          over_200k: 15.00
+        },
+        cache: {
+          write: 3.00,                     # no separate write charge; bill at miss rate
+          read: 0.30                       # $0.30/MTok cache hit
+        }
+      },
+
+      # Kimi K2.7 Code (256K context, multimodal coding model).
+      # Source: https://platform.moonshot.ai (USD / 1M tokens)
+      "kimi-k2.7-code" => {
+        input: {
+          default: 0.95,                   # $0.95/MTok cache miss
+          over_200k: 0.95
+        },
+        output: {
+          default: 4.00,                   # $4.00/MTok
+          over_200k: 4.00
+        },
+        cache: {
+          write: 0.95,                     # no separate write charge; bill at miss rate
+          read: 0.19                       # $0.19/MTok cache hit
+        }
+      },
+
+      "kimi-k2.7-code-highspeed" => {
+        input: {
+          default: 1.90,                   # $1.90/MTok cache miss
+          over_200k: 1.90
+        },
+        output: {
+          default: 8.00,                   # $8.00/MTok
+          over_200k: 8.00
+        },
+        cache: {
+          write: 1.90,                     # no separate write charge; bill at miss rate
+          read: 0.38                       # $0.38/MTok cache hit
+        }
+      },
+
       # Google Gemini 3 series (via Vertex AI). Tiered at 200K input tokens
       # for Pro; Flash has flat pricing.
       "gemini-3.1-pro" => {

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -222,6 +222,20 @@ RSpec.describe Clacky::ModelPricing do
         expect(result[:source]).to eq(:price)
       end
 
+      it "calculates kimi-k3 basic cost" do
+        usage = {
+          prompt_tokens: 100_000,          # 100K tokens
+          completion_tokens: 50_000         # 50K tokens
+        }
+
+        # Input:  (100_000 / 1_000_000) * $3.00 = $0.300
+        # Output: (50_000  / 1_000_000) * $15.00 = $0.750
+        # Total:  $1.050
+        result = described_class.calculate_cost(model: "kimi-k3", usage: usage)
+        expect(result[:cost]).to be_within(0.0001).of(1.050)
+        expect(result[:source]).to eq(:price)
+      end
+
       it "matches kimi-k2.5 case-insensitively" do
         usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
         result = described_class.calculate_cost(model: "Kimi-K2.5", usage: usage)

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Clacky::Providers do
         expect(described_class.supports?("minimax", :vision)).to be false
       end
 
-      it "returns true for kimi (k2.5/k2.6 are multimodal)" do
+      it "returns true for kimi (k3/k2.7-code/k2.5/k2.6 are multimodal)" do
         expect(described_class.supports?("kimi", :vision)).to be true
       end
 
@@ -303,7 +303,7 @@ RSpec.describe Clacky::Providers do
       # The subscription-billed Coding Plan endpoint is its own preset, not
       # an endpoint_variant of "kimi" — different domain (api.kimi.com vs
       # api.moonshot.{cn,ai}), different model alias (kimi-for-coding vs
-      # kimi-k2.5/k2.6), different transport (anthropic-messages vs
+      # kimi-k3/k2.7-code/k2.5/k2.6), different transport (anthropic-messages vs
       # openai-completions). These tests guard that the routing actually
       # discriminates instead of folding into the PAYG preset.
       it "recognises the canonical /coding base URL" do


### PR DESCRIPTION
## Problem
Kimi launched the K3 flagship model and K2.7 Code series. The kimi provider preset still lists only kimi-k2.6 / kimi-k2.5, and no pricing entries exist for the new models.

## Fix
- providers.rb: add kimi-k3, kimi-k2.7-code, kimi-k2.7-code-highspeed to the kimi preset `models`; switch `default_model` and `default_ocr_model` to kimi-k3 (official recommended default; K3 vision ≥ k2.5).
- model_pricing.rb: add USD pricing entries (source: platform.moonshot.ai). cache write bills at the miss rate (Kimi convention — no separate write fee).

  | model | input(miss) | cache read | output |
  |---|---|---|---|
  | kimi-k3 | $3.00 | $0.30 | $15.00 |
  | kimi-k2.7-code | $0.95 | $0.19 | $4.00 |
  | kimi-k2.7-code-highspeed | $1.90 | $0.38 | $8.00 |

- Frontend needs no change — settings/welcome pages consume `models` from `GET /api/providers`, which reads `PRESETS` directly.
- k2.5 / k2.6 retained: only Moonshot V1 is marked for 8/31 sunset; keeps existing user configs working.

## Test
✅ `bundle exec rspec spec/clacky/providers_spec.rb spec/clacky/model_pricing_spec.rb` → 116 examples, 0 failures