### PR TITLE
fix(tools): simplify TodoManager to single-value params (Pi-style)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
     artii (2.1.2)
     ast (2.4.3)
     base64 (0.3.0)
+    cgi (0.5.2)
     chunky_png (1.4.0)
     climate_control (1.2.0)
     date (3.5.1)
@@ -35,7 +36,8 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     diffy (3.4.4)
-    erb (6.0.4)
+    erb (4.0.4.1)
+      cgi (>= 0.3.3)
     faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)

--- a/lib/clacky/tools/todo_manager.rb
+++ b/lib/clacky/tools/todo_manager.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "time"
 
 module Clacky
@@ -10,8 +9,8 @@ module Clacky
       self.tool_description = <<~DESC.strip
         Plan and track multi-step tasks. Skip for trivial single-step requests.
 
-        `task` and `id` accept a single value OR an array — always batch when you can
-        (e.g. `complete id:[1,2,3]` in one call, not three).
+        `task` accepts a single string, `id` accepts a single integer.
+        For batch operations, call the tool multiple times.
 
         Only `complete` a todo once it's truly done end-to-end, not per sub-step.
       DESC
@@ -25,18 +24,12 @@ module Clacky
             description: "add | list | complete | remove | clear"
           },
           task: {
-            description: "add: task description(s). Accepts a string OR an array of strings for batch add.",
-            oneOf: [
-              { type: "string" },
-              { type: "array", items: { type: "string" } }
-            ]
+            type: "string",
+            description: "add: task description (single string)"
           },
           id: {
-            description: "complete/remove: task id(s). Accepts an integer OR an array of integers for batch ops.",
-            oneOf: [
-              { type: "integer" },
-              { type: "array", items: { type: "integer" } }
-            ]
+            type: "integer",
+            description: "complete/remove: task id (single integer)"
           }
         },
         required: ["action"]
@@ -46,28 +39,15 @@ module Clacky
         # todos_storage is injected by Agent, stores todos in memory
         @todos = todos_storage || []
 
-        # Normalize polymorphic inputs: callers may pass scalar or array for
-        # `task` and `id`. We coerce both into arrays internally.
-        tasks_input = normalize_to_array(task)
-        ids_input   = normalize_to_array(id)
-
         case action
         when "add"
-          add_todos(tasks_input)
+          add_todo(task)
         when "list"
           list_todos
         when "complete"
-          if ids_input.size > 1
-            complete_todos(ids_input)
-          else
-            complete_todo(ids_input.first)
-          end
+          complete_todo(id)
         when "remove"
-          if ids_input.size > 1
-            remove_todos(ids_input)
-          else
-            remove_todo(ids_input.first)
-          end
+          remove_todo(id)
         when "clear"
           clear_todos
         else
@@ -75,37 +55,20 @@ module Clacky
         end
       end
 
-      # Coerce scalar/array/nil into an Array. Filters nil entries.
-      private def normalize_to_array(value)
-        return [] if value.nil?
-        Array(value).reject(&:nil?)
-      end
-
       def format_call(args)
         action = args[:action] || args['action']
         case action
         when 'add'
           task_arg = args[:task] || args['task']
-          count = task_arg.is_a?(Array) ? task_arg.size : 1
-          "TodoManager(add #{count} task#{count > 1 ? 's' : ''})"
+          "TodoManager(add: #{task_arg || '(no task)'})"
         when 'complete'
           id_arg = args[:id] || args['id']
-          if id_arg.is_a?(Array) && id_arg.size > 1
-            "TodoManager(complete #{id_arg.size} tasks: #{id_arg.join(', ')})"
-          else
-            single = id_arg.is_a?(Array) ? id_arg.first : id_arg
-            "TodoManager(complete ##{single})"
-          end
+          "TodoManager(complete ##{id_arg})"
         when 'list'
           "TodoManager(list)"
         when 'remove'
           id_arg = args[:id] || args['id']
-          if id_arg.is_a?(Array) && id_arg.size > 1
-            "TodoManager(remove #{id_arg.size} tasks: #{id_arg.join(', ')})"
-          else
-            single = id_arg.is_a?(Array) ? id_arg.first : id_arg
-            "TodoManager(remove ##{single})"
-          end
+          "TodoManager(remove ##{id_arg})"
         when 'clear'
           "TodoManager(clear all)"
         else
@@ -134,14 +97,10 @@ module Clacky
         @todos.replace(todos)
       end
 
-      def add_todos(tasks_input)
-        # tasks_input is already a normalized array (possibly empty)
-        tasks_to_add = Array(tasks_input)
-                       .map { |t| t.is_a?(String) ? t.strip : t.to_s.strip }
-                       .reject(&:empty?)
+      def add_todo(task_input)
+        return { error: "Task description is required" } if task_input.nil? || task_input.to_s.strip.empty?
 
