### PR TITLE
feat(providers): refresh MiniMax preset with Anthropic endpoints, M3 thinking, and current lineup

### DIFF
--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -195,10 +195,16 @@ module Clacky
       # ── Private helpers ───────────────────────────────────────────────────────
 
       # Returns the token-limit field name for the given model.
-      # Most OpenAI-compatible APIs use :max_tokens; MiMo-V2.5 (Xiaomi) uses
-      # :max_completion_tokens to cap the combined thinking + answer length.
+      # Most OpenAI-compatible APIs use :max_tokens; MiMo-V2.5 (Xiaomi) and
+      # MiniMax-M3 use :max_completion_tokens to cap the combined thinking +
+      # answer length (M3 documents max_completion_tokens over the legacy
+      # max_tokens field).
       private_class_method def self.token_field_for(model)
-        model.to_s.match?(/^mimo-v2/i) ? :max_completion_tokens : :max_tokens
+        if model.to_s.match?(/^mimo-v2/i) || model.to_s.match?(/^minimax-m3$/i)
+          :max_completion_tokens
+        else
+          :max_tokens
+        end
       end
 
       # Apply model-specific reasoning / thinking parameters to the request body.
@@ -255,6 +261,23 @@ module Clacky
             body[:thinking] = { type: "disabled" }
           elsif !effort_str.empty?
             body[:thinking] = { type: "enabled" }
+          end
+        elsif model.to_s.match?(/^minimax-m3$/i)
+          # MiniMax-M3 controls thinking via a top-level "thinking" field with
+          # { type: "adaptive" | "disabled" } — the same envelope shape MiMo
+          # uses, but with MiniMax-specific values. Adaptive thinking is the
+          # server default when the field is omitted, so we only send the
+          # field to explicitly switch modes:
+          #   - reasoning_effort "off"/"disabled"  → thinking disabled
+          #     (M3 answers directly; M2.7 keeps thinking on regardless).
+          #   - any other effort                   → adaptive thinking (M3
+          #     decides per request); we let the server pick the intensity.
+          # M2.7 cannot disable thinking and ignores this field, so sending
+          # it is harmless for the rest of the MiniMax lineup.
+          if %w[off nothink disabled].include?(effort_str)
+            body[:thinking] = { type: "disabled" }
+          elsif !effort_str.empty?
+            body[:thinking] = { type: "adaptive" }
           end
         elsif reasoning_effort && !effort_str.empty?
           body[:reasoning_effort] = effort_str

