### PR TITLE
fix(ext-studio): stop tagging extension-dev sessions as setup (C-5722)

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/api/handler.rb
+++ b/lib/clacky/default_extensions/ext-studio/api/handler.rb
@@ -362,7 +362,7 @@ class ExtStudioExt < Clacky::ApiExtension
   post "/develop" do
     idea = presence(json_body["idea"])
     name = idea ? "扩展开发: #{idea[0, 40]}" : "扩展开发"
-    sid  = create_session(name: name, prompt: idea, profile: "ext-developer", source: :setup)
+    sid  = create_session(name: name, prompt: idea, profile: "ext-developer")
     json(ok: true, session_id: sid)
   end
 


### PR DESCRIPTION
## Problem

Extension-development sessions in the session list showed **two** badges: "Setup" (配置) and "Extension Dev" (扩展开发). "Setup" is misleading here — an extension-dev session is not a configuration session, and the two badges together muddy the session type.

## Root cause

`create_session` in the ext-studio `POST /develop` handler was called with an explicit `source: :setup`:

```ruby
sid = create_session(name: name, prompt: idea, profile: "ext-developer", source: :setup)
```

The frontend renders a source badge whenever `s.source === "setup"` (`sessions.js:2186`). `setup` is the legitimate source for configuration flows — onboarding, channels, MCP, profile, skills — all of which start via `Sessions.startWith`, whose `source` defaults to `"setup"` (`sessions.js:2439`). So the "Setup" badge itself is correct for those flows and must stay.

The bug was only in this one place: the extension-dev session was mislabeled as a configuration session. Its identity should come entirely from the `ext-developer` agent profile, not from `setup`.

## Fix

Remove the explicit `source: :setup` from the ext-studio develop handler so the session uses `create_session`'s default `source: :manual` (`api_extension.rb:266`):

```ruby
sid = create_session(name: name, prompt: idea, profile: "ext-developer")
```

- `source: :manual` matches no source badge → the "Setup" badge disappears.
- The `ext-developer` profile still renders the "Extension Dev" badge independently.
- No frontend changes; onboarding / channels / MCP / profile / skills sessions keep their "Setup" badge — zero impact.

Single-line backend change, fixing the mislabeled data at the source rather than patching the badge renderer downstream.

## Tests

The ext-studio handler is a Sinatra-style extension DSL that depends on the runtime host context; the repo has no unit-test precedent for these handlers, and the change is a pure parameter removal (very low risk). Ran the full suite to confirm no collateral breakage: **2820 examples, 0 failures**.