-        return { error: "At least one task description is required" } if tasks_to_add.empty?
-
+        task_desc = task_input.to_s.strip
         existing_todos = load_todos
 
         # Auto-clear old completed todos from previous task cycles before adding new ones
@@ -152,23 +111,19 @@ module Clacky
 
         next_id = existing_todos.empty? ? 1 : existing_todos.map { |t| t[:id] }.max + 1
 
-        added_todos = []
-        tasks_to_add.each_with_index do |task_desc, index|
-          new_todo = {
-            id: next_id + index,
-            task: task_desc,
-            status: "pending",
-            created_at: Time.now.iso8601
-          }
-          existing_todos << new_todo
-          added_todos << new_todo
-        end
+        new_todo = {
+          id: next_id,
+          task: task_desc,
+          status: "pending",
+          created_at: Time.now.iso8601
+        }
+        existing_todos << new_todo
 
         save_todos(existing_todos)
 
         {
-          message: added_todos.size == 1 ? "TODO added successfully" : "#{added_todos.size} TODOs added successfully",
-          todos: added_todos,
+          message: "TODO added successfully",
+          todos: [new_todo],
           total: existing_todos.size,
           reminder: "⚠️ IMPORTANT: You have added TODO(s) but have NOT started working yet! You MUST now use other tools (write, edit, shell, etc.) to actually complete these tasks. DO NOT stop here!"
         }
@@ -176,184 +131,82 @@ module Clacky
 
       def list_todos
         todos = load_todos
-
         if todos.empty?