--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -250,28 +250,35 @@ module Clacky
 
       "minimax" => {
         "name" => "Minimax",
-        "base_url" => "https://api.minimaxi.com/v1",
+        "base_url" => "https://api.minimax.io/v1",
         "api" => "openai-completions",
         "default_model" => "MiniMax-M3",
-        "models" => ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.5"],
+        "models" => ["MiniMax-M3", "MiniMax-M2.7"],
         # MiniMax operates two regional endpoints with identical APIs & model
-        # lineup — mainland China (.com) and international (.io). Listing both
-        # lets find_by_base_url identify either one as provider "minimax",
-        # so capability checks (vision=false) fire correctly regardless of
-        # which endpoint the user configured.
+        # lineup — international (.io) and mainland China (.com). Each region
+        # exposes both an OpenAI-compatible /v1 base URL and an
+        # Anthropic-compatible /anthropic base URL for the same models, so both
+        # URLs per region are listed. find_by_base_url matches any of them as
+        # provider "minimax", so capability checks (vision=false) fire
+        # correctly regardless of which endpoint the user configured.
         "endpoint_variants" => [
-          { "label" => "Mainland China", "label_key" => "settings.models.baseurl.variant.mainland_cn",    "base_url" => "https://api.minimaxi.com/v1", "region" => "cn"   }.freeze,
-          { "label" => "International",  "label_key" => "settings.models.baseurl.variant.international",  "base_url" => "https://api.minimax.io/v1",   "region" => "intl" }.freeze
+          { "label" => "International · OpenAI", "label_key" => "settings.models.baseurl.variant.international_openai", "base_url" => "https://api.minimax.io/v1",       "region" => "intl" }.freeze,
+          { "label" => "International · Anthropic", "label_key" => "settings.models.baseurl.variant.international_anthropic", "base_url" => "https://api.minimax.io/anthropic", "region" => "intl" }.freeze,
+          { "label" => "Mainland China · OpenAI", "label_key" => "settings.models.baseurl.variant.mainland_cn_openai", "base_url" => "https://api.minimaxi.com/v1",       "region" => "cn"   }.freeze,
+          { "label" => "Mainland China · Anthropic", "label_key" => "settings.models.baseurl.variant.mainland_cn_anthropic", "base_url" => "https://api.minimaxi.com/anthropic", "region" => "cn"   }.freeze
         ].freeze,
-        # MiniMax M2.x does not support multimodal/vision input on this endpoint.
-        # M3 (released 2026-06-01) is natively multimodal and accepts image
-        # input, so it overrides the provider-level vision=false below.
+        # MiniMax M2.7 is text-only on this endpoint. M3 (released 2026-06-01)
+        # is natively multimodal — it accepts both image and video input
+        # (OpenAI-style image_url / video_url content parts on the OpenAI
+        # endpoint, and native Anthropic image/video blocks on the /anthropic
+        # endpoint) — so it overrides the provider-level vision=false below.
+        # M3 exposes a 1,000,000-token context window (M2.7: 204,800).
         "capabilities" => { "vision" => false }.freeze,
         "model_capabilities" => {
           "MiniMax-M3" => { "vision" => true }.freeze
         }.freeze,
         "default_ocr_model" => "MiniMax-M3",
-        "website_url" => "https://www.minimaxi.com/user-center/basic-information/interface-key"
+        "website_url" => "https://platform.minimax.io/"
       }.freeze,
 
       "kimi" => {

--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -512,36 +512,36 @@ module Clacky
       },
 
       # MiniMax — USD per 1M tokens.
-      # Source: https://platform.minimaxi.com (Pay-as-You-Go).
-      # MiniMax pricing is identical across mainland (.com) and international
-      # (.io) endpoints, verified by the team. Same cache-write convention as
-      # DeepSeek/Kimi/GLM: bill writes at the input miss rate (OpenAI-compatible
-      # usage responses from MiniMax don't reliably carry a separate
-      # cache_creation_input_tokens field, so a distinct write rate would be
-      # dead code in practice).
-      # Note: providers.rb uses the capitalised "MiniMax-M2.x" model id, but
+      # Source: https://platform.minimax.io/docs/api-reference/api-overview
+      # (Pay-as-You-Go). MiniMax pricing is identical across the international
+      # (.io) and mainland China (.com) endpoints per the team's verification.
+      # Same cache-write convention as DeepSeek/Kimi/GLM: bill writes at the
+      # input miss rate (OpenAI-compatible usage responses from MiniMax don't
+      # reliably carry a separate cache_creation_input_tokens field, so a
+      # distinct write rate would be dead code in practice).
+      # Note: providers.rb uses the capitalised "MiniMax-M*" model id, but
       # the pricing table keys are lowercased to stay consistent with the
       # rest of this file; normalize_model_name() lowercases incoming model
       # names before lookup.
-      "minimax-m2.5" => {
-        input:  { default: 0.30, over_200k: 0.30 },
-        output: { default: 1.20, over_200k: 1.20 },
-        cache:  { write: 0.30, read: 0.03 }
-      },
 
