### PR TITLE
feat(open_ai): support MiMo-V2.5 thinking mode and max_completion_tokens

### DIFF
--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -47,7 +47,9 @@ module Clacky
       def build_request_body(messages, model, tools, max_tokens, caching_enabled, vision_supported: true, reasoning_effort: nil)
         api_messages = messages.map { |msg| normalize_message_content(msg, vision_supported: vision_supported) }
 
-        body = { model: model, max_tokens: max_tokens, messages: api_messages }
+        # MiMo-V2.5 (Xiaomi) uses max_completion_tokens instead of max_tokens.
+        token_field = model.to_s.match?(/^mimo-v2/i) ? :max_completion_tokens : :max_tokens
+        body = { model: model, token_field => max_tokens, messages: api_messages }
 
         if tools&.any?
           if caching_enabled
@@ -101,6 +103,16 @@ module Clacky
               when "medium", "low" then "low"
               else                      "max"
               end
+          end
+        elsif model.to_s.match?(/^mimo-v2/i)
+          # MiMo-V2.5 (Xiaomi) controls reasoning via a top-level
+          # thinking:{type:...} field rather than reasoning_effort. Map the
+          # internal reasoning_effort value to thinking on/off so MiMo does
+          # not receive an unsupported parameter.
+          if %w[off nothink disabled].include?(effort_str)
+            body[:thinking] = { type: "disabled" }
+          elsif !effort_str.empty?
+            body[:thinking] = { type: "enabled" }
           end
         elsif reasoning_effort && !effort_str.empty?
           body[:reasoning_effort] = effort_str

--- a/spec/clacky/message_format_openai_spec.rb
+++ b/spec/clacky/message_format_openai_spec.rb
@@ -233,8 +233,60 @@ RSpec.describe Clacky::MessageFormat::OpenAI do
       end
     end
 
+    context "for MiMo-V2.5 models" do
+      let(:model) { "mimo-v2.5-pro" }
+
+      it "uses max_completion_tokens instead of max_tokens" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false
+        )
+        expect(body[:max_completion_tokens]).to eq(max_tokens)
+        expect(body).not_to have_key(:max_tokens)
+      end
+
+      it "maps reasoning_effort to thinking enabled" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "high"
+        )
+        expect(body[:thinking]).to eq({ type: "enabled" })
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+
+      it "maps reasoning_effort 'off' to thinking disabled" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "off"
+        )
+        expect(body[:thinking]).to eq({ type: "disabled" })
+      end
+
+      it "omits thinking when reasoning_effort is nil" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: nil
+        )
+        expect(body).not_to have_key(:thinking)
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+
+      it "works with the omni-modal variant mimo-v2.5" do
+        body = described_class.build_request_body(
+          messages, "mimo-v2.5", tools, max_tokens, false, reasoning_effort: "medium"
+        )
+        expect(body[:thinking]).to eq({ type: "enabled" })
+        expect(body[:max_completion_tokens]).to eq(max_tokens)
+      end
+    end
+
     context "for generic OpenAI-compatible models" do
       let(:model) { "deepseek-v4-pro" }
+
+      it "uses max_tokens (not max_completion_tokens)" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false
+        )
+        expect(body[:max_tokens]).to eq(max_tokens)
+        expect(body).not_to have_key(:max_completion_tokens)
+      end
+
 
       it "passes reasoning_effort through unchanged" do
         body = described_class.build_request_body(


### PR DESCRIPTION
## Problem

MiMo-V2.5 (Xiaomi) deviates from the OpenAI standard in two ways:

- Uses **`max_completion_tokens`** instead of `max_tokens`
- Controls reasoning via a top-level **`thinking:{type:...}`** field, not `reasoning_effort`

Without this, MiMo received an unsupported `reasoning_effort` parameter and used the wrong token-limit field.

## Solution

**Rebased onto the GLM/Kimi-K3/generic branch framework introduced in #395** (now merged), adding **MiMo as a fourth branch**.

### Branch chain (now complete)

| Model family | Token field | Reasoning field |
|---|---|---|
| `glm-[45]` | `max_tokens` | `thinking` + `reasoning_effort` (max/high) |
| `kimi-k3` | `max_tokens` | `reasoning_effort` (low/high/max) |
| **`mimo-v2`** *(this PR)* | **`max_completion_tokens`** | **`thinking` (enabled/disabled)** |
| other | `max_tokens` | `reasoning_effort` (passthrough) |

### Changes

| File | Change |
|------|--------|
| `lib/clacky/message_format/open_ai.rb` | +14/-1: `max_completion_tokens` for `/mimo-v2/i` + `thinking` MiMo branch |
| `spec/clacky/message_format_openai_spec.rb` | +52: 6 new tests covering `max_completion_tokens`, thinking on/off, nil, omni-modal variant |

## Testing

```
$ bundle exec rspec spec/clacky/message_format_openai_spec.rb
31 examples, 0 failures
```

**Zero side-effects**: when `reasoning_effort` is nil/empty the request body is unchanged for all models, preserving the provider default.

> **Rebased 2026-07-28**: This PR was rebuilt on top of #395 (merged) to avoid conflicts. The MiMo branch now slots cleanly into the four-way model dispatch.

Built with OpenClacky