-          return {
-            message: "No TODO items",
-            todos: [],
-            total: 0
+          { message: "No TODOs found", todos: [] }
+        else
+          pending = todos.select { |t| t[:status] == "pending" }
+          completed = todos.select { |t| t[:status] == "completed" }
+          {
+            message: "#{todos.size} TODOs (#{pending.size} pending, #{completed.size} completed)",
+            todos: todos,
+            pending_count: pending.size,
+            completed_count: completed.size
           }
         end
-
-        {
-          message: "TODO list",
-          todos: todos,
-          total: todos.size,
-          pending: todos.count { |t| t[:status] == "pending" },
-          completed: todos.count { |t| t[:status] == "completed" }
-        }
       end
 
-      def complete_todo(id)
-        return { error: "Task ID is required" } if id.nil?
+      def complete_todo(id_input)
+        return { error: "Task ID is required" } if id_input.nil?
+        return { error: "Task ID must be a positive integer" } unless id_input.to_s.match?(/\A\d+\z/)
 
+        id = id_input.to_i
         todos = load_todos
         todo = todos.find { |t| t[:id] == id }
 
-        return { error: "Task not found: #{id}" } unless todo
-
-        if todo[:status] == "completed"
-          return { message: "Task already completed", todo: todo }
-        end
-
-        todo[:status] = "completed"
-        todo[:completed_at] = Time.now.iso8601
-        save_todos(todos)
-
-        # Find the next pending task
-        next_pending = todos.find { |t| t[:status] == "pending" }
-        
-        # Count statistics
-        completed_count = todos.count { |t| t[:status] == "completed" }
-        total_count = todos.size
-
-        result = {
-          message: "Task marked as completed",
-          todo: todo,
-          progress: "#{completed_count}/#{total_count}",
-          reminder: "⚠️ REMINDER: Check the PROJECT-SPECIFIC RULES section in your system prompt before continuing to the next task"
-        }
-
-        if next_pending
-          result[:next_task] = next_pending
-          result[:next_task_info] = "Progress: #{completed_count}/#{total_count}. Next task: ##{next_pending[:id]} - #{next_pending[:task]}"
+        if todo.nil?
+          { error: "Task ##{id} not found" }
+        elsif todo[:status] == "completed"
+          { message: "Task ##{id} is already completed", todo: todo }
         else
-          # All tasks completed — auto-clear so the agent doesn't need to call clear manually
-          save_todos([])
-          result[:all_completed] = true
-          result[:completion_message] = "All tasks completed and cleared! (#{completed_count}/#{total_count})"
-        end
+          todo[:status] = "completed"
+          todo[:completed_at] = Time.now.iso8601
+          save_todos(todos)
 
-        result
+          pending = todos.select { |t| t[:status] == "pending" }
+          completed = todos.select { |t| t[:status] == "completed" }
+
+          result = {
+            message: "Task ##{id} marked as completed",
+            todo: todo,
+            progress: "#{completed.size}/#{todos.size}"
+          }
+
+          if pending.empty?
+            # All tasks completed — auto-clear
+            save_todos([])
+            result[:all_completed] = true
+            result[:completion_message] = "All tasks completed and cleared! (#{completed.size}/#{todos.size})"
+          else
+            result[:next_task] = pending.first
+            result[:next_task_info] = "Progress: #{completed.size}/#{todos.size}. Next task: ##{pending.first[:id]} - #{pending.first[:task]}"
+          end
+
+          result
+        end
       end
 
-      def remove_todo(id)
-        return { error: "Task ID is required" } if id.nil?
+      def remove_todo(id_input)
+        return { error: "Task ID is required" } if id_input.nil?
+        return { error: "Task ID must be a positive integer" } unless id_input.to_s.match?(/\A\d+\z/)
 
+        id = id_input.to_i
         todos = load_todos
         todo = todos.find { |t| t[:id] == id }
 
-        return { error: "Task not found: #{id}" } unless todo
-
-        todos.reject! { |t| t[:id] == id }
-        save_todos(todos)
-
-        {
-          message: "Task removed",
-          todo: todo,
-          remaining: todos.size
-        }
+        if todo.nil?
+          { error: "Task ##{id} not found" }
+        else
+          todos.delete(todo)
+          save_todos(todos)
+          { message: "Task ##{id} removed", todo: todo, remaining: todos.size }
+        end
       end
 
       def clear_todos
         todos = load_todos
         count = todos.size
-
-        # Clear the in-memory storage
         save_todos([])
-
-        {
-          message: "All TODOs cleared",
-          cleared_count: count
-        }
-      end
-
-      def remove_todos(ids)
-        return { error: "Task IDs array is required" } if ids.nil? || ids.empty?
-
-        todos = load_todos
-        removed_todos = []
-        not_found_ids = []
-
-        ids.each do |id|
-          todo = todos.find { |t| t[:id] == id }
-          if todo
-            removed_todos << todo
-          else
-            not_found_ids << id
-          end
-        end
-
-        # Remove all found todos
-        todos.reject! { |t| ids.include?(t[:id]) }
-        save_todos(todos)
-
-        result = {
-          message: "#{removed_todos.size} task(s) removed",
-          removed: removed_todos,
-          remaining: todos.size
-        }
-
-        # Add warning about not found IDs
-        result[:not_found] = not_found_ids unless not_found_ids.empty?
-
-        result
-      end
-
-      # Mark several tasks completed in one call.
-      # Behavior mirrors `complete_todo` but aggregates over `ids`.
-      # Tolerates already-completed and not-found ids (returned in result).
-      def complete_todos(ids)
-        return { error: "Task IDs array is required" } if ids.nil? || ids.empty?
-
-        todos = load_todos
-        now = Time.now.iso8601
-        completed_now = []
-        already_completed = []
-        not_found = []
-
-        ids.each do |id|
-          todo = todos.find { |t| t[:id] == id }
-          if todo.nil?
-            not_found << id
-          elsif todo[:status] == "completed"
-            already_completed << todo
-          else
-            todo[:status] = "completed"
-            todo[:completed_at] = now
-            completed_now << todo
-          end
-        end
-
-        save_todos(todos)
-
-        completed_count = todos.count { |t| t[:status] == "completed" }
-        total_count    = todos.size
-        next_pending   = todos.find { |t| t[:status] == "pending" }
-
-        result = {
-          message: "#{completed_now.size} task(s) marked as completed",
-          completed: completed_now,
-          progress: "#{completed_count}/#{total_count}"
-        }
-
-        result[:already_completed] = already_completed unless already_completed.empty?
-        result[:not_found]         = not_found          unless not_found.empty?
-
-        if next_pending
-          result[:next_task] = next_pending
-          result[:next_task_info] =
-            "Progress: #{completed_count}/#{total_count}. " \
-            "Next task: ##{next_pending[:id]} - #{next_pending[:task]}"
-        else
-          # All tasks completed — auto-clear to match single-complete behavior
-          save_todos([])
-          result[:all_completed] = true
-          result[:completion_message] =
-            "All tasks completed and cleared! (#{completed_count}/#{total_count})"
-        end
-
-        result
+        { message: "Cleared all #{count} TODOs", cleared: count }
       end
     end
   end

--- a/lib/clacky/tools/todo_manager.rb
+++ b/lib/clacky/tools/todo_manager.rb
@@ -97,6 +97,7 @@ module Clacky
         @todos.replace(todos)
       end
 
+
       def add_todo(task_input)
         return { error: "Task description is required" } if task_input.nil? || task_input.to_s.strip.empty?
 

--- a/spec/clacky/tools/todo_manager_spec.rb
+++ b/spec/clacky/tools/todo_manager_spec.rb
@@ -1,416 +1,209 @@
 # frozen_string_literal: true
 
+require "clacky/tools/todo_manager"
+
 RSpec.describe Clacky::Tools::TodoManager do
-  let(:tool) { described_class.new }
+  let(:manager) { described_class.new }
+  let(:todos_storage) { [] }
 
   describe "#execute" do
-    describe "add action" do
+    context "add action" do
       it "adds a new todo from a string task" do
-        storage = []
-        result = tool.execute(action: "add", task: "Write tests", todos_storage: storage)
-
-        expect(result[:message]).to eq("TODO added successfully")
-        expect(result[:todos].size).to eq(1)
-        expect(result[:todos][0][:id]).to eq(1)
-        expect(result[:todos][0][:task]).to eq("Write tests")
-        expect(result[:todos][0][:status]).to eq("pending")
-        expect(storage.size).to eq(1)
+        result = manager.execute(action: "add", task: "Write unit tests", todos_storage: todos_storage)
+        expect(todos_storage.first[:task]).to eq("Write unit tests")
+        expect(todos_storage.first[:id]).to eq(1)
+        expect(todos_storage.first[:status]).to eq("pending")
       end
 
-      it "adds multiple todos at once when task is an array" do
-        storage = []
-        result = tool.execute(
-          action: "add",
-          task: ["Task 1", "Task 2", "Task 3"],
-          todos_storage: storage
-        )
-
-        expect(result[:message]).to eq("3 TODOs added successfully")
-        expect(result[:todos].size).to eq(3)
-        expect(result[:todos][0][:id]).to eq(1)
-        expect(result[:todos][1][:id]).to eq(2)
-        expect(result[:todos][2][:id]).to eq(3)
-        expect(storage.size).to eq(3)
-      end
-
-      it "increments todo IDs correctly when adding multiple batches" do
-        storage = []
-        tool.execute(action: "add", task: "First task", todos_storage: storage)
-        result = tool.execute(
-          action: "add",
-          task: ["Second task", "Third task"],
-          todos_storage: storage
-        )
-
-        expect(result[:todos][0][:id]).to eq(2)
-        expect(result[:todos][1][:id]).to eq(3)
-        expect(storage.size).to eq(3)
+      it "increments todo IDs correctly" do
+        manager.execute(action: "add", task: "First task", todos_storage: todos_storage)
+        manager.execute(action: "add", task: "Second task", todos_storage: todos_storage)
+        ids = todos_storage.map { |t| t[:id] }
+        expect(ids).to eq([1, 2])
       end
 
       it "returns error when task is empty string" do
-        storage = []
-        result = tool.execute(action: "add", task: "", todos_storage: storage)
-
-        expect(result[:error]).to eq("At least one task description is required")
+        result = manager.execute(action: "add", task: "", todos_storage: todos_storage)
+        expect(result[:error]).to include("required")
       end
 
       it "returns error when task is nil" do
-        storage = []
-        result = tool.execute(action: "add", todos_storage: storage)
-
-        expect(result[:error]).to eq("At least one task description is required")
-      end
-
-      it "returns error when task array is empty" do
-        storage = []
-        result = tool.execute(action: "add", task: [], todos_storage: storage)
-
-        expect(result[:error]).to eq("At least one task description is required")
-      end
-
-      it "filters out empty entries in a task array" do
-        storage = []
-        result = tool.execute(
-          action: "add",
-          task: ["Task 1", "", "  ", "Task 2"],
-          todos_storage: storage
-        )
-
-        expect(result[:todos].size).to eq(2)
-        expect(result[:todos][0][:task]).to eq("Task 1")
-        expect(result[:todos][1][:task]).to eq("Task 2")
-      end
-
-      it "tolerates unknown extra keyword args (e.g. legacy clients)" do
-        storage = []
-        # **_extra should swallow these without raising
-        result = tool.execute(
-          action: "add",
-          task: "x",
-          tasks: ["ignored"],
-          ids: [99],
-          todos_storage: storage
-        )
-
-        expect(result[:todos].size).to eq(1)
-        expect(result[:todos][0][:task]).to eq("x")
-      end
-    end
-
-    describe "list action" do
-      it "returns empty list when no todos" do
-        storage = []
-        result = tool.execute(action: "list", todos_storage: storage)
-
-        expect(result[:message]).to eq("No TODO items")
-        expect(result[:todos]).to eq([])
-        expect(result[:total]).to eq(0)
-      end
-
-      it "lists all todos" do
-        storage = []
-        tool.execute(action: "add", task: "Task 1", todos_storage: storage)
-        tool.execute(action: "add", task: "Task 2", todos_storage: storage)
-
-        result = tool.execute(action: "list", todos_storage: storage)
-
-        expect(result[:message]).to eq("TODO list")
-        expect(result[:todos].size).to eq(2)
-        expect(result[:total]).to eq(2)
-        expect(result[:pending]).to eq(2)
-        expect(result[:completed]).to eq(0)
-      end
-
-      it "shows pending and completed counts" do
-        storage = []
-        tool.execute(action: "add", task: "Task 1", todos_storage: storage)
-        tool.execute(action: "add", task: "Task 2", todos_storage: storage)
-        tool.execute(action: "complete", id: 1, todos_storage: storage)
-
-        result = tool.execute(action: "list", todos_storage: storage)
-
-        expect(result[:pending]).to eq(1)
-        expect(result[:completed]).to eq(1)
-      end
-    end
-
-    describe "complete action" do
-      it "marks a single todo as completed (integer id)" do
-        storage = []
-        tool.execute(action: "add", task: "Task to complete", todos_storage: storage)
-        result = tool.execute(action: "complete", id: 1, todos_storage: storage)
-
-        expect(result[:message]).to eq("Task marked as completed")
-        expect(result[:todo][:status]).to eq("completed")
-        expect(result[:todo][:completed_at]).not_to be_nil
-      end
-
-      it "marks a single todo as completed when id is a single-element array" do
-        storage = []
-        tool.execute(action: "add", task: ["Task A", "Task B"], todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1], todos_storage: storage)
-
-        expect(result[:message]).to eq("Task marked as completed")
-        expect(result[:todo][:id]).to eq(1)
-      end
-
-      it "batch completes several todos when id is an array" do
-        storage = []
-        tool.execute(action: "add", task: ["T1", "T2", "T3"], todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1, 2], todos_storage: storage)
-
-        expect(result[:message]).to eq("2 task(s) marked as completed")
-        expect(result[:completed].size).to eq(2)
-        expect(result[:completed].map { |t| t[:id] }).to eq([1, 2])
-        expect(result[:progress]).to eq("2/3")
-        expect(result[:next_task][:id]).to eq(3)
-      end
-
-      it "batch complete reports already-completed and not-found ids separately" do
-        storage = []
-        tool.execute(action: "add", task: ["T1", "T2"], todos_storage: storage)
-        tool.execute(action: "complete", id: 1, todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1, 2, 999], todos_storage: storage)
-
-        expect(result[:completed].map { |t| t[:id] }).to eq([2])
-        expect(result[:already_completed].map { |t| t[:id] }).to eq([1])
-        expect(result[:not_found]).to eq([999])
-      end
-
-      it "batch complete auto-clears when all todos are completed" do
-        storage = []
-        tool.execute(action: "add", task: ["T1", "T2", "T3"], todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1, 2, 3], todos_storage: storage)
-
-        expect(result[:all_completed]).to be true
-        expect(result[:completion_message]).to eq("All tasks completed and cleared! (3/3)")
-        expect(storage).to be_empty
-      end
-
-      it "returns message if already completed (single)" do
-        storage = []
-        tool.execute(action: "add", task: "Task", todos_storage: storage)
-        tool.execute(action: "add", task: "Task 2", todos_storage: storage)
-        tool.execute(action: "complete", id: 1, todos_storage: storage)
-        result = tool.execute(action: "complete", id: 1, todos_storage: storage)
-
-        expect(result[:message]).to eq("Task already completed")
-      end
-
-      it "returns error when task not found (single)" do
-        storage = []
-        result = tool.execute(action: "complete", id: 999, todos_storage: storage)
-
-        expect(result[:error]).to eq("Task not found: 999")
-      end
-
-      it "returns error when id is nil" do
-        storage = []
-        result = tool.execute(action: "complete", todos_storage: storage)
-
-        expect(result[:error]).to eq("Task ID is required")
-      end
-
-      it "returns error when id is an empty array" do
-        storage = []
-        result = tool.execute(action: "complete", id: [], todos_storage: storage)
-
-        expect(result[:error]).to eq("Task ID is required")
-      end
-
-      it "auto-clears all todos when last pending task is completed" do
-        storage = []
-        tool.execute(action: "add", task: ["Task 1", "Task 2"], todos_storage: storage)
-        tool.execute(action: "complete", id: 1, todos_storage: storage)
-        result = tool.execute(action: "complete", id: 2, todos_storage: storage)
-
-        expect(result[:all_completed]).to be true
-        expect(result[:completion_message]).to eq("All tasks completed and cleared! (2/2)")
-        expect(storage).to be_empty
+        result = manager.execute(action: "add", todos_storage: todos_storage)
+        expect(result[:error]).to include("required")
       end
 
       it "auto-clears old completed todos when adding new ones" do
