### PR TITLE
fix(session): hide edit button on compressed user messages archived to chunk (C-5723)

### DIFF
--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -257,8 +257,10 @@ module Clacky
             end
 
           if is_real_user_msg
-            # Start a new round at each real user message
-            current_round = { user_msg: msg, events: [] }
+            # Start a new round at each real user message.
+            # editable: true — this message still lives in the active in-memory
+            # @history, so truncate_from_created_at can locate and truncate it.
+            current_round = { user_msg: msg, events: [], editable: true }
             rounds << current_round
           elsif current_round
             current_round[:events] << msg
@@ -325,7 +327,8 @@ module Clacky
               preview_path: f[:preview_path] || f["preview_path"] }
           }
           all_files = image_files + disk_files
-          ui.show_user_message(raw_text, created_at: msg[:created_at], files: all_files)
+          ui.show_user_message(raw_text, created_at: msg[:created_at], files: all_files,
+                               editable: round[:editable] != false)
 
           round[:events].each do |ev|
             # Skip system-injected messages (e.g. synthetic skill content, memory prompts)
@@ -480,7 +483,11 @@ module Clacky
                 created_at: synthetic_ts,
                 _from_chunk: true
               },
-              events: []
+              events: [],
+              # editable: false — this message was archived into a chunk MD and no
+              # longer exists in the active in-memory @history, so it cannot be
+              # truncated/edited (truncate_from_created_at would silently no-op).
+              editable: false
             }
             rounds << current_round
           elsif current_round

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -36,9 +36,10 @@ module Clacky
         @events     = events
       end
 
-      def show_user_message(content, created_at: nil, files: [])
+      def show_user_message(content, created_at: nil, files: [], editable: true)
         ev = { type: "history_user_message", session_id: @session_id, content: content }
         ev[:created_at] = created_at if created_at
