### PR TITLE
fix(server): shutdown idle compression before worker exit

### DIFF
--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -68,6 +68,7 @@ module Clacky
           }
         end
         backfill_task_meta_from_history!
+        heal_missing_chunk_paths!
 
         # Check if the session ended with an error.
         # We record the rollback intent here but do NOT truncate history immediately —
@@ -141,6 +142,31 @@ module Clacky
           cur_end = entry[:ended_at]
           entry[:ended_at] = ts.to_f if cur_end.nil? || ts.to_f > cur_end
         end
+      end
+
+      # Repair compressed_summary messages whose chunk_path is missing or points
+      # at a file that no longer exists. This happens when a hot restart's
+      # SIGKILL killed the worker after the chunk file was written to disk but
+      # before its path was persisted into session.json — the archived history
+      # then never renders on replay. Rediscover the chunk on disk from
+      # session_id + created_at and write the real path back, once, at load time.
+      private def heal_missing_chunk_paths!
+        return unless @session_id && @created_at
+
+        broken = @history.to_a.select do |m|
+          m[:compressed_summary] && !(m[:chunk_path] && File.exist?(m[:chunk_path].to_s))
+        end
+        return if broken.empty?
+
+        chunks = session_manager.chunks_for_current(@session_id, @created_at)
+        return if chunks.empty?
+
+        latest_path = chunks.last[:path]
+        broken.each { |m| m[:chunk_path] = latest_path }
+
+        session_manager.save(to_session_data(preserve_updated_at: true))
+      rescue => e
+        Clacky::Logger.warn("heal_missing_chunk_paths! failed: #{e.message}")
       end
 
       private def persisted_card_field(key)
@@ -264,7 +290,7 @@ module Clacky
             rounds << current_round
           elsif current_round
             current_round[:events] << msg
-          elsif msg[:compressed_summary] && msg[:chunk_path]
+          elsif msg[:compressed_summary]
             # Compressed summary sitting before any user rounds — expand ALL chunk
             # MD files that belong to the same session (siblings of chunk_path),
             # in chunk-index ascending order.
@@ -274,15 +300,23 @@ module Clacky
             # points at the newest chunk). Older chunks (chunk-1..chunk-N-1) are
             # referenced only as basenames inside the summary text. Expanding just
             # msg[:chunk_path] would therefore lose all prior chunks on replay.
-            chunk_rounds = sibling_chunks_of(msg[:chunk_path]).flat_map { |p|
-              parse_chunk_md_to_rounds(p)
-            }
+            #
+            # chunk_path may be blank when a hot restart's SIGKILL killed the
+            # worker after the chunk file was written but before its path was
+            # persisted into session.json. Fall back to discovering the chunks
+            # on disk from session_id + created_at so the history is not lost.
+            chunk_paths = if msg[:chunk_path].to_s.empty?
+              session_manager.chunks_for_current(@session_id, @created_at).map { |c| c[:path] }
+            else
+              sibling_chunks_of(msg[:chunk_path])
+            end
+            chunk_rounds = chunk_paths.flat_map { |p| parse_chunk_md_to_rounds(p) }
             rounds.concat(chunk_rounds)
             # After expanding, treat the last chunk round as the current round so that
             # any orphaned assistant/tool messages that follow in session.json (belonging
             # to the same task whose user message was compressed into the chunk) get
             # appended here instead of being silently discarded.
-            current_round = rounds.last
+            current_round = rounds.last unless chunk_rounds.empty?
           elsif rounds.last
             # Orphaned non-user message with no current_round yet (e.g. recent_messages
             # after compression started mid-task with no leading user message).

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -6424,6 +6424,12 @@ module Clacky
       private def interrupt_all_agents
         return unless @registry && @session_manager
 
+        # Stop idle compression first: an in-flight compression must fully roll
+        # back (or complete) before the worker is killed, otherwise a hot
+        # restart's SIGKILL can leave a chunk file on disk whose chunk_path
+        # never made it into session.json (history vanishes on replay).
+        @registry.shutdown_all_idle_timers
+
         @registry.each_live_agent do |id, agent, thread|
           next unless thread&.alive?
           begin

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -496,6 +496,15 @@ module Clacky
         snapshot.each { |id, agent, thread| yield id, agent, thread }
       end
 