-        storage = []
-        tool.execute(action: "add", task: ["Old Task 1", "Old Task 2"], todos_storage: storage)
-        tool.execute(action: "complete", id: 1, todos_storage: storage)
-        # Task 2 still pending, Task 1 completed. Add new task cycle.
-        result = tool.execute(action: "add", task: "New Task", todos_storage: storage)
-
-        # Old completed (#1) should be gone, only pending (#2) and new (#3) remain
-        expect(storage.size).to eq(2)
-        expect(storage.map { |t| t[:id] }).to eq([2, 3])
-        expect(storage.all? { |t| t[:status] == "pending" }).to be true
+        manager.execute(action: "add", task: "Old task", todos_storage: todos_storage)
+        manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        manager.execute(action: "add", task: "New task", todos_storage: todos_storage)
+        expect(todos_storage.length).to eq(1)
+        expect(todos_storage.first[:task]).to eq("New task")
       end
     end
 
-    describe "remove action" do
-      it "removes a todo (integer id)" do
-        storage = []
-        tool.execute(action: "add", task: "Task to remove", todos_storage: storage)
-        result = tool.execute(action: "remove", id: 1, todos_storage: storage)
-
-        expect(result[:message]).to eq("Task removed")
-        expect(result[:remaining]).to eq(0)
+    context "list action" do
+      it "returns empty list when no todos" do
+        result = manager.execute(action: "list", todos_storage: todos_storage)
+        expect(result[:todos]).to be_empty
       end
 
