### PR TITLE
feat(max_output): per-model max_tokens via Providers::MODEL_MAX_OUTPUT

### DIFF
--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -352,6 +352,16 @@ module Clacky
         vision_supported: Providers.supports?(@provider_id, :vision, model_name: cap_model),
         reasoning_effort: reasoning_effort
       )
+
+      # Override max_tokens with the model-specific output ceiling when one is
+      # declared in Providers::MODEL_MAX_OUTPUT. The global default (16384) is
+      # tuned for the lowest common denominator (GPT-4o); thinking-capable
+      # models with much larger output budgets need more room — especially since
+      # reasoning_content and the final answer share the same output quota.
+      # Models not in the table keep the default.
+      model_limit = Clacky::Providers.max_output_for(model)
+      body[:max_tokens] = model_limit if model_limit
+
       return send_openai_stream_request(body, on_chunk) if on_chunk
 
       response = openai_connection.post("chat/completions") { |r| r.body = body.to_json }

--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -963,6 +963,38 @@ module Clacky
         return true unless caps.key?(key)
         caps[key] != false
       end
+
+      # Per-model maximum output token limits.
+      #
+      # Different models support vastly different output ceilings (e.g. GLM-5.2
+      # supports 128K output, while DeepSeek/Kimi cap around 8-16K). The Agent
+      # global default (@max_tokens = 16384) is tuned for the lowest common
+      # denominator (GPT-4o). This table lets each model family declare its own
+      # practical output ceiling so strong models aren't artificially throttled.
+      #
+      # Entries are matched top-to-bottom against the model name; the first
+      # match wins. Models not listed here fall back to the global default.
+      #
+      # NOTE: thinking-mode models (GLM, Kimi, DeepSeek) share the output budget
+      # between reasoning_content and the final answer, so a generous value is
+      # needed to leave headroom for deep reasoning + complete output.
+      MODEL_MAX_OUTPUT = [
+        { pattern: /glm/i,        limit: 65_536 },  # GLM-5.2 supports 128K; 64K is ample headroom
+        { pattern: /kimi/i,       limit: 16_384 },  # Kimi K-series
+        { pattern: /deepseek/i,   limit: 16_384 }   # DeepSeek V-series
+      ].freeze
+
+      # Resolve the max output token limit for a given model name.
+      # Returns nil when no declaration matches — the caller should then fall
+      # back to the global default (@max_tokens).
+      #
+      # @param model_name [String] The model name (e.g. "glm-5.2")
+      # @return [Integer, nil] The max output limit, or nil if undeclared
+      def max_output_for(model_name)
+        return nil if model_name.nil? || model_name.to_s.empty?
+        entry = MODEL_MAX_OUTPUT.find { |e| model_name.to_s.match?(e[:pattern]) }
+        entry&.[](:limit)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

The global `@max_tokens` default (`16384`) in `AgentConfig` is tuned for GPT-4o's output ceiling. Thinking-capable models with much larger output budgets are artificially throttled — especially problematic when `reasoning_content` (the thinking trace) and the final answer **share the same output quota**.

| Model | Max Output | Current Default | Utilization |
|---|---|---|---|
| GPT-4o | 16,384 | 16,384 | 100% ✅ |
| GLM-5.2 | 128K (131,072) | 16,384 | **12.5%** ⚠️ |
| DeepSeek V3 | 8,192 | 16,384 | (server-truncated) |
| Kimi K1.5 | 8,192 | 16,384 | (server-truncated) |

For GLM-5.2 with thinking mode enabled, 16384 tokens often causes reasoning to be cut off mid-thought or long code outputs to be truncated.

## Solution

Add a per-model output ceiling table in `Providers` so each model family can declare its practical max output limit. `send_openai_request` queries this table and overrides `body[:max_tokens]` **only when a declaration exists**. Undeclared models keep the global default — **zero behavior change** for existing setups.

### Changes

**`providers.rb`** — Declaration layer:
```ruby
MODEL_MAX_OUTPUT = [
  { pattern: /glm/i,        limit: 65_536 },
  { pattern: /kimi/i,       limit: 16_384 },
  { pattern: /deepseek/i,   limit: 16_384 }
].freeze

def max_output_for(model_name)
  return nil if model_name.nil? || model_name.to_s.empty?
  entry = MODEL_MAX_OUTPUT.find { |e| model_name.to_s.match?(e[:pattern]) }
  entry&.[](:limit)
end
```

**`client.rb`** — Query layer (in `send_openai_request`):
```ruby
model_limit = Clacky::Providers.max_output_for(model)
body[:max_tokens] = model_limit if model_limit
```

## Design Decisions

- **Declarative, not hardcoded**: Model-specific logic lives in a data table, not scattered `if` branches — adding a new model is one line.
- **Backward compatible**: Returns `nil` for undeclared models → falls back to the existing global default.
- **Extensible**: The table pattern can be refined per model (e.g. `/glm-5/i` vs `/glm-4/i`) as needed.
- **Scope**: Currently applied to `send_openai_request` (OpenAI-compatible endpoint). Anthropic and Bedrock paths already receive appropriate max_tokens via `build_request_body`.

## Test Plan

- [x] `ruby -c` syntax validation on both files
- [x] Unit test: `max_output_for("glm-5.2")` → 65536, `"kimi-k3"` → 16384, `"gpt-4o"` → nil
- [x] E2E data flow: `build_request_body` sets default → `client` overrides → final `body[:max_tokens]` is correct per model
- [ ] Live request with GLM-5.2 + thinking mode: verify `max_tokens: 65536` in the actual API payload and no premature truncation
