### PR TITLE
fix(web): guard message-edit Enter against IME composing (C-5742)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1811,8 +1811,9 @@ const Sessions = (() => {
     sendBtn.textContent = I18n.t("chat.send");
     sendBtn.addEventListener("click", () => _submitEdit(el, textarea.value.trim()));
 
+    const editIme = IME.track(textarea);
     textarea.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (e.key === "Enter" && !e.shiftKey && !editIme.isComposing(e)) {
         e.preventDefault();
         _submitEdit(el, textarea.value.trim());
       }


### PR DESCRIPTION
## Problem
When editing a sent message, pressing Enter during Chinese IME candidate selection (composing) sent the edit immediately instead of just committing the candidate word. All other inputs (composer, search, rename, path, dialogs) were already IME-guarded; the edit textarea was the only keydown handler still using a bare `Enter && !shiftKey` check.

## Fix
Wrap the edit textarea with `IME.track` and add `!editIme.isComposing(e)` to the Enter branch, reusing the existing helper (`utils.js`) already used across the codebase — no new abstraction.

```js
const editIme = IME.track(textarea);
textarea.addEventListener("keydown", (e) => {
  if (e.key === "Enter" && !e.shiftKey && !editIme.isComposing(e)) {
    e.preventDefault();
    _submitEdit(el, textarea.value.trim());
  }
  if (e.key === "Escape") _exitEditMode(el);
});
```

## Test
Manually verified in browser (macOS/Chrome):
- Enter during IME composing → only commits candidate word, does NOT submit ✅
- Plain Enter → submits edit ✅
- Shift+Enter → newline ✅
- Escape → exits edit mode ✅

No RSpec added (pure frontend interaction, no server logic changed).