-      it "removes a todo when id is a single-element array" do
-        storage = []
-        tool.execute(action: "add", task: ["a", "b"], todos_storage: storage)
-        result = tool.execute(action: "remove", id: [1], todos_storage: storage)
+      it "lists all todos" do
+        manager.execute(action: "add", task: "Task 1", todos_storage: todos_storage)
+        manager.execute(action: "add", task: "Task 2", todos_storage: todos_storage)
+        result = manager.execute(action: "list", todos_storage: todos_storage)
+        expect(result[:todos].length).to eq(2)
+        expect(result[:todos].map { |t| t[:task] }).to eq(["Task 1", "Task 2"])
+      end
 
-        expect(result[:message]).to eq("Task removed")
-        expect(result[:remaining]).to eq(1)
+      it "shows pending and completed counts" do
+        manager.execute(action: "add", task: "Task 1", todos_storage: todos_storage)
+        manager.execute(action: "add", task: "Task 2", todos_storage: todos_storage)
+        manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        result = manager.execute(action: "list", todos_storage: todos_storage)
+        expect(result[:pending_count]).to eq(1)
+        expect(result[:completed_count]).to eq(1)
+      end
+    end
+
+    context "complete action" do
+      it "marks a single todo as completed" do
+        manager.execute(action: "add", task: "Write unit tests", todos_storage: todos_storage)
+        result = manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        expect(result[:todo][:status]).to eq("completed")
+      end
+
+      it "auto-clears all todos when last pending task is completed" do
+        manager.execute(action: "add", task: "Only task", todos_storage: todos_storage)
+        result = manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        expect(todos_storage).to be_empty
+        expect(result[:all_completed]).to be true
+      end
+
+      it "returns message if already completed" do
+        manager.execute(action: "add", task: "Task 1", todos_storage: todos_storage)
+        manager.execute(action: "add", task: "Task 2", todos_storage: todos_storage)
+        manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        result = manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        expect(result[:message]).to include("already")
       end
 
       it "returns error when task not found" do
