### PR TITLE
feat(session): add hidden flag to create_session

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -49,6 +49,7 @@ module Clacky
                 :latest_latency,  # Hash of latency metrics from the most recent LLM call (see Client#send_messages_with_tools)
                 :reasoning_effort
     attr_accessor :pinned
+    attr_accessor :hidden
     attr_accessor :channel_info
     attr_accessor :project_id
 
@@ -83,6 +84,7 @@ module Clacky
       @session_id = session_id
       @name = ""
       @pinned = false
+      @hidden = false
       @history = MessageHistory.new
       @todos = []  # Store todos in memory
       @iterations = 0

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -11,6 +11,7 @@ module Clacky
         @session_id = session_data[:session_id]
         @name = session_data[:name] || ""
         @pinned = session_data[:pinned] || false
+        @hidden = session_data[:hidden] || false
         @history = MessageHistory.new(session_data[:messages] || [])
         @todos = session_data[:todos] || []  # Restore todos from session
         @iterations = session_data.dig(:stats, :total_iterations) || 0
@@ -203,6 +204,7 @@ module Clacky
           session_id: @session_id,
           name: @name,
           pinned: @pinned,
+          hidden: @hidden,
           created_at: @created_at,
           updated_at: (updated_at || (preserve_updated_at && @persisted_updated_at) || Time.now.iso8601).then { |v| v.is_a?(String) ? v : v.iso8601 },
           working_dir: @working_dir,

