### PR TITLE
feat(message_format): enable GLM native thinking for extended reasoning

### DIFF
--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -59,14 +59,14 @@ module Clacky
           end
         end
 
-        # GLM-5.2 (Zhipu / Z.ai) supports a native top-level "thinking" field
-        # for extended reasoning, separate from the OpenAI-standard
+        # GLM (Zhipu / Z.ai) models support a native top-level "thinking"
+        # field for extended reasoning, separate from the OpenAI-standard
         # reasoning_effort. Map the shared reasoning_effort setting to both
-        # fields so GLM-5.2 activates its thinking mode correctly.
+        # fields so GLM activates its thinking mode correctly.
         #
-        # GLM-5.2 only recognises "max" and "high" effort levels; other values
+        # GLM only recognises "max" and "high" effort levels; other values
         # collapse to "high". When thinking is explicitly disabled, send
-        # thinking:{type:"disabled"} which GLM-5.2 honours.
+        # thinking:{type:"disabled"} which GLM honours.
         #
         # Zero side-effects: when reasoning_effort is nil/empty the request
         # body is unchanged, preserving the provider default.
@@ -79,7 +79,7 @@ module Clacky
               case effort_str
               when "max", "xhigh" then "max"
               when "high"          then "high"
-              when "medium", "low" then "high"   # GLM-5.2 collapses these to "high"
+              when "medium", "low" then "high"   # GLM collapses these to "high"
               else                      "max"
               end
             body[:thinking] = { type: "enabled" }

--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -59,7 +59,33 @@ module Clacky
           end
         end
 
-        if reasoning_effort && !reasoning_effort.to_s.empty?
+        # GLM (Zhipu / Z.ai) models support a native top-level "thinking" field
+        # for extended reasoning, separate from the OpenAI-standard
+        # reasoning_effort. Map the shared reasoning_effort setting to both
+        # fields so GLM activates its thinking mode correctly.
+        #
+        # GLM-5.x only recognises "max" and "high" effort levels; other values
+        # collapse to "high". When thinking is explicitly disabled, send
+        # thinking:{type:"disabled"} which GLM honours.
+        #
+        # Zero side-effects: when reasoning_effort is nil/empty the request
+        # body is unchanged, preserving the provider default.
+        if model.to_s.match?(/^glm-[45]/)
+          effort_str = reasoning_effort.to_s
+          if %w[off nothink disabled].include?(effort_str)
+            body[:thinking] = { type: "disabled" }
+          elsif !effort_str.empty?
+            glm_effort =
+              case effort_str
+              when "max", "xhigh" then "max"
+              when "high"          then "high"
+              when "medium", "low" then "high"   # GLM collapses these to "high"
+              else                      "max"
+              end
+            body[:thinking] = { type: "enabled" }
+            body[:reasoning_effort] = glm_effort
+          end
+        elsif reasoning_effort && !reasoning_effort.to_s.empty?
           body[:reasoning_effort] = reasoning_effort.to_s
         end
 

--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -59,14 +59,14 @@ module Clacky
           end
         end
 
-        # GLM (Zhipu / Z.ai) models support a native top-level "thinking" field
+        # GLM-5.2 (Zhipu / Z.ai) supports a native top-level "thinking" field
         # for extended reasoning, separate from the OpenAI-standard
         # reasoning_effort. Map the shared reasoning_effort setting to both
-        # fields so GLM activates its thinking mode correctly.
+        # fields so GLM-5.2 activates its thinking mode correctly.
         #
-        # GLM-5.x only recognises "max" and "high" effort levels; other values
+        # GLM-5.2 only recognises "max" and "high" effort levels; other values
         # collapse to "high". When thinking is explicitly disabled, send
-        # thinking:{type:"disabled"} which GLM honours.
+        # thinking:{type:"disabled"} which GLM-5.2 honours.
         #
         # Zero side-effects: when reasoning_effort is nil/empty the request
         # body is unchanged, preserving the provider default.
@@ -79,7 +79,7 @@ module Clacky
               case effort_str
               when "max", "xhigh" then "max"
               when "high"          then "high"
-              when "medium", "low" then "high"   # GLM collapses these to "high"
+              when "medium", "low" then "high"   # GLM-5.2 collapses these to "high"
               else                      "max"
               end
             body[:thinking] = { type: "enabled" }


### PR DESCRIPTION
## What

Enable GLM (Zhipu / Z.ai) native extended-reasoning support in the OpenAI-compatible request path.

GLM models accept a top-level `thinking` field — distinct from the OpenAI-standard `reasoning_effort` — that activates their native extended-thinking mode. Currently, when a GLM user sets `reasoning_effort` via `PUT /sessions/:id`, the value is sent through unchanged but the `thinking` field is never set, so GLM's thinking mode stays inactive.

## Why

GLM-5.x is one of the strongest open coding models and is already a configured provider in OpenClacky (with pricing in `model_pricing.rb`). However, its reasoning capability can't be unlocked through the existing `reasoning_effort` setting because GLM expects the `thinking` field rather than (or in addition to) `reasoning_effort`.

This change bridges that gap:

| `reasoning_effort` | Request sent to GLM |
|---|---|
| `max` / `xhigh` | `thinking:{type:"enabled"}` + `reasoning_effort:"max"` |
| `high` / `medium` / `low` | `thinking:{type:"enabled"}` + `reasoning_effort:"high"` |
| `off` / `nothink` / `disabled` | `thinking:{type:"disabled"}` |
| *(unset)* | **no change** — request body untouched |

GLM-5.x only recognises `"max"` and `"high"` as effort levels, so `medium`/`low` collapse to `"high"` (this mirrors the behaviour of the official Z.ai SDK and the ZCode agent).

## Impact

- **Zero side-effects.** When `reasoning_effort` is nil/empty (the default), the request body is byte-for-byte identical to before. Non-GLM models are completely unaffected (guarded by `model.to_s.match?(/^glm-[45]/)`).
- **No new config knobs.** Reuses the existing `reasoning_effort` setting — no new parameters, env vars, or provider presets.
- **No new dependencies.** Pure Ruby, stdlib only.
- **Small diff:** +29 / −3 lines in a single method.

## Verification

- `ruby -c` syntax check passes.
- Behaviour matrix confirmed against GLM `coding/paas/v4` endpoint (returns 200 OK with thinking enabled).
- Mapping logic cross-validated against the official Z.ai SDK `thinkingLevelMap` and the ZCode agent's reasoning-depth configuration.

## Notes

Authored using OpenClacky. Mentioned per CONTRIBUTING.md.
