### PR TITLE
feat(open_ai): map reasoning_effort to GLM thinking mode and Kimi-K3 levels

### DIFF
--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -59,8 +59,51 @@ module Clacky
           end
         end
 
-        if reasoning_effort && !reasoning_effort.to_s.empty?
-          body[:reasoning_effort] = reasoning_effort.to_s
+        # ── Model-specific reasoning_effort / thinking mode mapping ────────
+        # Different model families expose extended reasoning through different
+        # API fields. We map the shared reasoning_effort setting to each
+        # family's native parameters.
+        #
+        # Zero side-effects: when reasoning_effort is nil/empty the request
+        # body is unchanged, preserving the provider default for all models.
+        effort_str = reasoning_effort.to_s
+
+        if model.to_s.match?(/^glm-[45]/i)
+          # GLM (Zhipu / Z.ai) supports a native top-level "thinking" field
+          # ({type: "enabled"|"disabled"}) plus a restricted reasoning_effort
+          # that only accepts "max" or "high". Other effort levels collapse
+          # to "high". Send both fields so GLM activates thinking correctly.
+          if %w[off nothink disabled].include?(effort_str)
+            body[:thinking] = { type: "disabled" }
+          elsif !effort_str.empty?
+            glm_effort =
+              case effort_str
+              when "max", "xhigh" then "max"
+              when "high"          then "high"
+              when "medium", "low" then "high"   # GLM collapses these to "high"
+              else                      "max"
+              end
+            body[:thinking] = { type: "enabled" }
+            body[:reasoning_effort] = glm_effort
+          end
+        elsif model.to_s.match?(/^kimi-k3/i)
+          # Kimi K3 reasoning_effort only accepts low/high/max (default max).
+          # Thinking is always enabled and cannot be turned off; "off" maps
+          # to the lowest intensity "low". Unsupported effort levels (medium,
+          # xhigh) would be rejected or ignored by the server.
+          if %w[off nothink disabled].include?(effort_str)
+            body[:reasoning_effort] = "low"
+          elsif !effort_str.empty?
+            body[:reasoning_effort] =
+              case effort_str
+              when "max", "xhigh"  then "max"
+              when "high"          then "high"
+              when "medium", "low" then "low"
+              else                      "max"
+              end
+          end
+        elsif reasoning_effort && !effort_str.empty?
+          body[:reasoning_effort] = effort_str
         end
 
         body

--- a/spec/clacky/message_format_openai_spec.rb
+++ b/spec/clacky/message_format_openai_spec.rb
@@ -150,6 +150,109 @@ RSpec.describe Clacky::MessageFormat::OpenAI do
     end
   end
 