+      # Shut down every session's idle-compression timer, waiting for any
+      # in-flight compression to roll back cleanly. Called on worker shutdown
+      # so a hot restart's SIGKILL cannot tear a compression apart between
+      # writing the chunk file and persisting its chunk_path into session.json.
+      def shutdown_all_idle_timers
+        timers = @mutex.synchronize { @sessions.values.filter_map { |s| s[:idle_timer] } }
+        timers.each { |t| t.shutdown rescue nil }
+      end
+
       private def persist_and_release(id, session)
         agent = session[:agent]
         @session_manager&.save(agent.to_session_data(status: :success, preserve_updated_at: true)) if agent

--- a/spec/clacky/agent/session_replay_chunk_spec.rb
+++ b/spec/clacky/agent/session_replay_chunk_spec.rb
@@ -600,4 +600,138 @@ RSpec.describe "replay_history chunk MD expansion" do
         .to include(a_string_including("Next task"))
     end
   end
+
+  describe "replay_history recovers when chunk_path is missing (hot-restart data loss)" do
+    # basename = "<created_at strftime %Y-%m-%d-%H-%M-%S>-<session_id[0..7]>"
+    let(:session_id) { "3e29d4cb77305f66" }
+    let(:created_at) { "2026-07-21T10:25:06+08:00" }
+    let(:base_name)  { "2026-07-21-10-25-06-3e29d4cb" }
+
+    def build_recovering_agent(messages)
+      history = Clacky::MessageHistory.new(messages)
+      sm = Clacky::SessionManager.new(sessions_dir: sessions_dir)
+      sid = session_id
+      cat = created_at
+
+      agent_class = Class.new do
+        include Clacky::Agent::SessionSerializer
+
+        define_method(:initialize) do |hist, mgr, s_id, c_at|
+          @history = hist
+          @session_manager = mgr
+          @session_id = s_id
+          @created_at = c_at
+        end
+
+        def session_manager; @session_manager; end
+        def build_system_prompt; "system"; end
+      end
+
+      agent_class.new(history, sm, sid, cat)
+    end
+
+    it "expands chunk history from disk when the summary's chunk_path is nil" do
+      chunk_path = File.join(sessions_dir, "#{base_name}-chunk-1.md")
+      File.write(chunk_path, chunk_md(
+        user_content: "Recovered question",
+        assistant_content: "Recovered answer",
+        chunk: 1
+      ))
+
+      # chunk_path is nil — the state produced by a hot-restart SIGKILL
+      messages = [
+        { role: "system",    content: "System." },
+        { role: "assistant", content: "Summary.", compressed_summary: true, chunk_path: nil },
+        { role: "user",      content: "Current question", created_at: Time.now.to_f }
+      ]
+
+      agent = build_recovering_agent(messages)
+      collector = TestCollector.new
+      agent.replay_history(collector)
+
+      user_contents = collector.events.select { |e| e[:type] == :user }.map { |e| e[:content] }
+      expect(user_contents).to include(a_string_including("Recovered question"))
+      expect(user_contents).to include(a_string_including("Current question"))
+    end
+
+    it "does nothing harmful when no chunk exists on disk" do
+      messages = [
+        { role: "system",    content: "System." },
+        { role: "assistant", content: "Summary.", compressed_summary: true, chunk_path: nil },
+        { role: "user",      content: "Still here", created_at: Time.now.to_f }
+      ]
+
+      agent = build_recovering_agent(messages)
+      collector = TestCollector.new
+      expect { agent.replay_history(collector) }.not_to raise_error
+
+      user_contents = collector.events.select { |e| e[:type] == :user }.map { |e| e[:content] }
+      expect(user_contents).to include(a_string_including("Still here"))
+    end
+  end
+
+  describe "heal_missing_chunk_paths! writes the recovered path back into session.json" do
+    let(:session_id) { "3e29d4cb77305f66" }
+    let(:created_at) { "2026-07-21T10:25:06+08:00" }
+    let(:base_name)  { "2026-07-21-10-25-06-3e29d4cb" }
+
+    def build_healing_agent(messages)
+      history = Clacky::MessageHistory.new(messages)
+      sm = Clacky::SessionManager.new(sessions_dir: sessions_dir)
+      sid = session_id
+      cat = created_at
+
+      agent_class = Class.new do
+        include Clacky::Agent::SessionSerializer
+
+        define_method(:initialize) do |hist, mgr, s_id, c_at|
+          @history = hist
+          @session_manager = mgr
+          @session_id = s_id
+          @created_at = c_at
+        end
+
+        def session_manager; @session_manager; end
+        def to_session_data(**); { session_id: @session_id, created_at: @created_at, messages: @history.to_a }; end
+      end
+
+      agent_class.new(history, sm, sid, cat)
+    end
+
+    it "backfills chunk_path on a broken summary and persists it" do
+      chunk_path = File.join(sessions_dir, "#{base_name}-chunk-1.md")
+      File.write(chunk_path, chunk_md(user_content: "Q", assistant_content: "A", chunk: 1))
+
+      summary = { role: "assistant", content: "Summary.", compressed_summary: true, chunk_path: nil }
+      agent = build_healing_agent([summary])
+
+      agent.send(:heal_missing_chunk_paths!)
+
+      expect(summary[:chunk_path]).to eq(chunk_path)
+      # persisted to disk
+      saved = Dir.glob(File.join(sessions_dir, "#{base_name}.json"))
+      expect(saved).not_to be_empty
+    end
+
+    it "leaves a healthy summary untouched" do
+      chunk_path = File.join(sessions_dir, "#{base_name}-chunk-1.md")
+      File.write(chunk_path, chunk_md(user_content: "Q", assistant_content: "A", chunk: 1))
+
+      summary = { role: "assistant", content: "Summary.", compressed_summary: true, chunk_path: chunk_path }
+      agent = build_healing_agent([summary])
+
+      expect(agent.session_manager).not_to receive(:save)
+      agent.send(:heal_missing_chunk_paths!)
+      expect(summary[:chunk_path]).to eq(chunk_path)
+    end
+
+    it "does not persist when no chunk exists on disk" do
+      summary = { role: "assistant", content: "Summary.", compressed_summary: true, chunk_path: nil }
+      agent = build_healing_agent([summary])
+
+      expect(agent.session_manager).not_to receive(:save)
+      expect { agent.send(:heal_missing_chunk_paths!) }.not_to raise_error
+      expect(summary[:chunk_path]).to be_nil
+    end
+  end
 end