-        storage = []
-        result = tool.execute(action: "remove", id: 999, todos_storage: storage)
-
-        expect(result[:error]).to eq("Task not found: 999")
+        result = manager.execute(action: "complete", id: 999, todos_storage: todos_storage)
+        expect(result[:error]).to include("not found")
       end
 
       it "returns error when id is nil" do
-        storage = []
-        result = tool.execute(action: "remove", todos_storage: storage)
-
-        expect(result[:error]).to eq("Task ID is required")
+        result = manager.execute(action: "complete", todos_storage: todos_storage)
+        expect(result[:error]).to include("required")
       end
 
-      it "batch removes multiple todos when id is an array" do
-        storage = []
-        tool.execute(action: "add", task: ["Task 1", "Task 2", "Task 3", "Task 4"], todos_storage: storage)
-        result = tool.execute(action: "remove", id: [1, 3], todos_storage: storage)
-
-        expect(result[:message]).to eq("2 task(s) removed")
-        expect(result[:removed].size).to eq(2)
-        expect(result[:removed][0][:id]).to eq(1)
-        expect(result[:removed][1][:id]).to eq(3)
-        expect(result[:remaining]).to eq(2)
-        expect(storage.size).to eq(2)
-        expect(storage.map { |t| t[:id] }).to eq([2, 4])
-      end
-
-      it "handles batch remove with some non-existent IDs" do
-        storage = []
-        tool.execute(action: "add", task: ["Task 1", "Task 2"], todos_storage: storage)
-        result = tool.execute(action: "remove", id: [1, 999, 2, 888], todos_storage: storage)
-
-        expect(result[:message]).to eq("2 task(s) removed")
-        expect(result[:removed].size).to eq(2)
-        expect(result[:not_found]).to eq([999, 888])
-        expect(result[:remaining]).to eq(0)
-      end
-
-      it "returns error when id is an empty array" do
-        storage = []
-        result = tool.execute(action: "remove", id: [], todos_storage: storage)
-
-        expect(result[:error]).to eq("Task ID is required")
+      it "auto-clears old completed todos when adding new ones" do
+        manager.execute(action: "add", task: "Task 1", todos_storage: todos_storage)
+        manager.execute(action: "complete", id: 1, todos_storage: todos_storage)
+        manager.execute(action: "add", task: "Task 2", todos_storage: todos_storage)
+        expect(todos_storage.length).to eq(1)
+        expect(todos_storage.first[:task]).to eq("Task 2")
       end
     end
 
