### PR TITLE
fix(docker): build image from source and publish to GHCR on version tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.clacky
+vendor
+spec
+docs
+tmp
+coverage
+pkg
+*.gem
+.rspec_status
+AGENTS.md
+CLAUDE.md
+.deploy_access_key
+.deploy_access_key.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,3 @@ pkg
 .rspec_status
 AGENTS.md
 CLAUDE.md
-.deploy_access_key
-.deploy_access_key.*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,103 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Gem version to install (e.g. 1.5.3). Defaults to tag without v, or lib/clacky/version.rb."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: openclacky
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: meta
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(ruby -e 'print File.read("lib/clacky/version.rb")[/VERSION\s*=\s*"([^"]+)"/, 1]')"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "Unable to resolve VERSION" >&2
+            exit 1
+          fi
+          OWNER_LC="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER_LC}/${IMAGE_NAME}"
+          TAGS="${IMAGE}:${VERSION}"
+          # Only promote :latest for stable semver (no pre-release suffix)
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            TAGS="${TAGS},${IMAGE}:latest"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=${VERSION} image=${IMAGE}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          labels: |
+            org.opencontainers.image.title=openclacky
+            org.opencontainers.image.description=OpenClacky AI agent CLI and Web UI
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}"
+          docker pull "$IMAGE"
+          docker run -d --name openclacky-smoke \
+            -e CLACKY_ACCESS_KEY= \
+            -p 7070:7070 \
+            "$IMAGE"
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:7070/health | grep -q '"status"'; then
+              echo "Health check passed"
+              docker rm -f openclacky-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Health check failed" >&2
+          docker logs openclacky-smoke || true
+          docker rm -f openclacky-smoke || true
+          exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Gem version to install (e.g. 1.5.3). Defaults to tag without v, or lib/clacky/version.rb."
+        description: "Image version label/tag (e.g. 1.5.3). Defaults to tag without v, or lib/clacky/version.rb."
         required: false
         type: string
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,33 @@
 FROM ruby:3.4.4-slim AS builder
 
+ARG VERSION
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN gem install openclacky --no-document
+# Build from repository source so the image matches this checkout (not a published gem).
+# gemspec uses `git ls-files`; seed a temporary git index because .git is dockerignored.
+COPY . /src
+WORKDIR /src
+RUN git init \
+    && git config user.email "docker@local" \
+    && git config user.name "docker" \
+    && git add -A \
+    && git commit -m "docker build" \
+    && gem build openclacky.gemspec \
+    && gem install ./openclacky-*.gem --no-document \
+    && ruby -e 'require "clacky"; abort "bad version" unless Clacky::VERSION'
 
 FROM ruby:3.4.4-slim
+
+ARG VERSION
+LABEL org.opencontainers.image.title="openclacky" \
+      org.opencontainers.image.description="OpenClacky AI agent CLI and Web UI" \
+      org.opencontainers.image.source="https://github.com/clacky-ai/openclacky" \
+      org.opencontainers.image.version="${VERSION}"
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/README.md
+++ b/README.md
@@ -110,18 +110,24 @@ see more: https://www.openclacky.com/docs/installation
 
 ### Docker
 
-Build:
+#### Pre-built image (GHCR)
+
+Images are published to GitHub Container Registry on version tags (`v*`).
 
 ```bash
-git clone https://github.com/clacky-ai/openclacky.git
-cd openclacky
-docker build -t openclacky .
+# Replace <owner> with the repo owner (e.g. clacky-ai or your fork)
+docker pull ghcr.io/<owner>/openclacky:latest
+# or pin a release:
+# docker pull ghcr.io/<owner>/openclacky:1.5.3
 ```
 
 **Linux:**
 
 ```bash
-docker run -d --network=host -e CLACKY_ACCESS_KEY="" openclacky
+docker run -d --name openclacky --network=host \
+  -e CLACKY_ACCESS_KEY="" \
+  -v openclacky-data:/root/.clacky \
+  ghcr.io/<owner>/openclacky:latest
 ```
 
 `--network=host` is required so the agent inside the container can reach Chrome's remote debugging port running on the host.
@@ -129,18 +135,31 @@ docker run -d --network=host -e CLACKY_ACCESS_KEY="" openclacky
 **macOS / Windows:**
 
 ```bash
-docker run -d -p 7070:7070 -e CLACKY_ACCESS_KEY="" openclacky
+docker run -d --name openclacky -p 7070:7070 \
+  -e CLACKY_ACCESS_KEY="" \
+  -v openclacky-data:/root/.clacky \
+  ghcr.io/<owner>/openclacky:latest
 ```
 
 > **Note:** On macOS/Windows, `--network=host` is not supported — browser automation may be limited.
 
 Open **http://localhost:7070** after starting.
 
+#### Build from source
+
+```bash
+git clone https://github.com/clacky-ai/openclacky.git
+cd openclacky
+# optional: pin the published gem version
+docker build --build-arg VERSION=1.5.3 -t openclacky .
+docker run -d -p 7070:7070 -e CLACKY_ACCESS_KEY="" openclacky
+```
+
 Environment variables:
 
 | Variable | Description |
 |---|---|
-| `CLACKY_ACCESS_KEY` | Protect the Web UI with an access key (empty = public mode) |
+| `CLACKY_ACCESS_KEY` | Protect the Web UI with an access key (empty = public mode; env must be present when binding `0.0.0.0`) |
 
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Open **http://localhost:7070** after starting.
 ```bash
 git clone https://github.com/clacky-ai/openclacky.git
 cd openclacky
-# optional: pin the published gem version
+# optional: set the OCI image version label
 docker build --build-arg VERSION=1.5.3 -t openclacky .
 docker run -d -p 7070:7070 -e CLACKY_ACCESS_KEY="" openclacky
 ```


### PR DESCRIPTION
## Summary
Built with OpenClacky.

The current Dockerfile installs OpenClacky from RubyGems (`gem install openclacky`). That works for consumers of published gems, but **source / fork builds** produce an empty gem tree and the container fails at runtime with `cannot load such file -- clacky`.

This PR:

- Builds and installs the gem **from the checked-out tree** (with a temporary git index so `git ls-files` works under Docker’s `.dockerignore` of `.git`)
- Adds a small smoke `require "clacky"` after install
- Adds a GHCR workflow on `v*` tags / `workflow_dispatch` (owner-agnostic image path)
- Documents pre-built image + source build in the README

### Default behavior change
- Image contents track **this repository checkout**, not “latest gem on RubyGems”.
- `VERSION` / workflow input is an **OCI image version label/tag**, not a RubyGems pin.

### Test plan
- [x] Local / CI-style: `docker build` from source (or workflow on fork tags)
- [x] Container starts; `require "clacky"` smoke in build
- [ ] Official `v*` tag publish on merge (GHCR)
