### PR TITLE
fix(spec): stub ExtensionLoader.load_all in panel visibility spec

### DIFF
--- a/spec/clacky/server/http_server_panel_visibility_spec.rb
+++ b/spec/clacky/server/http_server_panel_visibility_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Clacky::Server::HttpServer, "extension panel visibility" do
   after do
     [builtin, installed, local].each { |d| FileUtils.remove_entry(d) if Dir.exist?(d) }
     Clacky::ExtensionLoader.instance_variable_set(:@last_result, nil)
+    Clacky::ExtensionLoader.instance_variable_set(:@last_fingerprint, nil)
   end
 
   def make_ext(root, ext_id, manifest, files = {})
@@ -35,10 +36,16 @@ RSpec.describe Clacky::Server::HttpServer, "extension panel visibility" do
     end
   end
 
+  # Load the test fixture layers and pin the result so that the implementation's
+  # internal `ExtensionLoader.load_all` (called without args from panel_agents_map)
+  # doesn't blow away our test fixtures by rescanning the real default layers.
   def reload_layers
-    Clacky::ExtensionLoader.load_all(
-      layers: { builtin: builtin, installed: installed, local: local }
+    result = Clacky::ExtensionLoader.load_all(
+      layers: { builtin: builtin, installed: installed, local: local },
+      force: true
     )
+    allow(Clacky::ExtensionLoader).to receive(:load_all).and_return(result)
+    result
   end
 
   def stub_agent_profiles(map)


### PR DESCRIPTION
## Problem

Commit 0c5a216e added a bare `Clacky::ExtensionLoader.load_all` call inside `panel_agents_map` to force a fresh scan. In the spec, however, `reload_layers` loads test fixture layers into `@last_result`, and the subsequent internal `load_all` (with no args) rescans the real default layers and overwrites `@last_result` with an empty result, causing the two attach-related examples to fail with an empty agent list.

## Fix

- Force-load the fixture layers in `reload_layers` (`force: true`), then stub `Clacky::ExtensionLoader.load_all` to return that pinned result so subsequent internal calls don't blow away the fixtures.
- Also clear `@last_fingerprint` in after hook for completeness.

## Verification

```
bundle exec rspec spec/clacky/server/http_server_panel_visibility_spec.rb
# => 5 examples, 0 failures
```

Refs: PR #406 CI failure on Ruby 4.0.5.