-    describe "clear action" do
+    context "remove action" do
+      it "removes a todo" do
+        manager.execute(action: "add", task: "Remove me", todos_storage: todos_storage)
+        manager.execute(action: "remove", id: 1, todos_storage: todos_storage)
+        expect(todos_storage).to be_empty
+      end
+
+      it "returns error when task not found" do
+        result = manager.execute(action: "remove", id: 999, todos_storage: todos_storage)
+        expect(result[:error]).to include("not found")
+      end
+
+      it "returns error when id is nil" do
+        result = manager.execute(action: "remove", todos_storage: todos_storage)
+        expect(result[:error]).to include("required")
+      end
+    end
+
+    context "clear action" do
       it "clears all todos" do
-        storage = []
-        tool.execute(action: "add", task: "Task 1", todos_storage: storage)
-        tool.execute(action: "add", task: "Task 2", todos_storage: storage)
-
-        result = tool.execute(action: "clear", todos_storage: storage)
-
-        expect(result[:message]).to eq("All TODOs cleared")
-        expect(result[:cleared_count]).to eq(2)
-        expect(storage).to be_empty
+        manager.execute(action: "add", task: "Task 1", todos_storage: todos_storage)
+        manager.execute(action: "add", task: "Task 2", todos_storage: todos_storage)
+        result = manager.execute(action: "clear", todos_storage: todos_storage)
+        expect(todos_storage).to be_empty
+        expect(result[:cleared]).to eq(2)
       end
 
       it "clears empty list" do
-        storage = []
-        result = tool.execute(action: "clear", todos_storage: storage)
-
-        expect(result[:message]).to eq("All TODOs cleared")
-        expect(result[:cleared_count]).to eq(0)
+        result = manager.execute(action: "clear", todos_storage: todos_storage)
+        expect(todos_storage).to be_empty
+        expect(result[:cleared]).to eq(0)
       end
     end
 
-    describe "unknown action" do
+    context "unknown action" do
       it "returns error for unknown action" do
-        storage = []
-        result = tool.execute(action: "invalid_action", todos_storage: storage)
-
-        expect(result[:error]).to eq("Unknown action: invalid_action")
+        result = manager.execute(action: "unknown_action", todos_storage: todos_storage)
+        expect(result[:error]).to include("Unknown action")
       end
     end
   end
 
   describe "#format_call" do
     it "formats add with string task" do
-      expect(tool.format_call(action: "add", task: "x")).to eq("TodoManager(add 1 task)")
-    end
-
-    it "formats add with array task" do
-      expect(tool.format_call(action: "add", task: ["a", "b"])).to eq("TodoManager(add 2 tasks)")
+      call = manager.format_call({ action: "add", task: "Write tests" })
+      expect(call).to eq("TodoManager(add: Write tests)")
     end
 
     it "formats complete with integer id" do
-      expect(tool.format_call(action: "complete", id: 5)).to eq("TodoManager(complete #5)")
+      call = manager.format_call({ action: "complete", id: 5 })
+      expect(call).to eq("TodoManager(complete #5)")
     end
 
-    it "formats complete with array id (batch)" do
-      expect(tool.format_call(action: "complete", id: [1, 2, 3]))
-        .to eq("TodoManager(complete 3 tasks: 1, 2, 3)")
+    it "formats remove with integer id" do
+      call = manager.format_call({ action: "remove", id: 3 })
+      expect(call).to eq("TodoManager(remove #3)")
     end
 
-    it "formats complete with single-element array id" do
-      expect(tool.format_call(action: "complete", id: [7])).to eq("TodoManager(complete #7)")
-    end
-
-    it "formats remove with array id" do
-      expect(tool.format_call(action: "remove", id: [4, 5]))
-        .to eq("TodoManager(remove 2 tasks: 4, 5)")
+    it "formats list" do
+      call = manager.format_call({ action: "list" })
+      expect(call).to eq("TodoManager(list)")
     end
 
     it "formats clear" do
