### PR TITLE
fix(web): render markdown images with file://~/ tilde paths (C-5747)

### DIFF
--- a/lib/clacky/utils/file_processor.rb
+++ b/lib/clacky/utils/file_processor.rb
@@ -596,7 +596,7 @@ module Clacky
       return content if content.nil? || content.empty?
 
       # Rewrite markdown image syntax ![alt](file:///path) → proxy URL
-      content = content.gsub(/!\[([^\]]*)\]\(((?:file:\/\/)?\/[^)]+)\)/) do |_match|
+      content = content.gsub(/!\[([^\]]*)\]\(((?:file:\/\/)?(?:~\/|\/)[^)]+)\)/) do |_match|
         alt  = Regexp.last_match(1)
         href = Regexp.last_match(2)
 
@@ -611,7 +611,7 @@ module Clacky
       end
 
       # Rewrite <video src="file:///path/vid.mp4" ...> → proxy URL
-      content = content.gsub(/<video\b([^>]*)\bsrc="((?:file:\/\/)?\/[^"]+)"([^>]*)>/) do |_match|
+      content = content.gsub(/<video\b([^>]*)\bsrc="((?:file:\/\/)?(?:~\/|\/)[^"]+)"([^>]*)>/) do |_match|
         pre  = Regexp.last_match(1) || ""
         href = Regexp.last_match(2)
         post = Regexp.last_match(3) || ""
@@ -627,7 +627,7 @@ module Clacky
       end
 
       # Rewrite <audio src="file:///path/audio.wav" ...> → proxy URL
-      content = content.gsub(/<audio\b([^>]*)\bsrc="((?:file:\/\/)?\/[^"]+)"([^>]*)>/) do |_match|
+      content = content.gsub(/<audio\b([^>]*)\bsrc="((?:file:\/\/)?(?:~\/|\/)[^"]+)"([^>]*)>/) do |_match|
         pre  = Regexp.last_match(1) || ""
         href = Regexp.last_match(2)
         post = Regexp.last_match(3) || ""
@@ -643,7 +643,7 @@ module Clacky
       end
 
       # Rewrite video/audio markdown links [text](file:///path) → proxy URL
-      content = content.gsub(/(?<!!)\[([^\]]*)\]\(((?:file:\/\/)?\/[^)]+)\)/) do |_match|
+      content = content.gsub(/(?<!!)\[([^\]]*)\]\(((?:file:\/\/)?(?:~\/|\/)[^)]+)\)/) do |_match|
         text = Regexp.last_match(1)
         href = Regexp.last_match(2)
 

--- a/spec/clacky/utils/file_processor_spec.rb
+++ b/spec/clacky/utils/file_processor_spec.rb
@@ -463,6 +463,27 @@ RSpec.describe Clacky::Utils::FileProcessor do
       expect(result).to eq(content)
     end
 
+    it "rewrites a file://~/ tilde path, expanding ~ to the real home" do
+      Dir.mktmpdir(nil, File.expand_path("~")) do |dir|
+        img = File.join(dir, "photo.png")
+        File.binwrite(img, "PNG")
+        rel = img.sub(%r{\A#{Regexp.escape(File.expand_path("~"))}/}, "")
+
+        content = "![pic](file://~/#{rel})"
+        result = described_class.rewrite_local_image_urls(content)
+
+        expected_path = CGI.escape("file://~/#{rel}")
+        expect(result).to include("![pic](/api/local-image?path=#{expected_path}&v=")
+        expect(result).to match(/&v=\d+\)/)
+      end
+    end
+
+    it "does not match ~user (other account) tilde paths" do
+      content = "![pic](file://~someuser/photo.png)"
+      result = described_class.rewrite_local_image_urls(content)
+      expect(result).to eq(content)
+    end
+
     it "returns nil/empty content as-is" do
       expect(described_class.rewrite_local_image_urls(nil)).to be_nil
       expect(described_class.rewrite_local_image_urls("")).to eq("")


### PR DESCRIPTION
## Problem
Agent replies that used a relative Markdown image path starting with `~` (e.g. `![alt](file://~/clacky_workspace/assets/foo.png)`) rendered as a broken image in the Web UI. Absolute paths (`file:///Users/.../foo.png`) worked fine.

Root cause: `Utils::FileProcessor.rewrite_local_image_urls` matched local paths with 4 regexes that all required the path to start with `/` (`(?:file:\/\/)?\/[^)]+`). A `file://~/...` path never matched, so it was never rewritten to the `/api/local-image` proxy and the browser was left with a raw `file://~/` URL it cannot load. `resolve_local_path` already expands `~/` via `File.expand_path`; only the regex gate was blocking it.

## Fix
Widen the path prefix in all 4 regexes (img `![]()`, `<video src>`, `<audio src>`, media link `[]()`) from "must start with `/`" to "starts with `~/` or `/`":

```
\/[^)]+   ->  (?:~\/|\/)[^)]+
\/[^"]+   ->  (?:~\/|\/)[^"]+
```

`(?:~\/|\/)` is used instead of `[~/]` on purpose: `[~/]` would also match `file://~bob/` (another account's home), and `File.expand_path` raises `ArgumentError` on a non-existent user, crashing the render. `(?:~\/|\/)` only accepts `~/` or `/`, so `~user` paths fall through untouched — no rescue needed. No other logic (resolve/existence check/proxy URL/frontend) changed.

## Test ✅
- `bundle exec rspec spec/clacky/utils/file_processor_spec.rb` — 44 examples, 0 failures (added: `~/` tilde path is expanded & rewritten; `~user` path is left untouched)
- `bundle exec rspec` — 2763 examples, 0 failures, no regression
- Manual: Agent reply with `![x](file://~/clacky_workspace/assets/*.png)` now renders correctly in the Web UI