### PR TITLE
feat(write): add append mode to write tool

### DIFF
--- a/lib/clacky/tools/write.rb
+++ b/lib/clacky/tools/write.rb
@@ -16,12 +16,18 @@ module Clacky
           content: {
             type: "string",
             description: "The content to write to the file"
+          },
+          mode: {
+            type: "string",
+            enum: %w[overwrite append],
+            default: "overwrite",
+            description: "Write mode: 'overwrite' replaces entire file, 'append' adds to end"
           }
         },
         required: %w[path content]
       }
 
-      def execute(path:, content:, working_dir: nil)
+      def execute(path:, content:, mode: "overwrite", working_dir: nil)
         # Validate path
         if path.nil? || path.strip.empty?
           return { error: "Path cannot be empty" }
@@ -36,7 +42,11 @@ module Clacky
           FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
 
           # Write content to file
-          File.write(path, content)
+          if mode == "append"
+            File.open(path, "a") { |f| f.write(content) }
+          else
+            File.write(path, content)
+          end
 
           {
             path: File.expand_path(path),

--- a/spec/clacky/tools/write_spec.rb
+++ b/spec/clacky/tools/write_spec.rb
@@ -56,6 +56,73 @@ RSpec.describe Clacky::Tools::Write do
 
       expect(result[:error]).to include("cannot be empty")
     end
+
+    context "with mode: append" do
+      it "appends to existing file" do
+        Dir.mktmpdir do |dir|
+          file_path = File.join(dir, "test.txt")
+          File.write(file_path, "line1\n")
+
+          result = tool.execute(path: file_path, content: "line2\n", mode: "append")
+
+          expect(result[:error]).to be_nil
+          expect(result[:bytes_written]).to eq(6)
+          expect(File.read(file_path)).to eq("line1\nline2\n")
+        end
+      end
+
+      it "creates file if it does not exist" do
+        Dir.mktmpdir do |dir|
+          file_path = File.join(dir, "new.txt")
+
+          result = tool.execute(path: file_path, content: "hello\n", mode: "append")
+
+          expect(result[:error]).to be_nil
+          expect(File.read(file_path)).to eq("hello\n")
+        end
+      end
+
+      it "appends multiple times" do
+        Dir.mktmpdir do |dir|
+          file_path = File.join(dir, "log.txt")
+
+          tool.execute(path: file_path, content: "a\n", mode: "append")
+          tool.execute(path: file_path, content: "b\n", mode: "append")
+          result = tool.execute(path: file_path, content: "c\n", mode: "append")
+
+          expect(result[:error]).to be_nil
+          expect(File.read(file_path)).to eq("a\nb\nc\n")
+        end
+      end
+    end
+
+    context "with mode: overwrite" do
+      it "replaces existing content" do
+        Dir.mktmpdir do |dir|
+          file_path = File.join(dir, "test.txt")
+          File.write(file_path, "old")
+
+          result = tool.execute(path: file_path, content: "new", mode: "overwrite")
+
+          expect(result[:error]).to be_nil
+          expect(File.read(file_path)).to eq("new")
+        end
+      end
+    end
+
+    context "with default mode" do
+      it "defaults to overwrite" do
+        Dir.mktmpdir do |dir|
+          file_path = File.join(dir, "test.txt")
+          File.write(file_path, "old")
+
+          result = tool.execute(path: file_path, content: "new")
+
+          expect(result[:error]).to be_nil
+          expect(File.read(file_path)).to eq("new")
+        end
+      end
+    end
   end
 
   describe "#to_function_definition" do
@@ -67,6 +134,14 @@ RSpec.describe Clacky::Tools::Write do
       expect(definition[:function][:description]).to be_a(String)
       expect(definition[:function][:parameters][:required]).to include("path")
       expect(definition[:function][:parameters][:required]).to include("content")
+    end
+
+    it "includes mode parameter" do
+      definition = tool.to_function_definition
+
+      props = definition[:function][:parameters][:properties]
+      expect(props[:mode][:enum]).to eq(%w[overwrite append])
+      expect(props[:mode][:default]).to eq("overwrite")
     end
   end
 end


### PR DESCRIPTION
## What
Add optional `mode` parameter to `write` tool with `overwrite` (default, unchanged) and `append` options.

## Why
Appending to long files (logs, CSVs, markdown) currently requires read+write cycle, wasting tokens and risking data loss. `File.open(path, "a")` provides atomic append without reading existing content.

## Changes
- `lib/clacky/tools/write.rb`: add `mode` parameter, branch to `File.open(path, "a")` for append
- `spec/clacky/tools/write_spec.rb`: add 5 new tests covering append, overwrite, and default behavior

## Impact
- Fully backward compatible (default remains `overwrite`)
- No new dependencies
- No configuration changes

## Testing
All 12 tests pass (7 existing + 5 new).

Authored using OpenClacky itself.