### PR TITLE
fix(extension): reject packing when folder name diverges from ext.yml id (C-5752)

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
+++ b/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
@@ -51,6 +51,7 @@
       "err.version_conflict": "Version {{ver}} has already been published. Please enter a higher version number above and try again.",
       "err.invalid_version": "Invalid version. Use format like 1.0.0.",
       "err.name_taken": "The name \"{{id}}\" is already taken by another user.",
+      "err.id_folder_mismatch": "Extension ID mismatch: the folder is named \"{{folder}}\" but ext.yml declares id \"{{id}}\". Rename the folder or the id so they match before publishing.",
       "rename.label": "Choose a new ID for your extension:",
       "rename.placeholder": "e.g. my-ext-yourname",
       "rename.hint": "Only lowercase letters, digits and hyphens. This will rename the local folder and update ext.yml.",
@@ -235,6 +236,7 @@
       "err.version_conflict": "版本 {{ver}} 已发布过，请在上方输入更高的版本号后重试。",
       "err.invalid_version": "版本号格式不对，请使用如 1.0.0 的格式。",
       "err.name_taken": "扩展名「{{id}}」已被其他用户占用。",
+      "err.id_folder_mismatch": "扩展 ID 不一致：文件夹名为「{{folder}}」，但 ext.yml 声明的 id 是「{{id}}」。请先把文件夹名或 id 改成一致再发布。",
       "rename.label": "请为你的扩展选择一个新 ID：",
       "rename.placeholder": "例如 my-ext-yourname",
       "rename.hint": "只能使用小写字母、数字和连字符。",
@@ -726,6 +728,7 @@
         } catch (e) {
           const msg = e.message || "";
           const isConflict = /must be greater than/i.test(msg);
+          const mismatch = msg.match(/folder is '([^']+)' but ext\.yml declares id '([^']+)'/);
           if (isConflict) {
             setProgress(t("err.version_conflict", { ver }), true);
             verInput.classList.add("studio-input-error");
@@ -733,6 +736,8 @@
             verInput.focus();
             verInput.select();
             verInput.addEventListener("input", () => verInput.classList.remove("studio-input-error"), { once: true });
+          } else if (mismatch) {
+            setProgress(t("err.id_folder_mismatch", { folder: mismatch[1], id: mismatch[2] }), true);
           } else {
             setProgress(t("err.generic", { msg }), true);
           }

--- a/lib/clacky/extension/packager.rb
+++ b/lib/clacky/extension/packager.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require "tmpdir"
 require "open-uri"
+require "psych"
 require "zip"
 
 module Clacky
@@ -38,6 +39,7 @@ module Clacky
           raise Error, "no container found at #{container_dir} (expected #{MANIFEST})"
         end
 
+        refuse_id_folder_mismatch!(slug, container_dir)
         verify_container!(slug, container_dir)
         refuse_protected!(slug, container_dir)
 
@@ -94,6 +96,21 @@ module Clacky
         end
       ensure
         Clacky::ExtensionLoader.invalidate_cache!
+      end
+
+      # The container's identity must be the same on both sides of the publish
+      # boundary: the client keys extensions by folder name, the marketplace
+      # keys them by ext.yml `id`. If they diverge, a rename on one side alone
+      # lets a container masquerade under a name the uniqueness check never saw.
+      private def refuse_id_folder_mismatch!(slug, container_dir)
+        manifest = File.join(container_dir, MANIFEST)
+        data     = Psych.safe_load(File.read(manifest), permitted_classes: [], aliases: true) || {}
+        declared = data["id"].to_s.strip
+        return if declared == slug
+
+        raise Error,
+              "extension id mismatch: folder is '#{slug}' but #{MANIFEST} declares id '#{declared}'. " \
+              "Rename the folder or the id so they match before packing."
       end
 
       # Packing is for authored (open) containers. Anything already protected or

--- a/spec/clacky/extension_packager_spec.rb
+++ b/spec/clacky/extension_packager_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Clacky::ExtensionPackager do
         .to raise_error(described_class::Error, /no container found/)
     end
 
+    it "refuses to pack when the folder name diverges from the ext.yml id" do
+      scaffold("demo")
+      yml = File.join(local, "demo", "ext.yml")
+      File.write(yml, File.read(yml).sub(/^id:.*$/, "id: renamed-ext"))
+
+      expect { described_class.pack("demo", source_dir: local, out_dir: out) }
+        .to raise_error(described_class::Error, /folder is 'demo'.*id 'renamed-ext'/)
+    end
+
     it "refuses to pack a container carrying an encrypted skill" do
       dir = scaffold("enc")
       FileUtils.mkdir_p(File.join(dir, "skills", "secret"))


### PR DESCRIPTION
## Problem
Extension identity was split across two authorities. The openclacky client derives an extension's identity from its **folder name**, while the platform trusts the **id** field in `ext.yml`. Manually renaming a folder without updating the id produced a mismatch: the platform's duplicate-name check runs by declared id, finds no conflict, and lets a colliding extension land. (C-5752)

## Fix
Close the gap at the earliest point authors hit — packaging:
- `packager.rb`: before packing, read `ext.yml` and refuse when the declared `id` differs from the container folder name, raising a clear error.
- `ext-studio` publish panel (`view.js`): detect this error and show a localized message (zh/en) telling the author to align the folder or the id.

This is the front line (Gate 1) that normal authors always hit first. A second server-side guard lands in the platform repo as a backstop for callers that bypass the client.

## Tests
- `extension_packager_spec.rb`: new example — packing fails when the folder name and `ext.yml` id diverge.
- Full extension/packager/default-extensions specs green (50 examples, 0 failures).