+  describe ".build_request_body reasoning_effort mapping" do
+    let(:messages) { [{ role: "user", content: "Hi" }] }
+    let(:tools) { [] }
+    let(:max_tokens) { 1024 }
+
+    context "for GLM models" do
+      let(:model) { "glm-5.2" }
+
+      it "maps 'high' to thinking enabled + reasoning_effort high" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "high"
+        )
+        expect(body[:thinking]).to eq({ type: "enabled" })
+        expect(body[:reasoning_effort]).to eq("high")
+      end
+
+      it "maps 'max' to thinking enabled + reasoning_effort max" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "max"
+        )
+        expect(body[:thinking]).to eq({ type: "enabled" })
+        expect(body[:reasoning_effort]).to eq("max")
+      end
+
+      it "collapses 'medium' to thinking enabled + reasoning_effort high" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "medium"
+        )
+        expect(body[:thinking]).to eq({ type: "enabled" })
+        expect(body[:reasoning_effort]).to eq("high")
+      end
+
+      it "maps 'off' to thinking disabled without reasoning_effort" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "off"
+        )
+        expect(body[:thinking]).to eq({ type: "disabled" })
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+
+      it "adds no thinking or reasoning_effort when reasoning_effort is nil" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: nil
+        )
+        expect(body).not_to have_key(:thinking)
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+    end
+
+    context "for Kimi K3 models" do
+      let(:model) { "kimi-k3" }
+
+      it "maps 'high' to reasoning_effort high" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "high"
+        )
+        expect(body[:reasoning_effort]).to eq("high")
+        expect(body).not_to have_key(:thinking)
+      end
+
+      it "maps 'max' to reasoning_effort max" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "max"
+        )
+        expect(body[:reasoning_effort]).to eq("max")
+      end
+
+      it "maps 'off' to reasoning_effort low (cannot disable thinking)" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "off"
+        )
+        expect(body[:reasoning_effort]).to eq("low")
+      end
+
+      it "adds no reasoning_effort when reasoning_effort is nil" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: nil
+        )
+        expect(body).not_to have_key(:reasoning_effort)
+        expect(body).not_to have_key(:thinking)
+      end
+    end
+
+    context "for generic OpenAI-compatible models" do
+      let(:model) { "deepseek-v4-pro" }
+
+      it "passes reasoning_effort through unchanged" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "high"
+        )
+        expect(body[:reasoning_effort]).to eq("high")
+        expect(body).not_to have_key(:thinking)
+      end
+
+      it "adds no reasoning_effort when nil" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: nil
+        )
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+    end
+  end
+
   describe ".normalize_block" do
     it "returns nil for empty text blocks" do
       result = described_class.normalize_block(


### PR DESCRIPTION
## Problem

GLM (Zhipu/Z.ai) and Kimi-K3 expose extended reasoning through **different API fields** than the OpenAI-standard `reasoning_effort`:

- **GLM** uses a native top-level `thinking` field (`{type: "enabled"|"disabled"}`) and only accepts `reasoning_effort` values `"max"` or `"high"`
- **Kimi-K3** accepts `reasoning_effort` `low`/`high`/`max` (thinking cannot be disabled; `"off"` maps to the lowest intensity `"low"`)

Without this mapping, passing `reasoning_effort=medium` or `xhigh` to GLM or Kimi-K3 can cause the server to **reject or silently ignore** the request, leaving thinking in an undefined state.

## Solution

Add model-specific branches in `build_request_body` for `glm-[45]` and `kimi-k3`, falling through to the generic `reasoning_effort` passthrough for all other models.

### Mapping table

| Model | `reasoning_effort` input | `thinking` field | `reasoning_effort` sent |
|-------|--------------------------|-------------------|------------------------|
| `glm-[45]` | `max`, `xhigh` | `{type: "enabled"}` | `"max"` |
| `glm-[45]` | `high` | `{type: "enabled"}` | `"high"` |
| `glm-[45]` | `medium`, `low` | `{type: "enabled"}` | `"high"` (collapsed) |
| `glm-[45]` | `off`, `disabled` | `{type: "disabled"}` | *(omitted)* |
| `glm-[45]` | `nil` | *(omitted)* | *(omitted)* |
| `kimi-k3` | `max`, `xhigh` | *(omitted)* | `"max"` |
| `kimi-k3` | `high` | *(omitted)* | `"high"` |
| `kimi-k3` | `medium`, `low` | *(omitted)* | `"low"` |
| `kimi-k3` | `off`, `disabled` | *(omitted)* | `"low"` (cannot disable) |
| `kimi-k3` | `nil` | *(omitted)* | *(omitted)* |
| other | any non-nil | *(omitted)* | *(passthrough)* |

### Changes

| File | Change |
|------|--------|
| `lib/clacky/message_format/open_ai.rb` | +47/-2: model-specific reasoning_effort / thinking branches |
| `spec/clacky/message_format_openai_spec.rb` | +103: 11 new tests (GLM 5, Kimi-K3 4, generic 2) |

## Testing

```
$ bundle exec rspec spec/clacky/message_format_openai_spec.rb
25 examples, 0 failures
```

**Zero side-effects**: when `reasoning_effort` is `nil`/empty, the request body is unchanged for all models, preserving the provider default.

> **Note**: This PR touches the same method as PR #392 (MiMo thinking mode). The two PRs are compatible — once both are merged, the full chain is `glm-[45]` → `kimi-k3` → `mimo-v2` → generic passthrough.

Built with OpenClacky