--- a/spec/clacky/server/session_registry_spec.rb
+++ b/spec/clacky/server/session_registry_spec.rb
@@ -267,4 +267,39 @@ RSpec.describe Clacky::Server::SessionRegistry do
       expect(registry.get("s1")[:status]).to eq(:running)
     end
   end
+
+  describe "#shutdown_all_idle_timers" do
+    it "shuts down every session's idle timer" do
+      Dir.mktmpdir("clacky_idle_shutdown") do |dir|
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        timer1 = double("timer1")
+        timer2 = double("timer2")
+        expect(timer1).to receive(:shutdown)
+        expect(timer2).to receive(:shutdown)
+
+        sessions = registry.instance_variable_get(:@sessions)
+        sessions["s1"] = { idle_timer: timer1 }
+        sessions["s2"] = { idle_timer: timer2 }
+        sessions["s3"] = { idle_timer: nil }
+
+        expect { registry.shutdown_all_idle_timers }.not_to raise_error
+      end
+    end
+
+    it "does not raise when a timer's shutdown fails" do
+      Dir.mktmpdir("clacky_idle_shutdown") do |dir|
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        timer = double("timer")
+        allow(timer).to receive(:shutdown).and_raise(StandardError, "boom")
+
+        registry.instance_variable_get(:@sessions)["s1"] = { idle_timer: timer }
+
+        expect { registry.shutdown_all_idle_timers }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem
Idle compression runs on a background thread and writes the chunk MD file and then persists its `chunk_path` into session.json in two non-atomic steps. On a hot restart (triggered by a gem upgrade), the old worker only gets a 5s TERM window before SIGKILL; the compression's LLM call cannot finish in time, so the worker is force-killed between writing the chunk file and persisting its path. The chunk lands on disk but session.json's summary keeps `chunk_path = null`. Replay expands history via `chunk_path`, so the whole archived history vanishes on reopen. Reported by multiple users after upgrading.

## Fix
1. Shut down every session's idle-compression timer at worker exit (`interrupt_all_agents` → `SessionRegistry#shutdown_all_idle_timers`), so an in-flight compression fully rolls back before SIGKILL — no more half-written summaries.
2. Self-heal already-broken sessions: on load, `heal_missing_chunk_paths!` rediscovers the chunk on disk from `session_id + created_at`, writes the real path back into session.json, and persists once. `replay_history` also falls back to disk discovery so history renders even before the heal is saved.

## Test
✅ `session_registry_spec`: shutdown_all_idle_timers calls each timer's shutdown, tolerates failures
✅ `session_replay_chunk_spec`: replay recovers when chunk_path is nil; heal backfills and persists; healthy summaries untouched
✅ Full suite: 2775 examples, 0 failures