### PR TITLE
feat(extension): bridge WebSocket session events to Clacky.ext bus

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
+++ b/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
@@ -92,9 +92,11 @@ exactly three capabilities:
 
 ```js
 Clacky.ext.ui.mount(slot, spec, opts)     // inject UI into a named slot
-Clacky.ext.subscribe(event, handler)      // observe host store events (read-only)
+Clacky.ext.subscribe(event, handler)      // observe store events + live session events (read-only)
 Clacky.ext.api.register(name, fn)         // expose a named data source; api.resolve(name)
 ```
+
+**`subscribe(event, handler)`** - two event families: (1) host **store** events (`skills:changed`, `tasks:changed`, `profile:changed`, …) and (2) **live session events** mirrored from the WebSocket stream — conversation (`session:assistant-message`, `session:tool-call`, `session:tool-result`), status/errors (`session:error`, `session:warning`, `session:update`), lifecycle (`session:renamed`, `session:deleted`, …). Payload is `{ sessionId, ...wsFields }`. Full list in the "Core Events" section of the extend-webui docs. Handlers are read-only.
 
 **`ui.mount(slot, spec, opts)`** — `spec` is either `(container, ctx, runtime) => …` or
 `{ create?, render }`. The render function:

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -16,6 +16,36 @@
   // Guard: restore hash routing only once after initial session_list arrives.
   let _initialRestoreDone = false;
 
+  // WS event -> Clacky.ext event name. Mirrored so panels can subscribe
+  // without touching the raw WS layer (keeps extension isolation).
+  const SESSION_EXT_EVENTS = {
+    phase_start: "session:phase-start",
+    phase_end: "session:phase-end",
+    session_list: "session:list",
+    subscribed: "session:subscribed",
+    session_update: "session:update",
+    task_finished: "session:task-finished",
+    session_renamed: "session:renamed",
+    session_deleted: "session:deleted",
+    session_restored: "session:restored",
+    history_user_message: "session:user-message",
+    assistant_message: "session:assistant-message",
+    tool_call: "session:tool-call",
+    tool_result: "session:tool-result",
+    tool_stdout: "session:tool-stdout",
+    tool_error: "session:tool-error",
+    token_usage: "session:token-usage",
+    progress: "session:progress",
+    complete: "session:complete",
+    request_feedback: "session:request-feedback",
+    request_confirmation: "session:request-confirmation",
+    interrupted: "session:interrupted",
+    info: "session:info",
+    warning: "session:warning",
+    success: "session:success",
+    error: "session:error",
+  };
+
   // ── Phase grouping (folds subagent runs like skill evolution) ───────────
   //
   // Strategy: when a phase_start arrives, we append a foldable card to the
@@ -135,6 +165,15 @@ WS.onEvent(ev => {
   // - Session changed → phase belongs to the previous session, close it.
   if (ev.type === "history_user_message" || ev.type === "subscribed") {
     _closeAllPhases("incomplete");
+  }
+
+  // Bridge before the switch: per-case active-session guards must not block
+  // the extension bus. All received events mirror onto Clacky.ext here.
+  if (window.Clacky && Clacky.ext) {
+    const extName = SESSION_EXT_EVENTS[ev.type];
+    if (extName) {
+      Clacky.ext.emit(extName, { sessionId: ev.session_id, ...ev });
+    }
   }
 
   switch (ev.type) {
@@ -326,9 +365,6 @@ WS.onEvent(ev => {
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.clearProgress();
       Sessions.appendMsg("assistant", ev.content);
-      if (window.Clacky && Clacky.ext) {
-        Clacky.ext.emit("session:assistant-message", { sessionId: ev.session_id, content: ev.content });
-      }
       break;
 
     case "tool_call":


### PR DESCRIPTION
## Problem
Extension panels could not observe live session activity in real time. `Clacky.ext.subscribe` existed but the host only emitted 2 session events (`session:assistant-message`, `session:agent-changed`). Extensions had to poll APIs (high latency) or bypass isolation by calling `Clacky.WS.onEvent` directly.

## Fix
Unified bridge in `ws-dispatcher.js` mirrors 25 session-related WS events onto `Clacky.ext`:
- `SESSION_EXT_EVENTS` mapping table (WS type → `session:*` event name)
- Emit before the `switch` — per-case `activeId` guards no longer block the extension bus
- Payload: `{ sessionId, ...wsFields }` (raw WS fields passed through verbatim)
- Removed duplicate `emit` in `assistant_message` case
- Updated `ext-develop/SKILL.md` subscribe contract

## Test
- ✅ `node -c` syntax check passed
- ✅ `Clacky.ext.emit` only in bridge code (duplicate removed)
- ✅ RSpec 2921 examples, 0 failures