### PR TITLE
feat(ext-studio): guide ext-develop skill to the host-api reference

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
+++ b/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
@@ -68,7 +68,9 @@ you consult from whichever path you're on.
 ## Reference: the contracts
 
 Read the relevant reference doc with `web_fetch` before writing code — don't guess field
-names, hook events, adapter methods, or the `Clacky.ext` WebUI contract.
+names, hook events, adapter methods, or the `Clacky.ext` WebUI contract. These docs are
+long (well over the default cap); pass `max_length: 20000` so you get the whole page in one
+fetch instead of a truncated head full of nav chrome.
 
 ### Authoritative documentation
 
@@ -76,6 +78,7 @@ names, hook events, adapter methods, or the `Clacky.ext` WebUI contract.
 - **ext.yml manifest — every field (names, avatar, title_zh, order, …)** → https://www.openclacky.com/docs/ext-manifest
 - Panels (WebUI) → https://www.openclacky.com/docs/extend-webui
 - API backends → https://www.openclacky.com/docs/extend-api
+- **Calling the host's native APIs from a panel (sessions, trash/file-recovery, skills, memories, cron, billing, media)** → https://www.openclacky.com/docs/extend-host-api
 - Agents (prompt, avatar, panels/skills wiring) → https://www.openclacky.com/docs/agent-config
 - Channel adapters → https://www.openclacky.com/docs/extend-channel-adapter
 - Patches → https://www.openclacky.com/docs/extend-patches
@@ -152,6 +155,13 @@ Clacky.WS.send({ type: "..." });            // send a WebSocket message to the a
 
 - Prefer `Clacky.Xxx.method(...)` — the recommended, forward-stable form. Never test with
   `window.Sessions` / `"Sessions" in window` (see Hard rules).
+
+A panel can also `fetch("/api/...")` the host's own REST endpoints directly (same origin,
+auth is automatic) — sessions, trash/**file-recovery**, skills, memories, cron, billing,
+media, and more each have a ready-made endpoint. Before telling a user a feature "can't be
+done" (e.g. "delete a file but keep it recoverable"), check whether the host already
+exposes it — `web_fetch` https://www.openclacky.com/docs/extend-host-api for the callable
+list. Don't rebuild what the host already provides.
 
 ### API backend: the `Clacky::ApiExtension` contract
 


### PR DESCRIPTION
## What

Add the "extension panels can call the host's native HTTP APIs" capability knowledge to the `ext-develop` skill of the `ext-studio` extension, and point it to the online reference.

Changed file: `lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md`

## Why

Previously, when the AI built an extension it didn't know that a panel can call the host's native endpoints directly via same-origin `fetch("/api/...")`. As a result it tended to reinvent the wheel or tell the user it couldn't be done. This writes that capability into the skill and guides the AI to `web_fetch` the authoritative doc (extend-host-api) when it needs specific endpoints.

## Changes

- Explain that an extension panel shares the host's origin and `fetch` carries the access key automatically
- Add the extend-host-api online doc link
- Add a `web_fetch` hint to use `max_length` so the AI pulls the full page instead of a truncated fragment

## Companion PR

The corresponding endpoint doc lives in the openclacky-platform repo on branch `docs/extend-host-api` (separate PR).

## Test plan

- [ ] `bundle exec ruby bin/clacky ext verify` (ext-studio) passes
- [ ] `bundle exec rspec` is fully green