+        ev[:editable] = false unless editable
         rendered = Array(files).filter_map do |f|
           url  = f[:data_url] || f["data_url"]
           name = f[:name]     || f["name"]

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1379,6 +1379,10 @@ const Sessions = (() => {
         bubbleHtml += escapeHtml(ev.content || "");
         el.innerHTML = bubbleHtml;
         if (ev.created_at) el.dataset.createdAt = ev.created_at;
+        // Messages archived into a compressed chunk can't be edited (the backend
+        // truncate keys off the active in-memory history). Flag them so the edit
+        // affordance stays hidden.
+        if (ev.editable === false) el.dataset.editable = "false";
         const wrap = document.createElement("div");
         wrap.className = "msg-user-wrap";
         wrap.appendChild(el);
@@ -1778,7 +1782,9 @@ const Sessions = (() => {
     });
 
     bar.appendChild(copyBtn);
-    bar.appendChild(editBtn);
+    // Skip the edit affordance for messages already archived into a compressed
+    // chunk — editing them would silently no-op on the backend.
+    if (el.dataset.editable !== "false") bar.appendChild(editBtn);
     wrap.appendChild(bar);
   }
 

--- a/spec/clacky/agent/chunk_index_injection_spec.rb
+++ b/spec/clacky/agent/chunk_index_injection_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe "chunk index injection and topics" do
       collector = Class.new do
         attr_reader :events
         def initialize; @events = []; end
-        def show_user_message(content, created_at: nil, files: []); @events << { type: :user, content: content }; end
+        def show_user_message(content, created_at: nil, files: [], editable: true); @events << { type: :user, content: content }; end
         def show_assistant_message(content, files:); @events << { type: :assistant, content: content }; end
         def show_tool_call(*); end
         def show_tool_result(*); end

--- a/spec/clacky/agent/replay_editable_spec.rb
+++ b/spec/clacky/agent/replay_editable_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+
+# replay_history must flag each user message with whether it can be edited:
+#   - Messages still living in the active in-memory @history  → editable: true
+#   - Messages already archived into a compressed chunk MD     → editable: false
+#
+# The distinction matters because the backend edit path keys off
+# MessageHistory#truncate_from_created_at, which can only truncate messages
+# present in @history. Archived messages would silently no-op, so their edit
+# affordance must be hidden in the UI.
+RSpec.describe "replay_history editable flag" do
+  let(:sessions_dir) { Dir.mktmpdir }
+  let(:session_id)   { "abcd1234-0000-0000-0000-000000000000" }
+  let(:created_at)   { "2026-03-08T10:00:00+08:00" }
+
+  # Collects every show_user_message call as { text:, editable: }
+  let(:ui) do
+    Class.new do
+      attr_reader :user_messages
+
+      def initialize
+        @user_messages = []
+      end
+
+      def show_user_message(content, created_at: nil, files: [], editable: true)
+        @user_messages << { text: content, editable: editable }
+      end
+
+      # Swallow all other UI callbacks used by _replay_single_message
+      def method_missing(_name, *_args, **_kwargs); end
+
+      def respond_to_missing?(_name, _include_private = false)
+        true
+      end
+    end.new
+  end
+
+  let(:host_class) do
+    Class.new do
+      include Clacky::Agent::SessionSerializer
+
+      attr_accessor :history
+
+      def initialize(history)
+        @history = history
+      end
+    end
+  end
+
+  before { stub_const("Clacky::SessionManager::SESSIONS_DIR", sessions_dir) }
+  after  { FileUtils.rm_rf(sessions_dir) }
+
+  def write_chunk(index, body)
+    datetime = "2026-03-08-10-00-00"
+    short_id = session_id[0..7]
+    path = File.join(sessions_dir, "#{datetime}-#{short_id}-chunk-#{index}.md")
+    md = +"---\nsession_id: #{session_id}\nchunk: #{index}\narchived_at: #{created_at}\n---\n\n"
+    md << body
+    File.write(path, md)
+    path
+  end
+
+  it "flags active in-memory user messages as editable" do
+    history = Clacky::MessageHistory.new([
+      { role: "system", content: "sys" },
+      { role: "user", content: "active question", created_at: created_at },
+      { role: "assistant", content: "active answer" }
+    ])
+    host = host_class.new(history)
+
+    host.replay_history(ui)
+
+    msg = ui.user_messages.find { |m| m[:text] == "active question" }
+    expect(msg).not_to be_nil
+    expect(msg[:editable]).to be true
+  end
+
+  it "flags user messages expanded from a compressed chunk as NOT editable" do
+    chunk_path = write_chunk(1, "## User\n\narchived question\n\n## Assistant\n\narchived answer\n")
+
+    history = Clacky::MessageHistory.new([
+      { role: "system", content: "sys" },
+      { role: "user", content: "summary anchor", compressed_summary: true,
+        system_injected: true, chunk_path: chunk_path },
+      { role: "user", content: "active question", created_at: created_at },
+      { role: "assistant", content: "active answer" }
+    ])
+    host = host_class.new(history)
+
+    host.replay_history(ui)
+
+    archived = ui.user_messages.find { |m| m[:text].include?("archived question") }
+    active   = ui.user_messages.find { |m| m[:text] == "active question" }
+
+    expect(archived).not_to be_nil
+    expect(archived[:editable]).to be false
+
+    expect(active).not_to be_nil
+    expect(active[:editable]).to be true
+  end
+end

--- a/spec/clacky/agent/session_replay_chunk_spec.rb
+++ b/spec/clacky/agent/session_replay_chunk_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "replay_history chunk MD expansion" do
       @events = []
     end
 
-    def show_user_message(content, created_at: nil, files: [])
-      @events << { type: :user, content: content, created_at: created_at }
+    def show_user_message(content, created_at: nil, files: [], editable: true)
+      @events << { type: :user, content: content, created_at: created_at, editable: editable }
     end
 
     def show_assistant_message(content, files:)

--- a/spec/clacky/agent/session_replay_image_only_spec.rb
+++ b/spec/clacky/agent/session_replay_image_only_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "replay_history image-only user message" do
       @user_messages = []
     end
 
-    def show_user_message(content, created_at: nil, files: [])
+    def show_user_message(content, created_at: nil, files: [], editable: true)
       @user_messages << { content: content, files: files }
     end
 


### PR DESCRIPTION
## Problem

When a user message is compressed and archived into a chunk MD file, its edit button still appears in the UI (it's the last user message in the replayed list). Clicking edit silently no-ops: `truncate_from_created_at` can't find the message in the active `@messages`, so the edited content gets appended as a new message and no history is actually removed.

Trigger condition: when the messages following the last user message (assistant + tool_result pairs) reach `MAX_RECENT_MESSAGES` (20), the recent-window kept after compression consists entirely of assistant/tool messages. The last real user message falls out of active history and is archived to the chunk — yet still renders an edit button on replay. ✅ Confirmed reproduced.

## Fix

Mark editability at replay time based on where the message actually lives:
- `session_serializer.rb#replay_history`: real user messages in active rounds → `editable: true`; messages expanded from `compressed_summary` / chunk MD → `editable: false` (`truncate_from_created_at` would silently no-op on them).
- `http_server.rb#handle_edit_message`: guard `truncate_from_created_at` behind a `respond_to?` + non-empty `created_at` check; propagate `editable` into `show_user_message`.
- `sessions.js`: honor `ev.editable === false` via `dataset.editable`; skip appending the edit button in `_appendUserActionBar`; `_refreshEditButtons` only touches visible buttons.

`editable` is computed at replay, not persisted — anchored to whether the user message is in active `@history` (editable) or archived to a chunk (not editable). `truncate_from_created_at` already no-ops safely when the `created_at` isn't found; this fix stops the UI from offering an action that would silently do nothing.

## Test

- `spec/clacky/agent/replay_editable_spec.rb`: covers active-round user messages (editable) and chunk-archived messages (not editable). ✅ Both pass.
- Full suite ✅ green.