### PR TITLE
Fix expired extension download URLs

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -2735,15 +2735,41 @@ module Clacky
       # DELETE /api/store/extension   body: { id: <slug> }
       def api_store_extension_install(req, res)
         body         = parse_json_body(req)
+        id           = body["id"].to_s.strip
+        source       = body["source"].to_s.strip
         download_url = body["download_url"].to_s.strip
         name         = body["name"].to_s.strip
 
-        if download_url.empty?
-          json_response(res, 400, { ok: false, error: "Missing download_url." })
+        if id.empty? && download_url.empty?
+          json_response(res, 400, { ok: false, error: "Missing extension id or download_url." })
           return
         end
 
-        Clacky::ExtensionPackager.install(download_url, force: true)
+        attempts = 0
+        begin
+          unless id.empty?
+            result = extension_install_detail(id, source)
+            unless result[:success] && result[:extension]
+              json_response(res, 422, { ok: false, error: result[:error] || "Extension not found." })
+              return
+            end
+
+            extension  = result[:extension]
+            download_url = extension["download_url"].to_s.strip
+            name         = extension["name"].to_s.strip
+            if download_url.empty?
+              json_response(res, 422, { ok: false, error: "No download URL available." })
+              return
+            end
+          end
+
+          Clacky::ExtensionPackager.install(download_url, force: true)
+        rescue Clacky::ExtensionPackager::Error => e
+          attempts += 1
+          retry if !id.empty? && attempts < 2 && e.message.match?(/(?:404|not found)/i)
+          raise
+        end
+
         Clacky::ExtensionLoader.invalidate_cache!
         Clacky::Telemetry.extension_install!(name) unless name.empty?
         json_response(res, 200, { ok: true, name: name })
@@ -2751,6 +2777,15 @@ module Clacky
         json_response(res, 422, { ok: false, error: e.message })
       rescue StandardError => e
         json_response(res, 500, { ok: false, error: e.message })
+      end
+
+      private def extension_install_detail(id, source)
+        brand = Clacky::BrandConfig.load
+        if source == "brand"
+          brand.brand_extension_detail!(id)
+        else
+          brand.extension_detail!(id)
+        end
       end
 
       def api_store_extension_uninstall(req, res)

--- a/lib/clacky/web/features/extensions/store.js
+++ b/lib/clacky/web/features/extensions/store.js
@@ -247,28 +247,14 @@ const ExtensionsStore = (() => {
       }
     },
 
-    /** Install a marketplace extension by fetching its download_url then posting to the local server. */
+    /** Install a marketplace extension using a fresh server-resolved download URL. */
     async install(id) {
       if (!id) return;
       try {
-        // Prefer the already-loaded detail (avoids a second round-trip and correctly
-        // handles brand-private extensions whose detail was fetched with &source=brand).
-        let ext;
-        if (_detail && String(_detail.id) === String(id)) {
-          ext = _detail;
-        } else {
-          const source     = _filterBrand ? "&source=brand" : "";
-          const detailRes  = await fetch("/api/store/extension?id=" + encodeURIComponent(id) + source);
-          const detailData = await detailRes.json();
-          if (!detailRes.ok || !detailData.ok) throw new Error(detailData.error || "fetch detail failed");
-          ext = detailData.extension;
-        }
-        const download_url = ext.download_url;
-        if (!download_url) throw new Error("No download URL available");
         const res = await fetch("/api/store/extension/install", {
           method:  "POST",
           headers: { "Content-Type": "application/json" },
-          body:    JSON.stringify({ download_url, name: ext.name }),
+          body:    JSON.stringify({ id, source: _filterBrand ? "brand" : "marketplace" }),
         });
         const data = await res.json();
         if (!res.ok || !data.ok) throw new Error(data.error || "install failed");

--- a/spec/clacky/server/http_server_extension_install_spec.rb
+++ b/spec/clacky/server/http_server_extension_install_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "clacky/server/http_server"
+require "clacky/agent_config"
+require_relative "http_server_spec"
+
+RSpec.describe Clacky::Server::HttpServer, "extension marketplace install API" do
+  include HttpServerSpecHelpers
+
+  let(:tmpdir) { Dir.mktmpdir("clacky_extension_install_spec") }
+  let(:config_file) { File.join(tmpdir, "config.yml") }
+  let(:agent_config) do
+    stub_const("Clacky::AgentConfig::CONFIG_FILE", config_file)
+    Clacky::AgentConfig.new(models: [])
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "refreshes an expired download URL and retries one transient 404" do
+    brand = instance_double(Clacky::BrandConfig)
+    allow(brand).to receive(:extension_detail!).with("demo-extension").and_return(
+      {
+        success: true,
+        extension: {
+          "name" => "demo-extension",
+          "download_url" => "https://example.com/expired.zip"
+        }
+      },
+      {
+        success: true,
+        extension: {
+          "name" => "demo-extension",
+          "download_url" => "https://example.com/fresh.zip"
+        }
+      }
+    )
+    allow(Clacky::ExtensionPackager).to receive(:install)
+      .with("https://example.com/expired.zip", force: true)
+      .and_raise(Clacky::ExtensionPackager::Error, "failed to download: 404 Not Found")
+    allow(Clacky::ExtensionPackager).to receive(:install)
+      .with("https://example.com/fresh.zip", force: true)
+      .and_return(true)
+    allow(Clacky::ExtensionLoader).to receive(:invalidate_cache!)
+    allow(Clacky::Telemetry).to receive(:extension_install!)
+
+    with_server(agent_config: agent_config) do |server|
+      allow(Clacky::BrandConfig).to receive(:load).and_return(brand)
+      req = fake_req(
+        method: "POST",
+        path: "/api/store/extension/install",
+        body: { id: "demo-extension", source: "marketplace" }
+      )
+      res = fake_res
+      dispatch(server, req, res)
+
+      expect(res.status).to eq(200)
+      expect(parsed_body(res)).to include("ok" => true, "name" => "demo-extension")
+      expect(brand).to have_received(:extension_detail!).twice
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Resolve marketplace extension download URLs on the server at install time.
- Retry once after a transient 404 with a newly signed URL.
- Preserve compatibility with legacy `download_url` clients.

## Root cause

Active Storage download URLs expire after about five minutes. The extension detail UI cached the signed URL and later passed it to the local installer, so the first attempt could return 404 until the detail was refreshed.

## User impact

Users can install extensions after leaving a detail page open, and transient blob 404s are retried automatically.

## Validation

- `node --check lib/clacky/web/features/extensions/store.js`
- `ruby -c lib/clacky/server/http_server.rb`
- `ruby -c spec/clacky/server/http_server_extension_install_spec.rb`
- `rspec spec/clacky/server/http_server_extension_install_spec.rb` — 63 examples, 0 failures

Built with OpenClacky.
