### PR TITLE
feat(providers): add GLM-5.2 to preset lineup and pricing table

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -379,8 +379,8 @@ module Clacky
         "name" => "GLM (Z.ai / Zhipu)",
         "base_url" => "https://open.bigmodel.cn/api/paas/v4",
         "api" => "openai-completions",
-        "default_model" => "glm-5.1",
-        "models" => ["glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7"],
+        "default_model" => "glm-5.2",
+        "models" => ["glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7"],
         # Zhipu / Z.ai expose four functionally-equivalent endpoints:
         # two regional sites (mainland open.bigmodel.cn + international api.z.ai)
         # each with a general-billing and a Coding-Plan subpath. They share the

--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -472,6 +472,12 @@ module Clacky
       # endpoints don't charge separately for cache writes (Z.ai's page lists
       # "Cached Input Storage: Limited-time Free"), so bill writes at the
       # regular input miss rate for safe "displayed ≤ actual" behaviour.
+      "glm-5.2" => {
+        input:  { default: 1.40, over_200k: 1.40 },
+        output: { default: 4.40, over_200k: 4.40 },
+        cache:  { write: 1.40, read: 0.26 }
+      },
+
       "glm-5.1" => {
         input:  { default: 1.40, over_200k: 1.40 },
         output: { default: 4.40, over_200k: 4.40 },
@@ -786,6 +792,8 @@ module Clacky
         # (mainland bigmodel.cn vs intl z.ai) the user configured.
         # Strict anchored match so unrelated strings like "glm-5-x-foo"
         # don't silently borrow a nearby model's rate.
+        when /^glm-5\.2$/i
+          "glm-5.2"
         when /^glm-5\.1$/i
           "glm-5.1"
         when /^glm-5v-turbo$/i

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -453,6 +453,14 @@ RSpec.describe Clacky::ModelPricing do
   # regardless of mainland-vs-intl endpoint. Flat-rate (no tiered billing).
   # Source: https://docs.z.ai/guides/overview/pricing
   describe "GLM pricing" do
+    it "bills glm-5.2 at the Z.ai flat rate (same tier as glm-5.1)" do
+      usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
+      result = described_class.calculate_cost(model: "glm-5.2", usage: usage)
+      # (100_000/1M)*$1.4 + (50_000/1M)*$4.4 = 0.14 + 0.22 = $0.36
+      expect(result[:cost]).to be_within(0.0001).of(0.36)
+      expect(result[:source]).to eq(:price)
+    end
+
     it "bills glm-5.1 at the Z.ai flat rate" do
       usage = { prompt_tokens: 100_000, completion_tokens: 50_000 }
       result = described_class.calculate_cost(model: "glm-5.1", usage: usage)

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -291,6 +291,17 @@ RSpec.describe Clacky::Providers do
       end
     end
 
+    context "GLM-5.2 default model and lineup" do
+      it "resolves default model to glm-5.2" do
+        expect(described_class.default_model("glm")).to eq("glm-5.2")
+      end
+
+      it "includes glm-5.2 at the top of the model list" do
+        expect(described_class.models("glm")).to include("glm-5.2")
+        expect(described_class.models("glm").first).to eq("glm-5.2")
+      end
+    end
+
     context "Volcengine Ark (Doubao) three endpoints" do
       # Regression guard: Ark base_urls (Pay-as-you-go / Coding Plan / Agent
       # Plan) must resolve to the volcengine-ark preset so text-only models


### PR DESCRIPTION
## What

Adds GLM-5.2 — the latest flagship from Zhipu/Z.ai (released 2026-07), succeeding GLM-5.1 — to the preset lineup and pricing table.

## Why

GLM-5.2 is now the recommended model for the GLM provider, but openclacky's preset still defaults to `glm-5.1`. Users selecting GLM get an older model and `calculate_cost` returns `nil` for `glm-5.2` because the pricing table lacks an entry.

## Changes

**`lib/clacky/providers.rb`** — GLM preset:
- `default_model`: `glm-5.1` → `glm-5.2`
- `models`: prepend `"glm-5.2"` to the list

**`lib/clacky/utils/model_pricing.rb`**:
- Add `glm-5.2` pricing entry (same tier as `glm-5.1`: $1.40/$4.40/$0.26 per MTok)
- Add `glm-5.2` to `normalize_model_name` for strict matching

**Specs**: 3 new examples covering default model, model list, and pricing.

## Testing

```
bundle exec rspec spec/clacky/providers_spec.rb spec/clacky/model_pricing_spec.rb
# 128 examples, 0 failures
```

Built with OpenClacky