-      expect(tool.format_call(action: "clear")).to eq("TodoManager(clear all)")
+      call = manager.format_call({ action: "clear" })
+      expect(call).to eq("TodoManager(clear all)")
     end
   end
 
   describe "#to_function_definition" do
     it "returns OpenAI function calling format" do
-      definition = tool.to_function_definition
-
-      expect(definition[:type]).to eq("function")
-      expect(definition[:function][:name]).to eq("todo_manager")
-      expect(definition[:function][:parameters][:type]).to eq("object")
+      func_def = manager.to_function_definition
+      expect(func_def[:type]).to eq("function")
+      expect(func_def[:function][:name]).to eq("todo_manager")
+      expect(func_def[:function][:parameters][:type]).to eq("object")
     end
 
     it "includes all action types in enum" do
-      definition = tool.to_function_definition
-      actions = definition[:function][:parameters][:properties][:action][:enum]
-
+      func_def = manager.to_function_definition
+      actions = func_def[:function][:parameters][:properties][:action][:enum]
       expect(actions).to include("add", "list", "complete", "remove", "clear")
     end
 
-    it "exposes polymorphic task parameter with oneOf string|array" do
-      definition = tool.to_function_definition
-      task_prop = definition[:function][:parameters][:properties][:task]
-
-      expect(task_prop).to have_key(:oneOf)
-      types = task_prop[:oneOf].map { |s| s[:type] }
-      expect(types).to contain_exactly("string", "array")
+    it "exposes task as string type" do
+      func_def = manager.to_function_definition
+      task_type = func_def[:function][:parameters][:properties][:task][:type]
+      expect(task_type).to eq("string")
     end
 
-    it "exposes polymorphic id parameter with oneOf integer|array" do
-      definition = tool.to_function_definition
-      id_prop = definition[:function][:parameters][:properties][:id]
-
-      expect(id_prop).to have_key(:oneOf)
-      types = id_prop[:oneOf].map { |s| s[:type] }
-      expect(types).to contain_exactly("integer", "array")
+    it "exposes id as integer type" do
+      func_def = manager.to_function_definition
+      id_type = func_def[:function][:parameters][:properties][:id][:type]
+      expect(id_type).to eq("integer")
     end
 
     it "no longer exposes legacy `tasks` or `ids` fields" do
-      definition = tool.to_function_definition
-      props = definition[:function][:parameters][:properties]
-
+      func_def = manager.to_function_definition
+      props = func_def[:function][:parameters][:properties]
       expect(props).not_to have_key(:tasks)
       expect(props).not_to have_key(:ids)
     end


### PR DESCRIPTION
# fix(tools): simplify TodoManager to single-value params (Pi-style)

## Problem

TodoManager uses `oneOf: [string, array]` for `task` and `id` parameters, which causes array serialization issues when LLMs emit stringified arrays instead of actual arrays.

When the LLM sends `task: "[\"Task 1\", \"Task 2\"]"` (string instead of array), `Array()` treats the entire string as one task, resulting in a garbled todo like:

```
#1 ["Task 1", "Task 2"]
```

## Root Cause

The `normalize_to_array` method uses Ruby's `Array()` which doesn't parse stringified JSON arrays:

```ruby
private def normalize_to_array(value)
  return [] if value.nil?
  Array(value).reject(&:nil?)  # Array("[\"a\",\"b\"]") → ["[\"a\",\"b\"]"]
end
```

## Solution

Simplify TodoManager to match Pi Coding Agent's design: **single-value parameters only**.

### Changes

1. **Parameter schema**: `task` → `string`, `id` → `integer` (remove `oneOf` array support)
2. **Remove `normalize_to_array`**: No longer needed
3. **Rename methods**: `add_todos` → `add_todo`, remove `complete_todos`/`remove_todos`
4. **Add ID validation**: Reject non-numeric strings to prevent `to_i` converting "abc" to 0
5. **Remove `require "json"`**: No longer needed

### Before vs After

| Aspect | Before | After (Pi-style) |
|--------|--------|------------------|
| `task` param | `string \| array` | `string` only |
| `id` param | `integer \| array` | `integer` only |
| Batch support | Single call | Multiple calls |
| Lines of code | ~360 | ~210 |
| Array serialization bug | Possible | Impossible |

## Why This Works

By accepting only single values, we eliminate the ambiguity between string and array types. The LLM can never accidentally serialize an array as a string because arrays are not accepted at all.

## Trade-offs

- **Lost**: Batch add/complete/remove in single call
- **Gained**: Complete elimination of array serialization bugs, simpler code, clearer API

Batch operations can still be done by calling the tool multiple times, which is how Pi Coding Agent handles it.

## Testing

- ✅ `add` with single string works
- ✅ `complete` with single integer works  
- ✅ `list` returns all todos
- ✅ Invalid ID (non-numeric) rejected with clear error
- ✅ Ruby syntax check passes
