### PR TITLE
fix(web): persist sidebar visibility across page reloads

### DIFF
--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -662,16 +662,23 @@ function showConfirmModal(confId, message) {
 
 // ── DOM event listeners ───────────────────────────────────────────────────
 // Sidebar toggle (with mobile overlay support)
+// Persist the sidebar's visibility so a hard refresh keeps the user's last
+// state instead of always snapping back to "open". (Matches the treatment
+// already given to sidebar *width*, the aside panel, and the todo panel.)
+const _SIDEBAR_HIDDEN_KEY = "clacky-sidebar-hidden";
+
 function _isMobile() { return window.innerWidth <= 768; }
 
 function _closeSidebar() {
   $("sidebar").classList.add("hidden");
   $("sidebar-overlay").classList.remove("active");
+  try { localStorage.setItem(_SIDEBAR_HIDDEN_KEY, "1"); } catch (_e) { /* ignore */ }
 }
 
 function _openSidebar() {
   $("sidebar").classList.remove("hidden");
   if (_isMobile()) $("sidebar-overlay").classList.add("active");
+  try { localStorage.setItem(_SIDEBAR_HIDDEN_KEY, "0"); } catch (_e) { /* ignore */ }
 }
 
 function _toggleSidebar() {
@@ -737,8 +744,15 @@ $("sidebar-overlay").addEventListener("click", _closeSidebar);
   });
 })();
 
-// On mobile: start with sidebar hidden
-if (_isMobile()) _closeSidebar();
+// On mobile: start with sidebar hidden.
+// On desktop: restore the user's last sidebar visibility (persisted).
+if (_isMobile()) {
+  _closeSidebar();
+} else {
+  try {
+    if (localStorage.getItem(_SIDEBAR_HIDDEN_KEY) === "1") _closeSidebar();
+  } catch (_e) { /* ignore */ }
+}
 
 // On mobile: auto-close sidebar when switching sessions/pages
 function _mobileCloseSidebar() {


### PR DESCRIPTION
## What
Persist the left sidebar's collapsed/expanded state so it survives a hard page refresh.

## Why
Currently the sidebar's visibility is not persisted. `_closeSidebar()` / `_openSidebar()` only toggle the DOM `hidden` class without writing anything to storage, so a hard refresh always snaps back to **open** — discarding the user's choice.

This is inconsistent with the very same file, which already persists three sibling UI states:
- sidebar **width** → `clacky-sidebar-width`
- the **aside panel** → `clacky.aside.open`
- the **todo panel** → `clacky-todo-collapsed`

Only the sidebar's *visibility* was missed, so this looks like an oversight rather than a design choice.

## Changes
- `lib/clacky/web/app.js`:
  - `_closeSidebar()` / `_openSidebar()` now write `clacky-sidebar-hidden` (`"1"`/`"0"`) to `localStorage`.
  - On init, desktop restores the last state from `localStorage`; mobile keeps its existing default-hidden behavior unchanged.

## Impact
- Fully backward compatible. First-time visitors see no change (no stored value ⇒ stays open, same as before).
- No new dependencies, no new configuration knobs.
- Mobile behavior is unchanged (always starts hidden, tap overlay to close).
- Smallest possible diff: +16 / −2 in a single file.

## Testing
- `node --check lib/clacky/web/app.js` passes.
- Manual verification on a running `openclacky server` (1.5.4): collapsed the sidebar, hard-refreshed (Ctrl+Shift+R), confirmed it stays collapsed; expanded it, refreshed, confirmed it stays expanded. Mobile (≤768px) still starts hidden.

Authored using OpenClacky itself.