### PR TITLE
fix(web): render user message files immediately, proxy local disk images

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -6766,7 +6766,13 @@ module Clacky
         msg_created_at = Time.now.to_f
         web_ui = nil
         @registry.with_session(session_id) { |s| web_ui = s[:ui] }
-        web_ui&.show_user_message(content, created_at: msg_created_at, source: :web)
+        # Pass the uploaded files through to the realtime broadcast so images and
+        # attachments render in the bubble immediately. agent.run later appends the
+        # authoritative display_files to history — but only after vision/OCR
+        # processing finishes, which can take seconds. Without the preview here, a
+        # page refresh inside that window shows the message without its image (the
+        # "need to refresh several times before the image appears" bug).
+        web_ui&.show_user_message(content, created_at: msg_created_at, source: :web, files: Array(files))
 
         # File references are now handled inside agent.run — injected as a system_injected
         # message after the user message, so replay_history skips them automatically.

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require "json"
 require "securerandom"
 require_relative "../ui_interface"
@@ -70,11 +71,20 @@ module Clacky
         data[:created_at] = created_at if created_at
         # Build ev.images for the frontend renderer (history_user_message):
         #   - Images with data_url → pass the data_url directly (<img> thumbnail)
-        #   - Disk files (PDF, doc, etc., no data_url) → "pdf:name" sentinel (renders a badge)
+        #   - Disk image files (type=="image", has path) → /api/local-image proxy URL
+        #   - Disk files (PDF, doc, etc., no data_url, no image path) → "pdf:name" sentinel
         rendered = Array(files).filter_map do |f|
           url  = f[:data_url] || f["data_url"]
           name = f[:name]     || f["name"]
-          url || (name ? "pdf:#{name}" : nil)
+          type = f[:type]     || f["type"]
+          path = f[:path]     || f["path"]
+          if url
+            url
+          elsif type.to_s == "image" && path && File.exist?(path.to_s)
+            "/api/local-image?path=#{CGI.escape(path.to_s)}&v=#{File.mtime(path.to_s).to_i}"
+          elsif name
+            "pdf:#{name}"
+          end
         end
         data[:images] = rendered unless rendered.empty?
         emit("history_user_message", **data)

--- a/spec/clacky/server/web_ui_controller_spec.rb
+++ b/spec/clacky/server/web_ui_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "clacky/server/web_ui_controller"
+
+RSpec.describe Clacky::Server::WebUIController, "#show_user_message" do
+  let(:tmpdir) { Dir.mktmpdir("web_ui_controller_spec") }
+  let(:events) { [] }
+  let(:controller) do
+    described_class.new("test-session", ->(_sid, event) { events << event })
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  # Returns the images array of the emitted history_user_message event.
+  def emitted_images(content, files)
+    events.clear
+    controller.show_user_message(content, files: files)
+    ev = events.find { |e| e[:type] == "history_user_message" }
+    ev ? ev[:images] : nil
+  end
+
+  it "passes data_url images through unchanged" do
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+    images = emitted_images("hello", [{ name: "img.png", type: "image", data_url: data_url }])
+    expect(images).to eq([data_url])
+  end
+
+  it "serves a disk image file (type image + existing path) via /api/local-image" do
+    image_path = File.join(tmpdir, "puppy.png")
+    File.binwrite(image_path, "PNGDATA")
+    mtime_v = File.mtime(image_path).to_i
+
+    images = emitted_images("", [{ name: "puppy.png", type: "image", path: image_path }])
+    expect(images).to eq(["/api/local-image?path=#{CGI.escape(image_path)}&v=#{mtime_v}"])
+  end
+
+  it "falls back to pdf:name sentinel for disk files that are not images" do
+    images = emitted_images("doc", [{ name: "report.pdf", type: "pdf", path: "/tmp/report.pdf" }])
+    expect(images).to eq(["pdf:report.pdf"])
+  end
+
+  it "does not emit local-image URL when the image path does not exist on disk" do
+    images = emitted_images("", [{ name: "gone.png", type: "image", path: "/tmp/definitely-missing.png" }])
+    # Missing file -> falls through to name sentinel (badge), not a broken proxy URL
+    expect(images).to eq(["pdf:gone.png"])
+  end
+
+  it "supports symbol and string keyed file hashes" do
+    image_path = File.join(tmpdir, "str.png")
+    File.binwrite(image_path, "PNG")
+    images_str = emitted_images("", [{ "name" => "str.png", "type" => "image", "path" => image_path }])
+    expect(images_str.first).to start_with("/api/local-image?path=")
+  end
+
+  it "omits images key entirely when no files are renderable" do
+    events.clear
+    controller.show_user_message("plain text", files: [])
+    ev = events.find { |e| e[:type] == "history_user_message" }
+    expect(ev.key?(:images)).to be(false)
+  end
+end


### PR DESCRIPTION
## What

Fix two related gaps in the Web UI's user-message rendering:

1. The realtime `history_user_message` broadcast never included the uploaded files, so a page refresh while vision/OCR processing was still running showed the message **without its image**. The image only appeared once processing finished and `display_files` was appended to history — users saw "I have to refresh several times before the image shows up".
2. `show_user_message` degraded **local disk image files** (`type == "image"` with a `path`) to a `pdf:name` badge instead of rendering the actual image, so disk-resident images (oversized / OCR-downgraded) never displayed on the browser.

## Why

- User messages with attachments (images, PDFs, docs) should render immediately on send — not after the async `agent.run` finishes parsing files (which can take seconds for non-vision providers via OCR downgrade).
- The server already proxies local images via `GET /api/local-image?path=...&v=<mtime>` for assistant messages; user-message disk images should use the same path instead of a badge.

## Changes

- `lib/clacky/server/http_server.rb` (`handle_user_message`): pass `Array(files)` through to `show_user_message` so the realtime broadcast renders data_url images, local disk images and file badges immediately. `agent.run` still appends the authoritative `display_files` to history afterwards (no behaviour change there).
- `lib/clacky/server/web_ui_controller.rb` (`show_user_message`): route disk image files (`type == "image"` with an existing `path`) through `/api/local-image?path=<escaped>&v=<mtime>` instead of falling through to the `pdf:name` sentinel.

## Impact

- User bubble shows attachments instantly on send; no more "refresh N times" behaviour.
- Disk-resident images render correctly after refresh / session switch.
- No new dependencies; `require "cgi"` added to `web_ui_controller.rb` (stdlib).

## Testing

- New spec `spec/clacky/server/web_ui_controller_spec.rb` (6 examples): data_url passthrough, disk image → local-image URL, non-image → pdf badge, missing path fallback, symbol/string keyed hashes, no `images` key when nothing renderable. All pass (`bundle exec rspec spec/clacky/server/web_ui_controller_spec.rb` → 6 examples, 0 failures).
- Manually verified the realtime broadcast now carries the local-image proxy URL for uploaded disk images.

Authored using OpenClacky itself.
