### PR TITLE
fix(providers): align MiMo preset with V2.5 lineup and Token Plan endpoint

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -348,13 +348,30 @@ module Clacky
         "base_url" => "https://api.xiaomimimo.com/v1",
         "api" => "openai-completions",
         "default_model" => "mimo-v2.5-pro",
-        "models" => ["mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"],
-        # MiMo-V2-Pro is text-only; MiMo-V2-Omni supports vision (omni = multimodal).
+        # The MiMo-V2 family (mimo-v2-pro / mimo-v2-omni) was retired on
+        # 2026-06-30 and the model ids are no longer accepted by the API. The
+        # current lineup is the V2.5 series:
+        #   - mimo-v2.5-pro: text reasoning flagship, no vision
+        #   - mimo-v2.5: native omni-modal (image/video/audio/text), vision-capable
+        # Source: https://platform.xiaomimimo.com/docs/zh-CN/model
+        "models" => ["mimo-v2.5-pro", "mimo-v2.5"],
         "capabilities" => { "vision" => false }.freeze,
         "model_capabilities" => {
-          "mimo-v2-omni" => { "vision" => true }.freeze
+          "mimo-v2.5" => { "vision" => true }.freeze
         }.freeze,
-        "default_ocr_model" => "mimo-v2-omni",
+        "default_ocr_model" => "mimo-v2.5",
+        # Xiaomi serves the same V2.5 lineup from two billing endpoints: the
+        # pay-as-you-go API (api.xiaomimimo.com) and the Token Plan subscription
+        # endpoint (token-plan-cn.xiaomimimo.com). Both accept identical model
+        # ids and share one capability profile, so a single preset with
+        # endpoint_variants recognises both. Without this, users on the Token
+        # Plan endpoint fell through to "unknown provider" and the conservative
+        # vision=true default applied to every model — sending images to the
+        # text-only mimo-v2.5-pro, which rejects image input.
+        "endpoint_variants" => [
+          { "label" => "Pay-as-you-go", "label_key" => "settings.models.baseurl.variant.mimo_payg",        "base_url" => "https://api.xiaomimimo.com/v1",          "region" => "cn" }.freeze,
+          { "label" => "Token Plan",    "label_key" => "settings.models.baseurl.variant.mimo_token_plan", "base_url" => "https://token-plan-cn.xiaomimimo.com/v1", "region" => "cn" }.freeze
+        ].freeze,
         "website_url" => "https://platform.xiaomimimo.com/"
       }.freeze,
 

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -80,12 +80,12 @@ RSpec.describe Clacky::Providers do
     end
 
     context "for providers with mixed model capabilities" do
-      it "returns false for mimo (default text-only), true for mimo-v2-omni" do
+      it "returns false for mimo (default text-only), true for mimo-v2.5 (omni)" do
         expect(described_class.supports?("mimo", :vision)).to be false
         expect(described_class.supports?("mimo", :vision,
-                                         model_name: "mimo-v2-pro")).to be false
+                                         model_name: "mimo-v2.5-pro")).to be false
         expect(described_class.supports?("mimo", :vision,
-                                         model_name: "mimo-v2-omni")).to be true
+                                         model_name: "mimo-v2.5")).to be true
       end
 
       it "returns false for glm (default text-only), true for glm-5v-turbo" do
@@ -253,6 +253,40 @@ RSpec.describe Clacky::Providers do
           # vision model still reports true (per-model override).
           expect(described_class.supports?(id, :vision, model_name: "glm-5v-turbo"))
             .to be(true), "expected vision=true at #{url} for glm-5v-turbo"
