### PR TITLE
feat(terminal): smart truncation keeps head+tail of long output

### DIFF
--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -480,9 +480,7 @@ module Clacky
           # leaves the result as invalid UTF-8. Re-scrub after truncation so
           # everything downstream (JSON.generate, format_result, UI) gets a
           # guaranteed-valid UTF-8 string.
-          preview = cleaned.byteslice(0, OVERFLOW_PREVIEW_CHARS)
-          preview.force_encoding(Encoding::UTF_8)
-          preview = preview.scrub("?") unless preview.valid_encoding?
+          preview = smart_truncate(cleaned, OVERFLOW_PREVIEW_CHARS)
 
           notice = if overflow_file
             "\n\n...[Output truncated for LLM: showing first #{OVERFLOW_PREVIEW_CHARS} " \
@@ -1427,6 +1425,35 @@ module Clacky
         path
       rescue StandardError
         nil
+      end
+
+      # Smart truncation: keep head + tail within char budget.
+      # Ensures error messages at end of output remain visible.
+      private def smart_truncate(text, max_chars)
+        total_chars = text.bytesize
+        return text if total_chars <= max_chars
+
+        total_lines = text.lines.count
+
+        # 60% head, 40% tail
+        head_budget = (max_chars * 0.6).to_i
+        tail_budget = max_chars - head_budget
+
+        head = text.byteslice(0, head_budget)
+        head.force_encoding(Encoding::UTF_8)
+        head = head.scrub("?") unless head.valid_encoding?
+
+        tail = text.byteslice(-tail_budget, tail_budget)
+        tail.force_encoding(Encoding::UTF_8)
+        tail = tail.scrub("?") unless tail.valid_encoding?
+
+        # Align tail to line boundary if cut mid-line
+        if tail.include?("\n") && !tail.start_with?("\n")
+          first_nl = tail.index("\n")
+          tail = tail[(first_nl + 1)..-1] || ""
+        end
+
+        "#{head}\n\n...[#{total_lines} lines, #{total_chars} chars total, truncated]...\n\n#{tail}"
       end
 
 

--- a/spec/clacky/tools/terminal_spec.rb
+++ b/spec/clacky/tools/terminal_spec.rb
@@ -685,6 +685,14 @@ RSpec.describe Clacky::Tools::Terminal do
       # And must disclose the overflow path in a way the LLM can parse.
       expect(result[:output]).to include(result[:full_output_file])
       expect(result[:output]).to include("grep")
+
+      # Smart truncation: the in-context output must include BOTH the head
+      # (first lines) and the tail (last lines, e.g. error summaries),
+      # separated by a "...[truncated]..." marker. Previously only the
+      # head was shown, hiding errors that appear at the end of output.
+      expect(result[:output]).to include("payload-line-number-1\n")
+      expect(result[:output]).to include("payload-line-number-#{n_lines}")
+      expect(result[:output]).to match(/\.\.\.\[\d+ lines, \d+ chars total, truncated\]\.\.\./)
     ensure
       File.delete(result[:full_output_file]) if result && result[:full_output_file] && File.exist?(result[:full_output_file])
     end
@@ -737,6 +745,65 @@ RSpec.describe Clacky::Tools::Terminal do
     it "returns nil/empty inputs unchanged" do
       expect(tool.send(:truncate_long_lines, nil)).to be_nil
       expect(tool.send(:truncate_long_lines, "")).to eq("")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # smart_truncate: head+tail truncation keeps error messages visible.
+  # ---------------------------------------------------------------------------
+  describe "#smart_truncate" do
+    it "returns short text unchanged" do
+      text = "line1\nline2\nline3\n"
+      expect(tool.send(:smart_truncate, text, 100)).to eq(text)
+    end
+
+    it "returns empty string unchanged" do
+      expect(tool.send(:smart_truncate, "", 100)).to eq("")
+    end
+
+    it "includes both head and tail when truncating" do
+      # 100 lines × 20 chars = 2000 bytes
+      text = (1..100).map { |i| "line-#{i.to_s.rjust(3, '0')}-padding" }.join("\n")
+      result = tool.send(:smart_truncate, text, 400)
+      expect(result).to include("line-001")
+      expect(result).to include("line-100")
+      expect(result).to match(/\.\.\.\[100 lines, \d+ chars total, truncated\]\.\.\./)
+    end
+
+    it "stays within the char budget (plus marker overhead)" do
+      text = (1..500).map { |i| "payload-line-number-#{i}" }.join("\n")
+      result = tool.send(:smart_truncate, text, 3800)
+      # marker adds ~60 chars; allow small slack
+      expect(result.bytesize).to be <= 3800 + 100
+    end
+
+    it "handles multi-byte UTF-8 without invalid encoding" do
+      # Mix ASCII and 3-byte UTF-8 (e.g. CJK)
+      text = (1..200).map { |i| "行#{i}-数据填充ABCDEFGHIJ" }.join("\n")
+      result = tool.send(:smart_truncate, text, 1000)
+      expect(result.valid_encoding?).to eq(true)
+      expect(result).to include("行1")
+      expect(result).to include("行200")
+    end
+
+    it "aligns tail to line boundary when cut mid-line" do
+      text = (1..100).map { |i| "line-#{i.to_s.rjust(3, '0')}" }.join("\n")
+      result = tool.send(:smart_truncate, text, 400)
+      # The tail portion after the marker should start at a line boundary
+      # (i.e., the character after the marker's "\n\n" should be the start
+      # of a line, not a fragment).
+      marker = result.match(/\.\.\.\[\d+ lines, \d+ chars total, truncated\]\.\.\.\n\n/)
+      expect(marker).not_to be_nil
+      after_marker = marker.post_match
+      # after_marker should start with a full line like "line-XXX" or similar
+      expect(after_marker).to match(/\Aline-\d/)
+    end
+
+    it "handles single very long line (no newlines) gracefully" do
+      text = "x" * 10_000
+      result = tool.send(:smart_truncate, text, 1000)
+      expect(result.bytesize).to be <= 1000 + 100
+      expect(result).to include("truncated")
     end
   end
 


### PR DESCRIPTION
## What
Replace single-head truncation with head+tail smart truncation for long terminal output.

## Why
Previously only the first 3800 chars were shown, hiding error messages at the end (e.g. gem install failures, npm errors, docker build errors). The LLM sees the tail and can diagnose issues without a follow-up grep call.

## Changes
- `lib/clacky/tools/terminal.rb`: add `smart_truncate` private method (60% head / 40% tail char budget, UTF-8 safe, tail aligned to line boundary)
- `spec/clacky/tools/terminal_spec.rb`: add 6 new tests for smart_truncate + 1 assertion in overflow test verifying tail content is in-context

## Impact
- Fully backward compatible (same MAX_LLM_OUTPUT_CHARS budget)
- No new dependencies
- Sidecar file still contains full output; only the in-context preview changes

## Testing
All 112 tests pass (1 pre-existing raw-mode python failure unrelated to this change).

Authored using OpenClacky itself.