### PR TITLE
fix(workspace): copy Windows-accessible UNC path in WSL via wslpath (C-5693)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -3713,8 +3713,11 @@ module Clacky
           json_response(res, 200, { ok: true })
         when "download"
           serve_file_download(res, linux_path)
+        when "display-path"
+          display = Utils::EnvironmentDetector.linux_to_win_path(linux_path)
+          json_response(res, 200, { ok: true, path: display })
         else
-          json_response(res, 400, { error: "invalid action. Must be 'open', 'reveal' or 'download'" })
+          json_response(res, 400, { error: "invalid action. Must be 'open', 'reveal', 'download' or 'display-path'" })
         end
       rescue => e
         json_response(res, 500, { ok: false, error: e.message })

--- a/lib/clacky/web/features/workspace/store.js
+++ b/lib/clacky/web/features/workspace/store.js
@@ -72,6 +72,17 @@ const WorkspaceStore = (() => {
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     },
 
+    async displayPath(entry) {
+      const resp = await fetch("/api/file-action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: _absPath(entry.path), action: "display-path" })
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+      return data.path;
+    },
+
     async fetchFileBlob(entry) {
       const resp = await fetch("/api/file-action", {
         method: "POST",

--- a/lib/clacky/web/features/workspace/view.js
+++ b/lib/clacky/web/features/workspace/view.js
@@ -156,10 +156,16 @@ const WorkspaceView = (() => {
     if (existing) existing.remove();
   }
 
-  function copyPath(entry) {
-    const absPath = Workspace.state.workingDir.replace(/\/+$/, "") + "/" + entry.path.replace(/^\/+/, "");
-    navigator.clipboard.writeText(absPath).then(() => {
-      Modal.toast(absPath, "info");
+  async function copyPath(entry) {
+    const fallback = Workspace.state.workingDir.replace(/\/+$/, "") + "/" + entry.path.replace(/^\/+/, "");
+    let target = fallback;
+    try {
+      target = await Workspace.displayPath(entry);
+    } catch (err) {
+      target = fallback;
+    }
+    navigator.clipboard.writeText(target).then(() => {
+      Modal.toast(target, "info");
     });
   }
 

--- a/spec/clacky/server/http_server_file_action_display_path_spec.rb
+++ b/spec/clacky/server/http_server_file_action_display_path_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "clacky/server/http_server"
+require "clacky/agent_config"
+
+require_relative "http_server_spec"
+
+RSpec.describe Clacky::Server::HttpServer, "POST /api/file-action display-path" do
+  include HttpServerSpecHelpers
+
+  let(:tmpdir) { Dir.mktmpdir("clacky_file_action_display_spec") }
+  let(:config_file) { File.join(tmpdir, "config.yml") }
+  let(:file_path) { File.join(tmpdir, "cat.png") }
+
+  let(:agent_config) do
+    cfg = Clacky::AgentConfig.new(models: [
+      { "model" => "test-model", "api_key" => "k",
+        "base_url" => "https://example.invalid/v1", "type" => "default" }
+    ])
+    stub_const("Clacky::AgentConfig::CONFIG_FILE", config_file)
+    cfg
+  end
+
+  before { File.binwrite(file_path, "PNG") }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  def request_display_path(server)
+    req = fake_req(
+      method: "POST",
+      path:   "/api/file-action",
+      body:   { "path" => file_path, "action" => "display-path" }
+    )
+    res = fake_res
+    dispatch(server, req, res)
+    res
+  end
+
+  it "returns the Windows UNC path on WSL" do
+    unc = "\\\\wsl.localhost\\Ubuntu#{file_path}"
+    allow(Clacky::Utils::EnvironmentDetector)
+      .to receive(:linux_to_win_path).with(file_path).and_return(unc)
+
+    with_server(agent_config: agent_config) do |server|
+      res = request_display_path(server)
+      expect(res.status).to eq(200)
+      body = parsed_body(res)
+      expect(body["ok"]).to be(true)
+      expect(body["path"]).to eq(unc)
+    end
+  end
+
+  it "returns the original Linux path on non-WSL (no-op)" do
+    with_server(agent_config: agent_config) do |server|
+      res = request_display_path(server)
+      expect(res.status).to eq(200)
+      body = parsed_body(res)
+      expect(body["ok"]).to be(true)
+      expect(body["path"]).to eq(file_path)
+    end
+  end
+
+  it "returns 404 for a missing file" do
+    req = fake_req(
+      method: "POST",
+      path:   "/api/file-action",
+      body:   { "path" => File.join(tmpdir, "missing.png"), "action" => "display-path" }
+    )
+    res = fake_res
+    with_server(agent_config: agent_config) do |server|
+      dispatch(server, req, res)
+      expect(res.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
In WSL, the file panel's "Copy Path" action copied a Linux-style absolute path (e.g. `/root/clacky_workspace/cat.png`), which Windows File Explorer cannot open.

## Fix
`copyPath` now asks the backend for a display path. A new `display-path` action in `/api/file-action` runs the path through `EnvironmentDetector.linux_to_win_path`, which uses `wslpath -w` to produce the correct UNC path at runtime (no hardcoded `\\wsl$` / `\\wsl.localhost` prefix). On macOS/Linux it's a no-op, so the original absolute path is returned and behavior is unchanged. The frontend falls back to the locally-composed Linux path if the request fails.

## Test
- ✅ New spec `http_server_file_action_display_path_spec.rb`: WSL returns UNC (mocked), non-WSL returns the original path, missing file returns 404
- ✅ Full suite: 2766 examples, 0 failures