+        end
+      end
+    end
+
+    context "MiMo (Xiaomi) two billing endpoints" do
+      # The Token Plan subscription endpoint (token-plan-cn.xiaomimimo.com) is a
+      # distinct domain from the pay-as-you-go API (api.xiaomimimo.com) but
+      # serves the same V2.5 lineup, so both must resolve to "mimo" — otherwise
+      # Token Plan users hit "unknown provider" and the vision=true default
+      # leaks images into the text-only mimo-v2.5-pro.
+      it "recognises pay-as-you-go and Token Plan endpoints" do
+        %w[
+          https://api.xiaomimimo.com/v1
+          https://token-plan-cn.xiaomimimo.com/v1
+        ].each do |url|
+          expect(described_class.find_by_base_url(url)).to eq("mimo")
+        end
+      end
+
+      it "recognises endpoint subpaths" do
+        expect(described_class.find_by_base_url("https://token-plan-cn.xiaomimimo.com/v1/chat/completions"))
+          .to eq("mimo")
+      end
+
+      it "enforces vision matrix across both endpoints" do
+        %w[
+          https://api.xiaomimimo.com/v1
+          https://token-plan-cn.xiaomimimo.com/v1
+        ].each do |url|
+          id = described_class.find_by_base_url(url)
+          expect(described_class.supports?(id, :vision, model_name: "mimo-v2.5-pro"))
+            .to be(false), "expected vision=false at #{url} for mimo-v2.5-pro"
+          expect(described_class.supports?(id, :vision, model_name: "mimo-v2.5"))
+            .to be(true), "expected vision=true at #{url} for mimo-v2.5"
         end
       end
     end


### PR DESCRIPTION
## What

Updates the MiMo (Xiaomi) provider preset to the current **V2.5** model lineup and recognises the **Token Plan** subscription endpoint via `endpoint_variants`.

## Why

Two correctness problems affected every MiMo user today:

1. **Dead model ids.** The MiMo-V2 family (`mimo-v2-pro` / `mimo-v2-omni`) was retired on **2026-06-30** and the ids are no longer accepted by the API. The preset still listed them as selectable models and pointed the OCR sidecar (`default_ocr_model`) at the dead `mimo-v2-omni`.
   - Source: https://platform.xiaomimimo.com/docs/zh-CN/model

2. **Token Plan endpoint = unknown provider.** Xiaomi serves the same V2.5 lineup from two billing endpoints. The preset only knew the pay-as-you-go API (`api.xiaomimimo.com`), so anyone on the **Token Plan** subscription endpoint (`token-plan-cn.xiaomimimo.com`) fell through `find_by_base_url` to "unknown provider". The conservative `vision=true` default then applied to **every** model — silently leaking image input into `mimo-v2.5-pro`, which is text-only and rejects images.

Both are fixed by mirroring the existing `endpoint_variants` pattern (already used by GLM, MiniMax, Volcengine Ark) and swapping the model lineup to V2.5.

## Impact

| Aspect | Change |
|--------|--------|
| Models list | `mimo-v2-pro`/`mimo-v2-omni` → `mimo-v2.5-pro`/`mimo-v2.5` |
| Vision matrix | `mimo-v2.5` (native omni-modal) declares `vision=true`; `mimo-v2.5-pro` stays `vision=false` |
| OCR sidecar | `default_ocr_model`: `mimo-v2-omni` → `mimo-v2.5` |
| Endpoint recognition | + `token-plan-cn.xiaomimimo.com` (Token Plan subscription) |
| **Default behaviour for existing PAYG users** | **Unchanged** — `api.xiaomimimo.com` keeps resolving to `mimo` exactly as before |

This is a **zero side-effects** change for pay-as-you-go users: the canonical `base_url` is untouched and the existing model (`mimo-v2.5-pro`) remains the default. The only new activation is for the Token Plan URL, which previously resolved to nothing.

## Verification

- `git apply --check` on a clean clone of `main` — passes.
- `ruby -c` on both modified files — syntax OK.
- `bundle exec rspec spec/clacky/providers_spec.rb` — **73 examples, 0 failures** (updated the existing mimo vision test + added a dedicated `MiMo two billing endpoints` block covering URL recognition and the vision matrix across both endpoints).
- `bundle exec rubocop` — no new offence categories introduced (`find_by_base_url` complexity unchanged).
- Full `spec/clacky/` suite: 2515 examples, 1 pre-existing WSL-environment failure unrelated to this change (fails identically with the patch stashed).

## Notes

- Follows the existing `endpoint_variants` convention (GLM/MiniMax/Ark) — no new abstraction, no new config knob, no new dependency.
- Model lineup per Xiaomi's official model page (linked above), which confirms the V2.5 capabilities: `mimo-v2.5-pro` = 1T-param text reasoning flagship; `mimo-v2.5` = native omni-modal (image/video/audio/text).

Authored using OpenClacky.