-      # M3 (released 2026-06-01) is MiniMax's multimodal flagship. Official
-      # pricing is tiered by context length (≤512K vs 512K–1M); per the
-      # project's "displayed ≤ actual" convention we record only the lowest
-      # (≤512K) tier as a flat rate — the global TIERED_PRICING_THRESHOLD is
-      # 200K, so applying the 512K–1M rate to the 200K–512K band would over-
-      # charge. Listed at original (non-promotional) prices: input $0.60,
-      # output $2.40, cache read $0.12 per 1M tokens.
+      # M3 (released 2026-06-01) is MiniMax's multimodal flagship (image +
+      # video input, 1,000,000-token context window). Official pricing is
+      # tiered by context length (≤512K vs 512K–1M); per the project's
+      # "displayed ≤ actual" convention we record only the lowest (≤512K)
+      # tier as a flat rate — the global TIERED_PRICING_THRESHOLD is 200K,
+      # so applying the 512K–1M rate to the 200K–512K band would over-charge.
+      # Listed at original (non-promotional) prices: input $0.60, output
+      # $2.40, cache read $0.12 per 1M tokens; cache write is billed at the
+      # input miss rate.
       "minimax-m3" => {
         input:  { default: 0.60, over_200k: 0.60 },
         output: { default: 2.40, over_200k: 2.40 },
         cache:  { write: 0.60, read: 0.12 }
       },
 
+      # M2.7 — text-only model (204,800-token context window). Listed at
+      # original (non-promotional) prices: input $0.30, output $1.20, cache
+      # read $0.06 per 1M tokens; cache write billed at the input miss rate.
       "minimax-m2.7" => {
         input:  { default: 0.30, over_200k: 0.30 },
         output: { default: 1.20, over_200k: 1.20 },
@@ -804,12 +804,10 @@ module Clacky
           "glm-5"
         when /^glm-4\.7$/i
           "glm-4.7"
-        # MiniMax — model ids in providers.rb use capitalised "MiniMax-M2.x"
+        # MiniMax — model ids in providers.rb use capitalised "MiniMax-M*"
         # but we match case-insensitively and map to the lowercased table key.
         when /^minimax-m3$/i
           "minimax-m3"
-        when /^minimax-m2\.5$/i
-          "minimax-m2.5"
         when /^minimax-m2\.7$/i
           "minimax-m2.7"
 

--- a/spec/clacky/message_format_openai_spec.rb
+++ b/spec/clacky/message_format_openai_spec.rb
@@ -276,6 +276,49 @@ RSpec.describe Clacky::MessageFormat::OpenAI do
       end
     end
 
+    context "for MiniMax-M3 models" do
+      let(:model) { "MiniMax-M3" }
+
+      it "uses max_completion_tokens instead of max_tokens" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false
+        )
+        expect(body[:max_completion_tokens]).to eq(max_tokens)
+        expect(body).not_to have_key(:max_tokens)
+      end
+
+      it "maps a non-off reasoning_effort to adaptive thinking" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "high"
+        )
+        expect(body[:thinking]).to eq({ type: "adaptive" })
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+
+      it "maps reasoning_effort 'off' to thinking disabled" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: "off"
+        )
+        expect(body[:thinking]).to eq({ type: "disabled" })
+      end
+
+      it "omits thinking when reasoning_effort is nil (server default)" do
+        body = described_class.build_request_body(
+          messages, model, tools, max_tokens, false, reasoning_effort: nil
+        )
+        expect(body).not_to have_key(:thinking)
+        expect(body).not_to have_key(:reasoning_effort)
+      end
+
+      it "matches case-insensitively (lowercased id)" do
+        body = described_class.build_request_body(
+          messages, "minimax-m3", tools, max_tokens, false, reasoning_effort: "medium"
+        )
+        expect(body[:thinking]).to eq({ type: "adaptive" })
+        expect(body[:max_completion_tokens]).to eq(max_tokens)
+      end
+    end
+
     context "for generic OpenAI-compatible models" do
       let(:model) { "deepseek-v4-pro" }
 

--- a/spec/clacky/model_pricing_spec.rb
+++ b/spec/clacky/model_pricing_spec.rb
@@ -532,23 +532,21 @@ RSpec.describe Clacky::ModelPricing do
     end
   end
 
