### PR TITLE
fix(tools): flatten nested task arrays in TodoManager add

### DIFF
--- a/lib/clacky/tools/todo_manager.rb
+++ b/lib/clacky/tools/todo_manager.rb
@@ -135,8 +135,12 @@ module Clacky
       end
 
       def add_todos(tasks_input)
-        # tasks_input is already a normalized array (possibly empty)
+        # tasks_input is already a normalized array (possibly empty).
+        # Flatten guards against nested arrays (e.g. [["a","b"]]) that some
+        # models emit — without this the inner array would be stringified into
+        # a single bogus task whose text looks like ["a","b"].
         tasks_to_add = Array(tasks_input)
+                       .flatten
                        .map { |t| t.is_a?(String) ? t.strip : t.to_s.strip }
                        .reject(&:empty?)
 

--- a/spec/clacky/tools/todo_manager_spec.rb
+++ b/spec/clacky/tools/todo_manager_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe Clacky::Tools::TodoManager do
         expect(result[:todos][1][:task]).to eq("Task 2")
       end
 
+      it "flattens a nested task array into individual todos" do
+        # Regression: some models emit task as a nested array
+        # (e.g. [["a","b"]]); without flattening the inner array was
+        # stringified into one bogus task whose text looks like ["a","b"].
+        storage = []
+        result = tool.execute(
+          action: "add",
+          task: [["Task A", "Task B", "Task C"]],
+          todos_storage: storage
+        )
+
+        expect(result[:todos].size).to eq(3)
+        expect(result[:todos].map { |t| t[:task] }).to eq(["Task A", "Task B", "Task C"])
+        expect(storage.size).to eq(3)
+      end
+
       it "tolerates unknown extra keyword args (e.g. legacy clients)" do
         storage = []
         # **_extra should swallow these without raising


### PR DESCRIPTION
## Problem

When the agent model emits the `task` argument as a **nested array** (e.g. `task: [["Task 1", "Task 2", "Task 3"]]` — an array wrapped inside an array), `TodoManager#add_todos` stringifies the inner array into a single bogus todo whose text looks like `["Task 1", "Task 2", "Task 3"]`.

The result in the WebUI todo panel:

```
#1 ["Task 1", "Task 2", "Task 3", "Task 4"]   o
```

Three (or four) real tasks collapse into **one** garbled todo, and the todo panel renders as a single line instead of a proper task list.

## Root cause

`add_todos` normalizes input with `Array(tasks_input)` but does **not** flatten. `Array([["a","b"]])` keeps the nesting, so the inner `["a","b"]` is passed through `.to_s` and becomes the literal string `'["a","b"]'`:

```ruby
tasks_to_add = Array(tasks_input)               # [["a","b"]] stays nested
               .map { |t| t.is_a?(String) ? t.strip : t.to_s.strip }  # -> ['["a","b"]']
               .reject(&:empty?)
```

Some models (observed with GLM-5.2) occasionally wrap a batch of tasks in an extra set of brackets when constructing the tool-call JSON. The tool layer should be robust to this.

## Fix

Add `.flatten` after `Array(tasks_input)`:

```ruby
tasks_to_add = Array(tasks_input)
               .flatten                                    # NEW: unpack nested arrays
               .map { |t| t.is_a?(String) ? t.strip : t.to_s.strip }
               .reject(&:empty?)
```

This is a **no-op** for all already-supported cases:
- single string -> `Array("x").flatten == ["x"]`
- flat array -> `Array(["a","b"]).flatten == ["a","b"]`

## Verification

```console
$ bundle exec rspec spec/clacky/tools/todo_manager_spec.rb
45 examples, 0 failures
```

Added a regression test (`flattens a nested task array into individual todos`) that fails on `main` and passes with this patch.