### PR TITLE
feat(web): add in-thread navigation rail for quick message jumping

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2584,17 +2584,20 @@ body {
   width: 18px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start; /* center would clip overflow on long chats */
   gap: 6px;
   padding: 24px 0;
   z-index: 30;
-  pointer-events: none; /* dashes re-enable on a per-item basis */
+  overflow-y: auto;            /* scroll when dashes exceed the column height */
+  pointer-events: auto;        /* allow the rail itself to receive scroll */
+  scrollbar-width: none;       /* hide scrollbar (Firefox) */
   background: linear-gradient(to right,
               var(--color-bg-primary, #fff) 0%,
               transparent 100%);
   opacity: 0.65;
   transition: opacity 0.15s ease;
 }
+.thread-nav::-webkit-scrollbar { display: none; } /* hide scrollbar (Chrome/Safari) */
 .thread-nav:hover { opacity: 1; }
 .thread-nav.thread-nav-empty,
 .thread-nav.thread-nav-hidden { display: none; }
@@ -2628,8 +2631,8 @@ body {
   left: 22px;
   top: 50%;
   transform: translateY(-50%) translateX(-4px);
-  min-width: 220px;
-  max-width: 320px;
+  min-width: 180px;
+  max-width: min(320px, calc(100vw - 44px));
   padding: 10px 12px;
   border-radius: 8px;
   background: var(--color-bg-secondary, #ffffff);

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2584,12 +2584,12 @@ body {
   width: 18px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* center would clip overflow on long chats */
+  justify-content: flex-start; /* top-aligned so scroll reaches the last dash */
   gap: 6px;
   padding: 24px 0;
   z-index: 30;
   overflow-y: auto;            /* scroll when dashes exceed the column height */
-  pointer-events: auto;        /* allow the rail itself to receive scroll */
+  pointer-events: auto;        /* rail must capture wheel events to scroll */
   scrollbar-width: none;       /* hide scrollbar (Firefox) */
   background: linear-gradient(to right,
               var(--color-bg-primary, #fff) 0%,
@@ -2605,6 +2605,7 @@ body {
 .thread-nav-item {
   position: relative;
   height: 10px;
+  flex-shrink: 0;               /* keep fixed height; let overflow-y scroll */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2625,14 +2626,16 @@ body {
   background: var(--color-accent, #6366f1);
 }
 
-/* Preview card — hidden by default, slides in on hover. */
-.thread-nav-card {
-  position: absolute;
-  left: 22px;
-  top: 50%;
+/* Preview card — rendered as a global portal (#thread-nav-tooltip) so it
+   is never clipped by the rail's overflow. JS sets left/top + toggles
+   .visible on mouseenter/leave. */
+#thread-nav-tooltip.thread-nav-card {
+  position: fixed;
   transform: translateY(-50%) translateX(-4px);
   min-width: 180px;
   max-width: min(320px, calc(100vw - 44px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
   padding: 10px 12px;
   border-radius: 8px;
   background: var(--color-bg-secondary, #ffffff);
@@ -2641,15 +2644,14 @@ body {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease, transform 0.12s ease;
-  z-index: 40;
+  z-index: 9999;
   font-size: 12px;
   line-height: 1.45;
   color: var(--color-text-primary, #111827);
 }
-.thread-nav-item:hover .thread-nav-card {
+#thread-nav-tooltip.thread-nav-card.visible {
   opacity: 1;
   transform: translateY(-50%) translateX(0);
-  pointer-events: auto;
 }
 
 .thread-nav-q {

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2568,6 +2568,107 @@ body {
 #chat-panel { flex: 1; display: flex; flex-direction: row; overflow: hidden; position: relative; }
 #chat-main { flex: 1; display: flex; flex-direction: column; overflow: hidden; position: relative; min-width: 0; }
 
+/* ── In-thread navigation rail ─────────────────────────────────────────────
+   A slim vertical strip of dash markers pinned to the left edge of the chat
+   column. One dash per user turn; hovering reveals a preview card with the
+   question and the first lines of the AI reply. Clicking a dash scrolls
+   the corresponding message into view.
+
+   Purely presentational — the rail renders itself from the DOM and hides
+   when there is nothing to show (.thread-nav-empty / .thread-nav-hidden). */
+.thread-nav {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  padding: 24px 0;
+  z-index: 30;
+  pointer-events: none; /* dashes re-enable on a per-item basis */
+  background: linear-gradient(to right,
+              var(--color-bg-primary, #fff) 0%,
+              transparent 100%);
+  opacity: 0.65;
+  transition: opacity 0.15s ease;
+}
+.thread-nav:hover { opacity: 1; }
+.thread-nav.thread-nav-empty,
+.thread-nav.thread-nav-hidden { display: none; }
+
+.thread-nav-item {
+  position: relative;
+  height: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.thread-nav-dash {
+  width: 6px;
+  height: 1px;
+  border-radius: 0.5px;
+  background: var(--color-text-tertiary, #9ca3af);
+  transition: width 0.12s ease, background 0.12s ease;
+}
+.thread-nav-item:hover .thread-nav-dash,
+.thread-nav-item.thread-nav-active .thread-nav-dash {
+  width: 10px;
+  background: var(--color-accent, #6366f1);
+}
+
+/* Preview card — hidden by default, slides in on hover. */
+.thread-nav-card {
+  position: absolute;
+  left: 22px;
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  min-width: 220px;
+  max-width: 320px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--color-bg-secondary, #ffffff);
+  border: 1px solid var(--color-border-primary, #e5e7eb);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  z-index: 40;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--color-text-primary, #111827);
+}
+.thread-nav-item:hover .thread-nav-card {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+  pointer-events: auto;
+}
+
+.thread-nav-q {
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--color-text-primary, #111827);
+  word-break: break-word;
+}
+.thread-nav-a {
+  color: var(--color-text-secondary, #4b5563);
+  margin-bottom: 4px;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.thread-nav-time {
+  font-size: 11px;
+  color: var(--color-text-tertiary, #9ca3af);
+}
+
 /* ── Session extension slots (agent-scoped panels mount here) ───────────────
    Each slot is laid out by the host; an empty slot collapses to zero so it
    never reserves space when no panel is mounted for the current agent. */
@@ -2793,7 +2894,7 @@ body {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 1.75rem 1.25rem 1.25rem;
+  padding: 1.75rem 1.25rem 1.25rem 22px;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -88,6 +88,7 @@ const I18n = (() => {
       "chat.interrupted":    "Interrupted.",
       "chat.feedback_hint":  "Or type your own answer below ↓",
       "chat.newMessageHint": "New messages ↓",
+      "threadNav.aria":          "Thread navigation",
       "chat.retry":          "Retry",
       "chat.resetSession":   "Reset session",
       "chat.resetSessionConfirm": "Reset will start a brand-new session. The current conversation history stays in your sidebar but will no longer be active. Continue?",
@@ -1133,6 +1134,7 @@ const I18n = (() => {
       "chat.interrupted":    "已中断。",
       "chat.feedback_hint":  "或在下方输入框自由作答 ↓",
       "chat.newMessageHint": "有新消息 ↓",
+      "threadNav.aria":          "对话导航",
       "chat.retry":          "重试",
       "chat.copy":           "复制",
       "chat.todo.spawn":     "开干",
@@ -2155,6 +2157,7 @@ const I18n = (() => {
    *   data-i18n="key"             → element.textContent
    *   data-i18n-placeholder="key" → element.placeholder
    *   data-i18n-title="key"       → element.title
+   *   data-i18n-aria-label="key"  → element.aria-label
    */
   function applyAll() {
     document.querySelectorAll("[data-i18n]").forEach(el => {
@@ -2176,6 +2179,11 @@ const I18n = (() => {
       const key  = el.getAttribute("data-i18n-title");
       const vars = _extractVars(el);
       el.title = t(key, vars);
+    });
+    document.querySelectorAll("[data-i18n-aria-label]").forEach(el => {
+      const key  = el.getAttribute("data-i18n-aria-label");
+      const vars = _extractVars(el);
+      el.setAttribute("aria-label", t(key, vars));
     });
 
     // Update <html lang=""> attribute

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -473,6 +473,9 @@
 
       <!-- Chat column (messages + info bar + input) -->
       <div id="chat-main">
+      <!-- In-thread navigation rail (left edge). One dash per user turn;
+           hover for a preview card, click to jump. Rendered by thread-nav.js. -->
+      <nav id="thread-nav" class="thread-nav" aria-label="Thread navigation"></nav>
       <!-- Banner slot: agent-scoped notices/toolbars above the message stream. -->
       <div id="ext-slot-session-banner" class="session-banner" data-slot="session.banner"></div>
       <div id="messages" class="chat-messages-scroll"></div>
@@ -1623,6 +1626,7 @@
 <script src="/ws-dispatcher.js"></script>
 <script src="/sessions.js"></script>
 <script src="/projects.js"></script>
+<script src="/thread-nav.js"></script>
 <script src="/features/workspace/store.js"></script>
 <script src="/features/workspace/view.js"></script>
 <script src="/components/datepicker.js"></script>

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -475,7 +475,8 @@
       <div id="chat-main">
       <!-- In-thread navigation rail (left edge). One dash per user turn;
            hover for a preview card, click to jump. Rendered by thread-nav.js. -->
-      <nav id="thread-nav" class="thread-nav" aria-label="Thread navigation"></nav>
+      <nav id="thread-nav" class="thread-nav"
+           data-i18n-aria-label="threadNav.aria" aria-label="Thread navigation"></nav>
       <!-- Banner slot: agent-scoped notices/toolbars above the message stream. -->
       <div id="ext-slot-session-banner" class="session-banner" data-slot="session.banner"></div>
       <div id="messages" class="chat-messages-scroll"></div>

--- a/lib/clacky/web/thread-nav.js
+++ b/lib/clacky/web/thread-nav.js
@@ -3,8 +3,8 @@
  *
  * Renders a vertical strip of dash markers on the left edge of #chat-main,
  * one per user message in the active session. Hovering a dash shows a
- * preview card with the user's question and the first line of the AI
- * reply. Clicking scrolls the message into view.
+ * preview card (rendered in a global portal so it is never clipped by the
+ * rail's overflow). Clicking scrolls the message into view.
  *
  * Design notes:
  *  - Purely DOM-driven: we observe #messages via MutationObserver and
@@ -12,6 +12,9 @@
  *    sessions.js internals — the module is self-contained.
  *  - Zero-cost when the chat panel is hidden or there are no user
  *    messages (rail hides itself).
+ *  - The preview card lives in a separate #thread-nav-tooltip element
+ *    appended to <body> (position:fixed). This decouples it from the
+ *    rail's overflow so the rail can scroll freely without clipping.
  *  - Reuses existing theme variables so it fits both light and dark
  *    mode without extra configuration. Visible strings go through i18n
  *    (see data-i18n-aria-label on #thread-nav in index.html).
@@ -45,6 +48,23 @@
 
   function chatMainEl() {
     return document.getElementById("chat-main");
+  }
+
+  /**
+   * Lazily create (or return existing) the single global tooltip element
+   * used for all dash previews. Lives in <body> so it is never clipped by
+   * the rail's overflow-y:auto.
+   */
+  function _tooltip() {
+    let el = document.getElementById("thread-nav-tooltip");
+    if (!el) {
+      el = document.createElement("div");
+      el.id = "thread-nav-tooltip";
+      el.className = "thread-nav-card";
+      el.setAttribute("role", "tooltip");
+      document.body.appendChild(el);
+    }
+    return el;
   }
 
   // ── Rail construction ─────────────────────────────────────────────────
@@ -105,6 +125,50 @@
     return entries;
   }
 
+  // ── Tooltip (preview card portal) ─────────────────────────────────────
+
+  /**
+   * Show the preview card for `entry`, anchored vertically on `item`.
+   * The card is position:fixed so it ignores the rail's overflow entirely.
+   */
+  function _showTooltip(entry, item) {
+    const tip = _tooltip();
+    tip.innerHTML = "";
+
+    const q = document.createElement("div");
+    q.className = "thread-nav-q";
+    q.textContent = entry.question;
+    tip.appendChild(q);
+
+    if (entry.reply) {
+      const a = document.createElement("div");
+      a.className = "thread-nav-a";
+      a.textContent = entry.reply;
+      tip.appendChild(a);
+    }
+    if (entry.time) {
+      const t = document.createElement("div");
+      t.className = "thread-nav-time";
+      t.textContent = entry.time;
+      tip.appendChild(t);
+    }
+
+    // Position: right of the rail, vertically centred on the item — clamped
+    // to the viewport so the card never bleeds off-screen.
+    const r = item.getBoundingClientRect();
+    tip.style.left = r.right + 4 + "px";
+    const halfH = tip.offsetHeight / 2;
+    let top = r.top + r.height / 2;
+    top = Math.max(halfH + 8, Math.min(top, window.innerHeight - halfH - 8));
+    tip.style.top = top + "px";
+    tip.classList.add("visible");
+  }
+
+  function _hideTooltip() {
+    const tip = document.getElementById("thread-nav-tooltip");
+    if (tip) tip.classList.remove("visible");
+  }
+
   /**
    * Render the rail from the current DOM. Idempotent — clears and rebuilds.
    */
@@ -118,6 +182,7 @@
     // so _setActive re-applies the class to the freshly created items.
     _activeIdx = -1;
     rail.innerHTML = "";
+    _hideTooltip();
 
     if (!entries.length) {
       rail.classList.add("thread-nav-empty");
@@ -134,32 +199,17 @@
       dash.className = "thread-nav-dash";
       item.appendChild(dash);
 
-      // Preview card (positioned on hover via CSS)
-      const card = document.createElement("div");
-      card.className = "thread-nav-card";
-      const q = document.createElement("div");
-      q.className = "thread-nav-q";
-      q.textContent = entry.question;
-      card.appendChild(q);
-      if (entry.reply) {
-        const a = document.createElement("div");
-        a.className = "thread-nav-a";
-        a.textContent = entry.reply;
-        card.appendChild(a);
-      }
-      if (entry.time) {
-        const t = document.createElement("div");
-        t.className = "thread-nav-time";
-        t.textContent = entry.time;
-        card.appendChild(t);
-      }
-      item.appendChild(card);
+      // No card child — the card is a global portal (see _showTooltip).
 
       item.addEventListener("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         _scrollToEntry(entry, idx);
       });
+
+      // Preview card via global tooltip — immune to rail overflow.
+      item.addEventListener("mouseenter", () => _showTooltip(entry, item));
+      item.addEventListener("mouseleave", _hideTooltip);
 
       rail.appendChild(item);
     });
@@ -281,6 +331,33 @@
         container.addEventListener("scroll", _scheduleActiveUpdate, { passive: true });
       }
 
+      // Hide tooltip when the rail itself scrolls (dash moves away from cursor).
+      const rail = railEl();
+      if (rail) {
+        rail.addEventListener("scroll", _hideTooltip, { passive: true });
+
+        // Wheel containment: when the cursor is over the rail, wheel events
+        // must scroll the rail ONLY — never chain through to #messages.
+        // Without this, a non-overflowing (or boundary-hit) rail passes the
+        // wheel to the sibling messages panel, which is what the user sees
+        // as "scrolling the content instead of the sidebar".
+        rail.addEventListener("wheel", function (e) {
+          const maxScroll = rail.scrollHeight - rail.clientHeight;
+          if (maxScroll <= 0) {
+            // Rail has nothing to scroll — swallow the event so messages
+            // don't move either.
+            e.preventDefault();
+            return;
+          }
+          const atTop = rail.scrollTop <= 0 && e.deltaY < 0;
+          var atBottom = rail.scrollTop >= maxScroll - 1 && e.deltaY > 0;
+          if (atTop || atBottom) {
+            // Reached an edge — stop here, don't chain to #messages.
+            e.preventDefault();
+          }
+        }, { passive: false });
+      }
+
       // Track resizes — long sessions can change height when fonts load,
       // images expand, etc.
       window.addEventListener("resize", _scheduleRebuild);
@@ -301,6 +378,7 @@
     },
 
     hide() {
+      _hideTooltip();
       const rail = railEl();
       if (rail) rail.classList.add("thread-nav-hidden");
       _stopObserver();

--- a/lib/clacky/web/thread-nav.js
+++ b/lib/clacky/web/thread-nav.js
@@ -1,0 +1,318 @@
+/**
+ * thread-nav.js — In-thread navigation rail for the chat panel.
+ *
+ * Renders a vertical strip of dash markers on the left edge of #chat-main,
+ * one per user message in the active session. Hovering a dash shows a
+ * preview card with the user's question and the first line of the AI
+ * reply. Clicking scrolls the message into view.
+ *
+ * Design notes:
+ *  - Purely DOM-driven: we observe #messages via MutationObserver and
+ *    rebuild the rail from .msg-user-wrap elements. No changes to
+ *    sessions.js internals — the module is self-contained.
+ *  - Zero-cost when the chat panel is hidden or there are no user
+ *    messages (rail hides itself).
+ *  - Reuses existing i18n / theme variables so it fits both light and
+ *    dark mode without extra configuration.
+ *
+ * Public API (window.ThreadNav):
+ *   init()     — wire observers & event listeners (idempotent)
+ *   refresh()  — force a rebuild of the rail from the current DOM
+ *   show()     — unhide the rail (called when a session is active)
+ *   hide()     — hide the rail (called when leaving a session)
+ */
+
+(function () {
+  "use strict";
+
+  // ── State ──────────────────────────────────────────────────────────────
+  let _inited = false;
+  let _observer = null;
+  let _rebuildTimer = null;
+  let _scrollTimer = null;
+  let _activeIdx = -1;
+
+  // ── DOM helpers ────────────────────────────────────────────────────────
+
+  function $(id) { return document.getElementById(id); }
+
+  function railEl() {
+    return $("thread-nav");
+  }
+
+  function messagesEl() {
+    return $("messages");
+  }
+
+  function chatMainEl() {
+    return $("chat-main");
+  }
+
+  // ── Rail construction ─────────────────────────────────────────────────
+
+  /**
+   * Truncate text for preview. Keeps CJK / Latin readable and avoids
+   * cutting in the middle of surrogate pairs.
+   */
+  function _truncate(text, max) {
+    if (!text) return "";
+    const t = String(text).replace(/\s+/g, " ").trim();
+    if (t.length <= max) return t;
+    return Array.from(t).slice(0, max).join("") + "…";
+  }
+
+  /**
+   * Find the first assistant reply following a user wrap element, walking
+   * forward through siblings. Returns the .msg-assistant element or null.
+   */
+  function _findReplyFor(userWrap) {
+    let node = userWrap.nextElementSibling;
+    // Skip info / tool / progress messages until we hit the next assistant
+    // or the next user wrap (means the assistant never replied).
+    while (node) {
+      if (node.classList && node.classList.contains("msg-user-wrap")) return null;
+      if (node.classList && node.classList.contains("msg-assistant")) return node;
+      // A submodel / nested container can wrap the assistant bubble — peek
+      // inside one level to be safe.
+      if (node.querySelector) {
+        const inner = node.querySelector(".msg-assistant");
+        if (inner) return inner;
+      }
+      node = node.nextElementSibling;
+    }
+    return null;
+  }
+
+  /**
+   * Collect one entry per .msg-user-wrap in #messages. Returns
+   * [{ wrap, question, reply, time }].
+   */
+  function _collectEntries() {
+    const container = messagesEl();
+    if (!container) return [];
+    const wraps = container.querySelectorAll(".msg-user-wrap");
+    const entries = [];
+    wraps.forEach((wrap) => {
+      const userEl = wrap.querySelector(".msg-user");
+      if (!userEl) return;
+      // The raw markdown of the user's message lives in the user bubble's
+      // text content; fall back to innerText for safety.
+      const question = _truncate(userEl.textContent || "", 80);
+      if (!question) return;
+      const replyEl = _findReplyFor(wrap);
+      const reply = replyEl ? _truncate(replyEl.textContent || "", 120) : "";
+      const time = wrap.querySelector(".msg-time");
+      entries.push({
+        wrap,
+        question,
+        reply,
+        time: time ? time.textContent.trim() : "",
+      });
+    });
+    return entries;
+  }
+
+  /**
+   * Render the rail from the current DOM. Idempotent — clears and rebuilds.
+   */
+  function _rebuildRail() {
+    const rail = railEl();
+    const container = messagesEl();
+    if (!rail || !container) return;
+
+    const entries = _collectEntries();
+    rail.innerHTML = "";
+
+    if (!entries.length) {
+      rail.classList.add("thread-nav-empty");
+      return;
+    }
+    rail.classList.remove("thread-nav-empty");
+
+    entries.forEach((entry, idx) => {
+      const item = document.createElement("div");
+      item.className = "thread-nav-item";
+      item.dataset.idx = String(idx);
+
+      const dash = document.createElement("div");
+      dash.className = "thread-nav-dash";
+      item.appendChild(dash);
+
+      // Preview card (positioned on hover via CSS)
+      const card = document.createElement("div");
+      card.className = "thread-nav-card";
+      const q = document.createElement("div");
+      q.className = "thread-nav-q";
+      q.textContent = entry.question;
+      card.appendChild(q);
+      if (entry.reply) {
+        const a = document.createElement("div");
+        a.className = "thread-nav-a";
+        a.textContent = entry.reply;
+        card.appendChild(a);
+      }
+      if (entry.time) {
+        const t = document.createElement("div");
+        t.className = "thread-nav-time";
+        t.textContent = entry.time;
+        card.appendChild(t);
+      }
+      item.appendChild(card);
+
+      item.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        _scrollToEntry(entry, idx);
+      });
+
+      rail.appendChild(item);
+    });
+
+    _updateActiveFromScroll();
+  }
+
+  /**
+   * Scroll the messages container so the target user wrap is near the top.
+   */
+  function _scrollToEntry(entry, idx) {
+    const container = messagesEl();
+    if (!container) return;
+    const wrap = entry.wrap;
+    if (!wrap || !wrap.isConnected) {
+      _rebuildRail();
+      return;
+    }
+    // Offset slightly so the bubble isn't flush against the top edge.
+    const target = wrap.offsetTop - 24;
+    container.scrollTo({ top: target, behavior: "smooth" });
+    _setActive(idx);
+  }
+
+  /**
+   * Highlight the dash at `idx`, clear all others.
+   */
+  function _setActive(idx) {
+    if (idx === _activeIdx) return;
+    _activeIdx = idx;
+    const rail = railEl();
+    if (!rail) return;
+    rail.querySelectorAll(".thread-nav-item").forEach((el) => {
+      const i = Number(el.dataset.idx || -1);
+      el.classList.toggle("thread-nav-active", i === idx);
+    });
+  }
+
+  /**
+   * Update the active dash based on the messages container scroll position.
+   * The "active" entry is the last user wrap whose top edge is above the
+   * container's vertical midpoint.
+   */
+  function _updateActiveFromScroll() {
+    const rail = railEl();
+    const container = messagesEl();
+    if (!rail || !container) return;
+    const items = rail.querySelectorAll(".thread-nav-item");
+    if (!items.length) return;
+
+    const wraps = container.querySelectorAll(".msg-user-wrap");
+    if (!wraps.length) return;
+
+    const mid = container.scrollTop + container.clientHeight / 2;
+    let active = 0;
+    wraps.forEach((wrap, i) => {
+      if (wrap.offsetTop <= mid) active = i;
+    });
+    _setActive(active);
+  }
+
+  // ── Event wiring ───────────────────────────────────────────────────────
+
+  function _scheduleRebuild() {
+    if (_rebuildTimer) clearTimeout(_rebuildTimer);
+    _rebuildTimer = setTimeout(_rebuildRail, 60);
+  }
+
+  function _scheduleActiveUpdate() {
+    if (_scrollTimer) clearTimeout(_scrollTimer);
+    _scrollTimer = setTimeout(_updateActiveFromScroll, 80);
+  }
+
+  function _startObserver() {
+    const container = messagesEl();
+    if (!container || _observer) return;
+    _observer = new MutationObserver((mutations) => {
+      // Cheap early-out: if no user-wrap was added/removed, skip.
+      let relevant = false;
+      for (const m of mutations) {
+        if (m.type !== "childList") continue;
+        const touched = [...m.addedNodes, ...m.removedNodes];
+        for (const n of touched) {
+          if (!n || n.nodeType !== 1) continue;
+          if (n.classList && n.classList.contains("msg-user-wrap")) { relevant = true; break; }
+          if (n.querySelector && n.querySelector(".msg-user-wrap, .msg-assistant")) { relevant = true; break; }
+        }
+        if (relevant) break;
+      }
+      if (relevant) _scheduleRebuild();
+    });
+    _observer.observe(container, { childList: true, subtree: true });
+  }
+
+  function _stopObserver() {
+    if (_observer) { _observer.disconnect(); _observer = null; }
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────
+
+  const ThreadNav = {
+    init() {
+      if (_inited) return;
+      _inited = true;
+
+      // Rebuild on panel visibility changes (session switching shows/hides
+      // #chat-panel and re-renders #messages).
+      window.addEventListener("hashchange", () => setTimeout(_scheduleRebuild, 0));
+
+      // Track scroll to update the active dash.
+      const container = messagesEl();
+      if (container) {
+        container.addEventListener("scroll", _scheduleActiveUpdate, { passive: true });
+      }
+
+      // Track resizes — long sessions can change height when fonts load,
+      // images expand, etc.
+      window.addEventListener("resize", _scheduleRebuild);
+
+      _startObserver();
+      _rebuildRail();
+    },
+
+    refresh() {
+      _rebuildRail();
+    },
+
+    show() {
+      const rail = railEl();
+      if (rail) rail.classList.remove("thread-nav-hidden");
+      _startObserver();
+      _rebuildRail();
+    },
+
+    hide() {
+      const rail = railEl();
+      if (rail) rail.classList.add("thread-nav-hidden");
+      _stopObserver();
+    },
+  };
+
+  // Expose globally so app.js / sessions.js can call it.
+  window.ThreadNav = ThreadNav;
+
+  // Auto-init once DOM is ready. The module is idempotent, so calling
+  // init() again later is harmless.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => ThreadNav.init());
+  } else {
+    ThreadNav.init();
+  }
+})();

--- a/lib/clacky/web/thread-nav.js
+++ b/lib/clacky/web/thread-nav.js
@@ -12,8 +12,9 @@
  *    sessions.js internals — the module is self-contained.
  *  - Zero-cost when the chat panel is hidden or there are no user
  *    messages (rail hides itself).
- *  - Reuses existing i18n / theme variables so it fits both light and
- *    dark mode without extra configuration.
+ *  - Reuses existing theme variables so it fits both light and dark
+ *    mode without extra configuration. Visible strings go through i18n
+ *    (see data-i18n-aria-label on #thread-nav in index.html).
  *
  * Public API (window.ThreadNav):
  *   init()     — wire observers & event listeners (idempotent)
@@ -34,18 +35,16 @@
 
   // ── DOM helpers ────────────────────────────────────────────────────────
 
-  function $(id) { return document.getElementById(id); }
-
   function railEl() {
-    return $("thread-nav");
+    return document.getElementById("thread-nav");
   }
 
   function messagesEl() {
-    return $("messages");
+    return document.getElementById("messages");
   }
 
   function chatMainEl() {
-    return $("chat-main");
+    return document.getElementById("chat-main");
   }
 
   // ── Rail construction ─────────────────────────────────────────────────
@@ -62,53 +61,47 @@
   }
 
   /**
-   * Find the first assistant reply following a user wrap element, walking
-   * forward through siblings. Returns the .msg-assistant element or null.
-   */
-  function _findReplyFor(userWrap) {
-    let node = userWrap.nextElementSibling;
-    // Skip info / tool / progress messages until we hit the next assistant
-    // or the next user wrap (means the assistant never replied).
-    while (node) {
-      if (node.classList && node.classList.contains("msg-user-wrap")) return null;
-      if (node.classList && node.classList.contains("msg-assistant")) return node;
-      // A submodel / nested container can wrap the assistant bubble — peek
-      // inside one level to be safe.
-      if (node.querySelector) {
-        const inner = node.querySelector(".msg-assistant");
-        if (inner) return inner;
-      }
-      node = node.nextElementSibling;
-    }
-    return null;
-  }
-
-  /**
-   * Collect one entry per .msg-user-wrap in #messages. Returns
-   * [{ wrap, question, reply, time }].
+   * Collect one entry per .msg-user-wrap in #messages, each paired with
+   * the first .msg-assistant that follows it (if any). Single linear
+   * pass over the children of #messages — O(n).
+   * Returns [{ wrap, question, reply, time }].
    */
   function _collectEntries() {
     const container = messagesEl();
     if (!container) return [];
-    const wraps = container.querySelectorAll(".msg-user-wrap");
     const entries = [];
-    wraps.forEach((wrap) => {
-      const userEl = wrap.querySelector(".msg-user");
-      if (!userEl) return;
-      // The raw markdown of the user's message lives in the user bubble's
-      // text content; fall back to innerText for safety.
-      const question = _truncate(userEl.textContent || "", 80);
-      if (!question) return;
-      const replyEl = _findReplyFor(wrap);
-      const reply = replyEl ? _truncate(replyEl.textContent || "", 120) : "";
-      const time = wrap.querySelector(".msg-time");
-      entries.push({
-        wrap,
-        question,
-        reply,
-        time: time ? time.textContent.trim() : "",
-      });
-    });
+    // Walk children once; remember the most recent user entry that has
+    // not yet been paired with a reply.
+    for (const node of container.children) {
+      if (node.nodeType !== 1) continue;
+      if (node.classList.contains("msg-user-wrap")) {
+        const userEl = node.querySelector(".msg-user");
+        if (!userEl) continue;
+        const question = _truncate(userEl.textContent || "", 80);
+        if (!question) continue;
+        const timeEl = node.querySelector(".msg-time");
+        entries.push({
+          wrap: node,
+          question,
+          reply: "",
+          time: timeEl ? timeEl.textContent.trim() : "",
+        });
+        continue;
+      }
+      // An assistant reply: assign to the last entry that still has none.
+      let replyEl = null;
+      if (node.classList.contains("msg-assistant")) {
+        replyEl = node;
+      } else if (node.querySelector) {
+        // A submodel / nested container can wrap the assistant bubble —
+        // peek inside one level to be safe.
+        replyEl = node.querySelector(".msg-assistant");
+      }
+      if (replyEl && entries.length) {
+        const last = entries[entries.length - 1];
+        if (!last.reply) last.reply = _truncate(replyEl.textContent || "", 120);
+      }
+    }
     return entries;
   }
 
@@ -121,6 +114,9 @@
     if (!rail || !container) return;
 
     const entries = _collectEntries();
+    // The DOM was rebuilt, so any stale highlight index is invalid — reset
+    // so _setActive re-applies the class to the freshly created items.
+    _activeIdx = -1;
     rail.innerHTML = "";
 
     if (!entries.length) {
@@ -182,8 +178,11 @@
       _rebuildRail();
       return;
     }
-    // Offset slightly so the bubble isn't flush against the top edge.
-    const target = wrap.offsetTop - 24;
+    // .msg-user-wrap has position:relative, so its offsetParent is
+    // #chat-main (position:relative), NOT #messages (static). Subtract the
+    // container's own offset so the target is measured within the scroll
+    // viewport — otherwise the jump lands off by the banner-slot height.
+    const target = wrap.offsetTop - container.offsetTop - 24;
     container.scrollTo({ top: target, behavior: "smooth" });
     _setActive(idx);
   }
@@ -217,10 +216,13 @@
     const wraps = container.querySelectorAll(".msg-user-wrap");
     if (!wraps.length) return;
 
+    // See _scrollToEntry: offsetParent is #chat-main, so subtract the
+    // container offset to align with container.scrollTop.
+    const base = container.offsetTop;
     const mid = container.scrollTop + container.clientHeight / 2;
     let active = 0;
     wraps.forEach((wrap, i) => {
-      if (wrap.offsetTop <= mid) active = i;
+      if (wrap.offsetTop - base <= mid) active = i;
     });
     _setActive(active);
   }

--- a/spec/clacky/web/thread_nav_spec.rb
+++ b/spec/clacky/web/thread_nav_spec.rb
@@ -87,19 +87,45 @@ RSpec.describe "Thread navigation rail" do
     end
   end
 
-  # ─── Hover preview (CSS-driven) ────────────────────────────────────────────
+  # ─── Hover preview (global tooltip portal) ─────────────────────────────────
 
   describe "hover preview card" do
-    it "creates a preview card element in JS" do
+    it "creates a global tooltip portal element in JS" do
+      expect(js_source).to include("thread-nav-tooltip"),
+        "must create a #thread-nav-tooltip portal element"
+    end
+
+    it "appends the tooltip to document body (not inside the rail)" do
+      expect(js_source).to match(/document\.body\.appendChild.*tooltip|body\.appendChild.*_tooltip/m),
+        "tooltip must be appended to <body> so the rail's overflow never clips it"
+    end
+
+    it "assigns the thread-nav-card class to the tooltip" do
       expect(js_source).to include("thread-nav-card")
     end
 
-    it "defines the card as a child of the marker (for CSS :hover)" do
-      expect(js_source).to match(/item\.appendChild|item\.insertAdjacent|card/)
+    it "uses mouseenter / mouseleave to show and hide the tooltip" do
+      expect(js_source).to match(/mouseenter/),
+        "must listen for mouseenter to show the preview"
+      expect(js_source).to match(/mouseleave/),
+        "must listen for mouseleave to hide the preview"
     end
 
-    it "CSS shows the card on marker hover" do
-      expect(css_source).to match(/\.thread-nav-item:hover\s+\.thread-nav-card|\.thread-nav-item:hover\s*\{/)
+    it "toggles a .visible class on the tooltip (not CSS :hover)" do
+      expect(js_source).to match(/classList\.add\(\s*["']visible["']\)|classList\.add.*visible/),
+        "must add the .visible class when showing the tooltip"
+      expect(js_source).to match(/classList\.remove\(\s*["']visible["']\)|classList\.remove.*visible/),
+        "must remove the .visible class when hiding the tooltip"
+    end
+
+    it "positions the tooltip via JS (left/top), not CSS positioning" do
+      expect(js_source).to match(/\.style\.left|\.style\.top|getBoundingClientRect/),
+        "must compute tooltip position from the marker's bounding rect"
+    end
+
+    it "CSS defines the visible state via a .visible class on the tooltip" do
+      expect(css_source).to match(/thread-nav-tooltip.*\.visible|thread-nav-card\.visible|\.visible\s*\{/),
+        "CSS must define the .visible class for showing the tooltip"
     end
   end
 
@@ -141,8 +167,9 @@ RSpec.describe "Thread navigation rail" do
       expect(css_source).to match(/\.thread-nav-dash\s*\{/)
     end
 
-    it "defines the preview card style" do
-      expect(css_source).to match(/\.thread-nav-card\s*\{/)
+    it "defines the preview card style (portal tooltip)" do
+      expect(css_source).to match(/thread-nav-tooltip.*thread-nav-card|\.thread-nav-card/),
+        "CSS must style the #thread-nav-tooltip.thread-nav-card element"
     end
 
     it "defines the active marker style" do

--- a/spec/clacky/web/thread_nav_spec.rb
+++ b/spec/clacky/web/thread_nav_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+# Source-level guardrails for the in-thread navigation rail (thread-nav.js).
+#
+# These checks encode the structural contract of the navigation rail so that a
+# future refactor cannot silently break the core promises the feature makes:
+#
+#   1. **Observation** — the rail stays in sync with the DOM via MutationObserver,
+#      not a one-time scan.
+#   2. **Navigation** — markers are clickable and scroll the target into view.
+#   3. **Hover preview** — a CSS-driven preview card shows context per marker.
+#   4. **Active tracking** — the marker for the currently-visible turn is highlighted.
+#   5. **Graceful degradation** — the rail must not throw if the DOM is empty.
+
+RSpec.describe "Thread navigation rail" do
+  let(:web_dir)     { File.expand_path("../../../lib/clacky/web", __dir__) }
+  let(:js_path)     { File.join(web_dir, "thread-nav.js") }
+  let(:js_source)   { File.read(js_path) }
+  let(:html_source) { File.read(File.join(web_dir, "index.html")) }
+  let(:css_source)  { File.read(File.join(web_dir, "app.css")) }
+
+  # ─── File presence & wiring ────────────────────────────────────────────────
+
+  describe "file presence and wiring" do
+    it "thread-nav.js exists" do
+      expect(File).to exist(js_path)
+    end
+
+    it "index.html loads thread-nav.js" do
+      expect(html_source).to include('thread-nav.js'),
+        "index.html must load thread-nav.js via a <script> tag"
+    end
+
+    it "index.html contains the nav container element" do
+      expect(html_source).to match(%r{<nav[^>]*id=["']thread-nav["']}).
+        and(match(/thread-nav/))
+    end
+  end
+
+  # ─── MutationObserver contract ─────────────────────────────────────────────
+
+  describe "MutationObserver-based observation" do
+    it "creates a MutationObserver instance" do
+      expect(js_source).to match(/new\s+MutationObserver/)
+    end
+
+    it "observes the messages container for child-list changes" do
+      expect(js_source).to match(/\.observe\(/)
+      expect(js_source).to match(/childList/)
+    end
+
+    it "disconnects the observer to avoid memory leaks" do
+      expect(js_source).to match(/\.disconnect\(/)
+    end
+  end
+
+  # ─── Rail construction ─────────────────────────────────────────────────────
+
+  describe "rail construction" do
+    it "targets the nav container by id" do
+      expect(js_source).to match(/getElementById\(\s*["']thread-nav["']|["']thread-nav["']/)
+    end
+
+    it "identifies user turns via .msg-user-wrap elements" do
+      expect(js_source).to include("msg-user-wrap"),
+        "must scan for .msg-user-wrap to identify conversation turns"
+    end
+
+    it "creates marker elements dynamically via createElement" do
+      expect(js_source).to match(/createElement/)
+    end
+
+    it "assigns the thread-nav-item class to markers" do
+      expect(js_source).to include("thread-nav-item")
+    end
+  end
+
+  # ─── Click-to-scroll navigation ────────────────────────────────────────────
+
+  describe "click-to-scroll navigation" do
+    it "attaches click handlers to marker items" do
+      expect(js_source).to match(/addEventListener\(\s*["']click["']/)
+    end
+
+    it "scrolls the target message into view on click" do
+      expect(js_source).to match(/scrollIntoView|\.scrollTop\s*=|\.scrollTo\(/)
+    end
+  end
+
+  # ─── Hover preview (CSS-driven) ────────────────────────────────────────────
+
+  describe "hover preview card" do
+    it "creates a preview card element in JS" do
+      expect(js_source).to include("thread-nav-card")
+    end
+
+    it "defines the card as a child of the marker (for CSS :hover)" do
+      expect(js_source).to match(/item\.appendChild|item\.insertAdjacent|card/)
+    end
+
+    it "CSS shows the card on marker hover" do
+      expect(css_source).to match(/\.thread-nav-item:hover\s+\.thread-nav-card|\.thread-nav-item:hover\s*\{/)
+    end
+  end
+
+  # ─── Active marker tracking ────────────────────────────────────────────────
+
+  describe "active marker tracking" do
+    it "tracks scroll position to determine the active turn" do
+      expect(js_source).to match(/scroll|getBoundingClientRect/)
+    end
+
+    it "toggles an active class on the current marker" do
+      expect(js_source).to match(/classList\.toggle\(|classList\.add\(/)
+      expect(js_source).to include("thread-nav-active")
+    end
+  end
+
+  # ─── Graceful degradation ──────────────────────────────────────────────────
+
+  describe "graceful degradation" do
+    it "guards against a missing nav element before operating" do
+      expect(js_source).to match(/if\s*\(\s*!.*\)\s*return|return\s+null|return\s*;?\s*\n/),
+        "thread-nav.js must early-return when required elements are absent"
+    end
+
+    it "handles an empty conversation (no user wraps) without throwing" do
+      expect(js_source).to match(/\.length\s*===\s*0|\.length\s*<\s*1|thread-nav-empty|!.*wraps|!.*length/),
+        "must detect and handle the empty-rail case"
+    end
+  end
+
+  # ─── CSS styling contract ──────────────────────────────────────────────────
+
+  describe "CSS styling contract" do
+    it "defines the rail container style" do
+      expect(css_source).to match(/\.thread-nav\s*\{/)
+    end
+
+    it "defines the dash marker style" do
+      expect(css_source).to match(/\.thread-nav-dash\s*\{/)
+    end
+
+    it "defines the preview card style" do
+      expect(css_source).to match(/\.thread-nav-card\s*\{/)
+    end
+
+    it "defines the active marker style" do
+      expect(css_source).to match(/\.thread-nav-active|\.thread-nav-item\.active/)
+    end
+
+    it "reserves left padding on the chat container for the rail" do
+      expect(css_source).to include("22px"),
+        "chat-messages-scroll must reserve 22px left padding for the rail"
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a **left-edge vertical navigation rail** to the Web UI that lets users quickly jump between conversation turns in long threads.

- One dash marker per user turn along the left edge
- **Hover** any marker → preview card with timestamp + first line of that turn
- **Click** any marker → instantly scroll-jump to that message
- Active marker highlights based on scroll position

## Why

In long conversations (50+ turns), scrolling back to find a specific earlier exchange is painful. This rail gives a constant visual overview of thread structure and enables one-click jumping — similar to how code editors show minimaps or how document readers show thumbnail rails.

## How

| File | Change |
|---|---|
| `thread-nav.js` *(new, 318 lines)* | `MutationObserver` scans the chat container for user-turn markers, builds the rail dynamically, manages hover preview cards, handles click-to-scroll, and tracks scroll position for active-marker highlighting |
| `index.html` *(+4 lines)* | Inject `<nav id="thread-nav">` after `#chat-main`, load `thread-nav.js` |
| `app.css` *(+103 lines)* | Rail styling, preview card, hover/active states; reserves 22px left padding on `.chat-messages-scroll` so content never sits under the rail |

## Design decisions

- **No new dependencies** — vanilla JS, uses existing DOM structure
- **No new config knobs** — works out of the box
- **Graceful degradation** — if JS fails to load, the `<nav>` stays empty and invisible; zero impact on existing functionality
- **Respects existing architecture** — follows the same DOM-observer pattern already used by other Web UI modules (sessions.js, extensions)
- **Purely additive** — 1 deletion (padding value change), rest is new code

## User-visible impact

A thin navigation rail (~16px wide) appears on the left edge of the chat area. Existing layout shifts right by 22px (the padding change) to make room. No behavior change for anything else.

---

*Authored using OpenClacky.*