-  # MiniMax pricing — identical across mainland (.com) and international (.io)
-  # endpoints per the team's verification.
-  # Source: https://platform.minimaxi.com (Pay-as-You-Go)
+  # MiniMax pricing — identical across the international (.io) and mainland
+  # China (.com) endpoints per the team's verification.
+  # Source: https://platform.minimax.io/docs/api-reference/api-overview
+  # (Pay-as-You-Go)
   describe "MiniMax pricing" do
-    it "bills MiniMax-M2.5 with its distinct cache-read rate" do
-      usage = {
-        prompt_tokens: 100_000,
-        completion_tokens: 50_000,
-        cache_read_input_tokens: 20_000
-      }
-      result = described_class.calculate_cost(model: "MiniMax-M2.5", usage: usage)
-      # Regular input: (100_000 - 20_000) / 1M * $0.30  = $0.024
-      # Cache read:     20_000 / 1M * $0.03             = $0.0006
-      # Output:         50_000 / 1M * $1.20             = $0.06
-      # Total: $0.0846
-      expect(result[:cost]).to be_within(0.0001).of(0.0846)
-      expect(result[:source]).to eq(:price)
+    it "returns N/A for retired MiniMax models (M2.5 is no longer listed)" do
+      # MiniMax-M2.5 was removed from the lineup (only M3 and M2.7 remain in
+      # providers.rb), so it must fall through to nil cost instead of
+      # silently borrowing a neighbouring model's rate.
+      result = described_class.calculate_cost(
+        model: "MiniMax-M2.5",
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 0 }
+      )
+      expect(result[:cost]).to be_nil,   "expected N/A for MiniMax-M2.5, got #{result[:cost]}"
+      expect(result[:source]).to be_nil, "expected nil source for MiniMax-M2.5, got #{result[:source]}"
     end
 
     it "bills MiniMax-M2.7 with its higher cache-read rate" do
@@ -704,7 +702,7 @@ RSpec.describe Clacky::ModelPricing do
     end
 
     it "returns nil cost for unregistered MiniMax variants" do