--- a/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
+++ b/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
@@ -204,6 +204,10 @@ Response helpers: `json` / `text(str)` / `send_data(bytes, content_type:, filena
 - Drive sessions from the backend: `create_session(prompt:, profile:, …)`,
   `submit_task(session_id, prompt)`, `dispatch_to_session(session_id, prompt)` (runs a
   side task on a fork and returns its reply without touching the conversation).
+- `create_session(hidden: true)` creates a session the openclacky session list hides
+  and the 200-session cleanup skips - use it for dedicated extension sessions you
+  manage yourself. Still reachable by `session_id` via `submit_task` /
+  `dispatch_to_session` / `registry.with_session`; forking resets `hidden` to false.
 - Public (no-auth) endpoints: call `public_endpoint("/path")` in the class **and** set
   `public: true` at ext.yml top level — both are required.
 

--- a/lib/clacky/extension/api_extension.rb
+++ b/lib/clacky/extension/api_extension.rb
@@ -263,7 +263,7 @@ module Clacky
     # submitted immediately (the session starts running); display_message
     # controls the user-facing bubble shown in place of the raw prompt.
     def create_session(name: nil, prompt: nil, working_dir: nil, profile: "general",
-                       source: :manual, display_message: nil)
+                       source: :manual, display_message: nil, hidden: false)
       error!("server not ready", status: 503) unless @http_server
 
       session_id = @http_server.send(
@@ -271,7 +271,8 @@ module Clacky
         name: name,
         working_dir: working_dir,
         profile: profile,
-        source: source
+        source: source,
+        hidden: hidden
       )
 
       submit_task(session_id, prompt, display_message: display_message) if prompt && !prompt.strip.empty?

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -7009,7 +7009,7 @@ module Clacky
       # @param working_dir [String] working directory for the agent
       # @param permission_mode [Symbol] :confirm_all (default, human present) or
       #   :auto_approve (unattended — suppresses request_user_feedback waits)
-      def build_session(name:, working_dir: nil, permission_mode: :confirm_all, profile: "general", source: :manual, model_id: nil)
+      def build_session(name:, working_dir: nil, permission_mode: :confirm_all, profile: "general", source: :manual, model_id: nil, hidden: false)
         working_dir ||= default_working_dir
         FileUtils.mkdir_p(working_dir) unless Dir.exist?(working_dir)
         session_id = Clacky::SessionManager.generate_id
@@ -7048,6 +7048,7 @@ module Clacky
         agent = Clacky::Agent.new(client, config, working_dir: working_dir, ui: ui, profile: profile,
                                   session_id: session_id, source: source)
         agent.rename(name) unless name.nil? || name.empty?
+        agent.hidden = hidden
         idle_timer = build_idle_timer(session_id, agent)
 
         @registry.with_session(session_id) do |s|

--- a/lib/clacky/server/session_registry.rb
+++ b/lib/clacky/server/session_registry.rb
@@ -203,7 +203,7 @@ module Clacky
       #   [ ...all_pinned_matching (newest-first), ...non_pinned (newest-first, limited) ]
       #
       # source and profile are orthogonal — either can be nil independently.
-      def list(limit: nil, before: nil, q: nil, q_scope: "name", date: nil, type: nil, exclude_type: nil, include_pinned: true, project_id: nil, exclude_project: false)
+      def list(limit: nil, before: nil, q: nil, q_scope: "name", date: nil, type: nil, exclude_type: nil, include_pinned: true, project_id: nil, exclude_project: false, include_hidden: false)
         return [] unless @session_manager
 
         live = @mutex.synchronize do
@@ -226,6 +226,10 @@ module Clacky
         end
 
         all = @session_manager.all_sessions  # already sorted newest-first
+
+        # Hidden sessions (extension-managed) are excluded from the list by
+        # default; callers that need them pass include_hidden: true.
+        all = all.reject { |s| s[:hidden] } unless include_hidden
 
         # ── type filter (replaces old source/profile split) ──────────────────
         # type=coding  → agent_profile == "coding"

--- a/lib/clacky/session_manager.rb
+++ b/lib/clacky/session_manager.rb
@@ -64,6 +64,7 @@ module Clacky
       forked[:created_at]  = Time.now.iso8601
       forked[:updated_at]  = Time.now.iso8601
       forked[:pinned]      = false
+      forked[:hidden]      = false
       forked[:name]        = "#{original[:name] || "Unnamed session"} (copy)"
       forked[:stats] = (original[:stats] || {}).merge(
         total_tasks: 0, total_iterations: 0, total_cost_usd: 0.0,
@@ -328,12 +329,12 @@ module Clacky
       deleted
     end
 
-    # Keep only the most recent N non-pinned sessions by created_at; the rest
-    # are soft-deleted (moved to the session trash, recoverable). Pinned
-    # sessions are never deleted and do not count toward the cap.
+    # Keep only the most recent N non-pinned, non-hidden sessions by created_at;
+    # the rest are soft-deleted (moved to the session trash, recoverable). Pinned
+    # and hidden sessions are never deleted and do not count toward the cap.
     # Returns count of soft-deleted sessions.
     def cleanup_by_count(keep:, keep_cron: 200)
-      non_pinned = all_sessions.reject { |s| s[:pinned] } # already sorted newest-first
+      non_pinned = all_sessions.reject { |s| s[:pinned] || s[:hidden] } # already sorted newest-first
 
       cron, regular = non_pinned.partition { |s| s[:source].to_s == "cron" }
 

--- a/spec/clacky/server/session_registry_spec.rb
+++ b/spec/clacky/server/session_registry_spec.rb
@@ -12,7 +12,7 @@ require "clacky/server/session_registry"
 RSpec.describe Clacky::Server::SessionRegistry do
   let(:default_config) { Clacky::AgentConfig.new }
 
-  def write_session_file(dir, session_id:, name:, created_at:, pinned: false)
+  def write_session_file(dir, session_id:, name:, created_at:, pinned: false, hidden: false)
     data = {
       session_id:    session_id,
       name:          name,
@@ -22,6 +22,7 @@ RSpec.describe Clacky::Server::SessionRegistry do
       source:        "manual",
       agent_profile: "general",
       pinned:        pinned,
+      hidden:        hidden,
       messages:      [],
       stats:         { total_tasks: 0, total_cost_usd: 0.0 },
     }
@@ -299,6 +300,38 @@ RSpec.describe Clacky::Server::SessionRegistry do
         registry.instance_variable_get(:@sessions)["s1"] = { idle_timer: timer }
 
         expect { registry.shutdown_all_idle_timers }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#list hidden filtering" do
+    it "excludes hidden sessions by default" do
+      Dir.mktmpdir("clacky_hidden_spec") do |dir|
+        write_session_file(dir, session_id: "sess_visible", name: "v",
+                           created_at: "2026-04-01T00:00:00+00:00")
+        write_session_file(dir, session_id: "sess_hidden", name: "h",
+                           created_at: "2026-04-02T00:00:00+00:00", hidden: true)
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        ids = registry.list.map { |s| s[:id] }
+        expect(ids).to contain_exactly("sess_visible")
+      end
+    end
+
+    it "includes hidden sessions when include_hidden: true" do
+      Dir.mktmpdir("clacky_hidden_spec") do |dir|
+        write_session_file(dir, session_id: "sess_visible", name: "v",
+                           created_at: "2026-04-01T00:00:00+00:00")
+        write_session_file(dir, session_id: "sess_hidden", name: "h",
+                           created_at: "2026-04-02T00:00:00+00:00", hidden: true)
+
+        manager  = Clacky::SessionManager.new(sessions_dir: dir)
+        registry = described_class.new(session_manager: manager, agent_config: default_config)
+
+        ids = registry.list(include_hidden: true).map { |s| s[:id] }
+        expect(ids).to contain_exactly("sess_visible", "sess_hidden")
       end
     end
   end

--- a/spec/clacky/session_manager_cleanup_spec.rb
+++ b/spec/clacky/session_manager_cleanup_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe Clacky::SessionManager, "#cleanup_by_count" do
 
   # Write a session JSON directly so we control created_at / pinned without
   # triggering save's own cleanup pass.
-  def write_session(id:, created_at:, pinned: false)
+  def write_session(id:, created_at:, pinned: false, hidden: false)
     filename = manager.send(:generate_filename, id, created_at)
     data = {
       session_id: id,
       created_at: created_at,
       updated_at: created_at,
       pinned:     pinned,
+      hidden:     hidden,
       messages:   []
     }
     File.write(File.join(temp_dir, filename), JSON.generate(data))
@@ -63,6 +64,20 @@ RSpec.describe Clacky::SessionManager, "#cleanup_by_count" do
 
     expect(evicted).to eq(1)
     expect(active_ids).to contain_exactly("pin", "ccc", "ddd")
+    expect(trashed_ids).to contain_exactly("bbb")
+  end
+
+  it "never soft-deletes hidden sessions and does not count them toward the cap" do
+    write_session(id: "hid", hidden: true, created_at: "2026-01-01T00:00:00Z") # oldest, hidden
+    write_session(id: "bbb", created_at: "2026-02-01T00:00:00Z")
+    write_session(id: "ccc", created_at: "2026-03-01T00:00:00Z")
+    write_session(id: "ddd", created_at: "2026-04-01T00:00:00Z")
+
+    # keep=2 applies only to the 3 non-hidden sessions -> 1 oldest non-hidden evicted.
+    evicted = manager.cleanup_by_count(keep: 2)
+
+    expect(evicted).to eq(1)
+    expect(active_ids).to contain_exactly("hid", "ccc", "ddd")
     expect(trashed_ids).to contain_exactly("bbb")
   end
 


### PR DESCRIPTION
## feat: add hidden flag to create_session

### Background
Extension-created sessions (background tasks, scheduled jobs, etc.) often need to self-manage: stay out of the session list and survive automatic cleanup. Native openclacky never sets hidden and exposes no entry point.

### Changes
- Data layer: agent.rb + session_serializer.rb add hidden field (parallel to pinned, persisted)
- Creation path: api_extension#create_session + http_server#build_session thread hidden through
- Cleanup exemption: session_manager#cleanup_by_count skips hidden (same as pinned, does not count toward the 200-session limit)
- List filtering: session_registry#list gains include_hidden param (default false)
- fork resets hidden to false
- Knowledge base: ext-develop SKILL.md documents hidden usage
- Specs: cleanup skips hidden; list filters by default / includes on demand

### Tests
Full regression: 2911 examples, 0 failures