-      %w[minimax-m2.5-highspeed m2-her minimax-abab6].each do |m|
+      %w[minimax-m2.5-highspeed minimax-m2.5 m2-her minimax-abab6].each do |m|
         result = described_class.calculate_cost(
           model: m,
           usage: { prompt_tokens: 1_000_000, completion_tokens: 0 }

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -391,22 +391,46 @@ RSpec.describe Clacky::Providers do
       end
     end
 
-    context "MiniMax two regional endpoints" do
-      it "recognises mainland (.com)" do
+    context "MiniMax regional endpoints" do
+      it "recognises mainland China OpenAI endpoint (.com)" do
         expect(described_class.find_by_base_url("https://api.minimaxi.com/v1"))
           .to eq("minimax")
       end
 
-      it "recognises international (.io)" do
+      it "recognises mainland China Anthropic endpoint (.com)" do
+        expect(described_class.find_by_base_url("https://api.minimaxi.com/anthropic"))
+          .to eq("minimax")
+      end
+
+      it "recognises international OpenAI endpoint (.io)" do
         expect(described_class.find_by_base_url("https://api.minimax.io/v1"))
           .to eq("minimax")
       end
 
-      it "enforces vision=false on both regional endpoints" do
-        ["https://api.minimaxi.com/v1", "https://api.minimax.io/v1"].each do |url|
+      it "recognises international Anthropic endpoint (.io)" do
+        expect(described_class.find_by_base_url("https://api.minimax.io/anthropic"))
+          .to eq("minimax")
+      end
+
+      it "enforces vision=false on every regional endpoint" do
+        [
+          "https://api.minimaxi.com/v1",
+          "https://api.minimaxi.com/anthropic",
+          "https://api.minimax.io/v1",
+          "https://api.minimax.io/anthropic"
+        ].each do |url|
           expect(described_class.supports?(described_class.find_by_base_url(url), :vision))
             .to be(false), "expected vision=false at #{url}"
         end
+      end
+
+      it "lists the current lineup (M3 + M2.7) and M3 overrides vision" do
+        preset = described_class::PRESETS["minimax"]
+        expect(preset["models"]).to eq(["MiniMax-M3", "MiniMax-M2.7"])
+        expect(described_class.supports?("minimax", :vision, model_name: "MiniMax-M3"))
+          .to be(true)
+        expect(described_class.supports?("minimax", :vision, model_name: "MiniMax-M2.7"))
+          .to be(false)
       end
     end
 


### PR DESCRIPTION
Reason: parameter-refresh — align the MiniMax preset with the current MiniMax-M3/MiniMax-M2.7 lineup, the global/CN Anthropic-compatible endpoints, M3 adaptive/disabled thinking, and the 1,000,000-token context declaration.

## Changes

**`lib/clacky/providers.rb`** — MiniMax preset:
- `base_url` → international OpenAI endpoint (`https://api.minimax.io/v1`).
- `endpoint_variants` now lists **four** URLs: the OpenAI-compatible `/v1` **and** the Anthropic-compatible `/anthropic` base URL for both the international (`.io`) and mainland China (`.com`) regions, so `find_by_base_url` recognises either transport as `minimax`.
- `models` trimmed to the current lineup: `MiniMax-M3`, `MiniMax-M2.7` (drops `MiniMax-M2.5`, which is no longer listed).
- `model_capabilities` keeps the `MiniMax-M3 → vision: true` override; comments now document that M3 accepts both image **and** video input on both transports, and that M3 exposes a 1,000,000-token context window (M2.7: 204,800).
- `website_url` → the international platform console.

**`lib/clacky/utils/model_pricing.rb`**:
- Removed the retired `minimax-m2.5` PRICING_TABLE entry and its `normalize_model_name` `when` branch; M2.5 now resolves to N/A cost.
- Reordered to `minimax-m3` then `minimax-m2.7`; updated source URL and comments to record M3's 1,000,000-token context window and image+video multimodal input alongside the existing flat ≤512K-tier list prices (input $0.60 / output $2.40 / cache read $0.12 for M3; input $0.30 / output $1.20 / cache read $0.06 for M2.7).

**`lib/clacky/message_format/open_ai.rb`**:
- `token_field_for` now returns `max_completion_tokens` for `MiniMax-M3` (the documented field for M3), in addition to MiMo.
- `apply_reasoning_params` adds a `MiniMax-M3` branch mapping the shared `reasoning_effort` to MiniMax's native `thinking: { type: "adaptive" | "disabled" }` envelope (adaptive is the server default, so the field is only sent to explicitly switch modes; M2.7 cannot disable thinking and ignores it).

## Tests

- `spec/clacky/providers_spec.rb`: covers all four regional/transport endpoints, `vision=false` on each, the current `["MiniMax-M3", "MiniMax-M2.7"]` lineup, and the per-model vision override.
- `spec/clacky/model_pricing_spec.rb`: M2.5 now returns N/A cost; added `minimax-m2.5` to the unregistered-variants guard.
- `spec/clacky/message_format_openai_spec.rb`: `MiniMax-M3` uses `max_completion_tokens`, maps a non-off effort to `thinking:{type:"adaptive"}`, `"off"` to `disabled`, omits the field on `nil`, and matches case-insensitively.

## Checks

- `ruby -c` clean on `lib/clacky/providers.rb`, `lib/clacky/utils/model_pricing.rb`, `lib/clacky/message_format/open_ai.rb`.
- `rspec spec/clacky/providers_spec.rb spec/clacky/model_pricing_spec.rb spec/clacky/message_format_openai_spec.rb spec/clacky/agent_config_spec.rb spec/clacky/agent/file_processing_spec.rb` — 279 examples, 0 failures.
- Full `rspec` suite — 2868 examples, 0 failures (the only previously-observed failure was a pre-existing, sandbox-environment `spec/clacky/tools/terminal_spec.rb` shell/IO timing case unrelated to this change).
