### PR TITLE
feat(providers): add Ollama (Cloud) provider preset

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -477,6 +477,67 @@ module Clacky
         "website_url" => "https://console.volcengine.com/ark/region:cn-beijing/overview"
       }.freeze,
 
+      "ollama" => {
+        "name" => "Ollama (Cloud)",
+        # Ollama Cloud API — OpenAI-compatible endpoint serving both local and
+        # cloud models. Cloud models are available immediately without pulling.
+        # Authentication: API key via Authorization: Bearer <key> header.
+        # Create API keys at: https://ollama.com/settings/keys
+        "base_url" => "https://ollama.com/api",
+        "api" => "openai-completions",
+        "default_model" => "deepseek-v4-flash",
+        # Curated list of cloud-enabled models from the Ollama library.
+        # Users can type any Ollama model name manually; this list seeds the picker.
+        "models" => [
+          "glm-5.2",
+          "kimi-k3",
+          "gemma4",
+          "qwen3.5",
+          "glm-5.1",
+          "minimax-m2.7",
+          "nemotron-3-super",
+          "minimax-m3",
+          "kimi-k2.7-code",
+          "kimi-k2.6",
+          "deepseek-v4-flash",
+          "deepseek-v4-pro",
+          "nemotron-3-ultra",
+          "gemini-3-flash-preview",
+          "nemotron-3-nano",
+          "mistral-large-3",
+          "gpt-oss"
+        ],
+        # Provider-level default: many Ollama cloud models are vision-capable.
+        "capabilities" => { "vision" => true }.freeze,
+        # Model-level overrides: text-only models that don't accept image input.
+        "model_capabilities" => {
+          "glm-5.2"             => { "vision" => false }.freeze,
+          "glm-5.1"             => { "vision" => false }.freeze,
+          "minimax-m2.7"        => { "vision" => false }.freeze,
+          "deepseek-v4-pro"     => { "vision" => false }.freeze,
+          "deepseek-v4-flash"   => { "vision" => false }.freeze,
+          "nemotron-3-super"    => { "vision" => false }.freeze,
+          "nemotron-3-ultra"    => { "vision" => false }.freeze,
+          "nemotron-3-nano"     => { "vision" => false }.freeze,
+          "gpt-oss"             => { "vision" => false }.freeze
+        }.freeze,
+        # Per-primary lite pairing: subagents use smaller models for cheap/fast work.
+        "lite_models" => {
+          "glm-5.2"                => "glm-5.1",
+          "kimi-k3"                => "kimi-k2.6",
+          "gemma4"                 => "nemotron-3-nano",
+          "qwen3.5"                => "gemini-3-flash-preview",
+          "minimax-m3"             => "minimax-m2.7",
+          "kimi-k2.7-code"         => "kimi-k2.6",
+          "deepseek-v4-pro"        => "deepseek-v4-flash",
+          "mistral-large-3"        => "nemotron-3-nano",
+          "gpt-oss"                => "nemotron-3-nano",
+          "gemini-3-flash-preview"  => "nemotron-3-nano"
+        },
+        "default_ocr_model" => "kimi-k2.7-code",
+        "website_url" => "https://ollama.com/settings/keys"
+      }.freeze,
+
       "openai" => {
         "name" => "OpenAI (GPT)",
         "base_url" => "https://api.openai.com/v1",

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -131,6 +131,71 @@ RSpec.describe Clacky::Providers do
       end
     end
 
+    context "for Ollama (Cloud) provider" do
+      it "resolves default model to deepseek-v4-flash" do
+        expect(described_class.default_model("ollama")).to eq("deepseek-v4-flash")
+      end
+
+      it "has correct base_url and api type" do
+        expect(described_class.base_url("ollama")).to eq("https://ollama.com/api")
+        expect(described_class.api_type("ollama")).to eq("openai-completions")
+      end
+
+      it "includes expected cloud models" do
+        expect(described_class.models("ollama")).to include(
+          "glm-5.2", "kimi-k3", "gemma4", "qwen3.5",
+          "deepseek-v4-pro", "deepseek-v4-flash",
+          "gemini-3-flash-preview", "gpt-oss"
+        )
+        expect(described_class.models("ollama")).not_to include(
+          "qwen3-coder:480b-cloud", "gpt-oss:120b-cloud",
+          "gpt-oss:20b-cloud", "deepseek-v3.1:671b-cloud"
+        )
+      end
+
+      it "returns correct lite model mappings" do
+        expect(described_class.lite_model("ollama", "glm-5.2")).to eq("glm-5.1")
+        expect(described_class.lite_model("ollama", "kimi-k3")).to eq("kimi-k2.6")
+        expect(described_class.lite_model("ollama", "deepseek-v4-pro")).to eq("deepseek-v4-flash")
+        expect(described_class.lite_model("ollama", "qwen3.5")).to eq("gemini-3-flash-preview")
+        expect(described_class.lite_model("ollama", "gpt-oss")).to eq("nemotron-3-nano")
+      end
+
+      it "returns nil lite for models without lite pairing" do
+        expect(described_class.lite_model("ollama", "glm-5.1")).to be_nil
+        expect(described_class.lite_model("ollama", "minimax-m2.7")).to be_nil
+      end
+
+      it "enforces vision capabilities correctly" do
+        # Vision-capable models
+        expect(described_class.supports?("ollama", :vision, model_name: "kimi-k3")).to be true
+        expect(described_class.supports?("ollama", :vision, model_name: "gemma4")).to be true
+        expect(described_class.supports?("ollama", :vision, model_name: "qwen3.5")).to be true
+        expect(described_class.supports?("ollama", :vision, model_name: "minimax-m3")).to be true
+        expect(described_class.supports?("ollama", :vision, model_name: "mistral-large-3")).to be true
+        # Text-only models
+        expect(described_class.supports?("ollama", :vision, model_name: "glm-5.2")).to be false
+        expect(described_class.supports?("ollama", :vision, model_name: "deepseek-v4-pro")).to be false
+        expect(described_class.supports?("ollama", :vision, model_name: "deepseek-v4-flash")).to be false
+        expect(described_class.supports?("ollama", :vision, model_name: "minimax-m2.7")).to be false
+        expect(described_class.supports?("ollama", :vision, model_name: "gpt-oss")).to be false
+      end
+
+      it "resolves provider by base_url" do
+        expect(described_class.find_by_base_url("https://ollama.com/api")).to eq("ollama")
+        expect(described_class.find_by_base_url("https://ollama.com/api/v1/chat/completions")).to eq("ollama")
+      end
+
+      it "has a website_url for API keys" do
+        preset = described_class::PRESETS["ollama"]
+        expect(preset["website_url"]).to eq("https://ollama.com/settings/keys")
+      end
+
+      it "has a default_ocr_model" do
+        expect(described_class.default_ocr_model("ollama")).to eq("kimi-k2.7-code")
+      end
+    end
+
     context "conservative default (unknown or undeclared)" do
       it "returns true for an unknown provider_id" do
         # Custom base_urls map to nil provider_id; assume capability supported


### PR DESCRIPTION
## What

Adds an **Ollama (Cloud)** provider preset to OpenClacky, enabling users to configure and use Ollama's cloud-hosted models directly through the OpenAI-compatible API endpoint at `https://ollama.com/api`.

## Why

Ollama Cloud offers a growing catalog of open-weight cloud models (kimi-k3, gemma4, qwen3.5, deepseek-v4, etc.) under a simple subscription model. Adding a built-in preset means users can point OpenClacky at Ollama Cloud with zero manual configuration — just their API key.

## What's included

- **Provider preset** (`lib/clacky/providers.rb`): 17 cloud-enabled models with correct vision capability mappings (vision-capable models like kimi-k3, gemma4, qwen3.5 vs text-only models like glm-5.2, deepseek-v4)
- **OCR sidecar**: `kimi-k2.7-code` configured as the default OCR model for image reading when the primary model is text-only
- **Lite model pairings**: Per-primary lite mappings so subagent forks automatically use a cheaper/faster companion model
- **Tests** (`spec/clacky/providers_spec.rb`): Full coverage for default model, base URL, API type, model list, lite mappings, vision capabilities, provider resolution, and OCR defaults

## User-visible impact

- Users can now select "Ollama (Cloud)" from the provider dropdown in Settings
- Configure with `base_url: https://ollama.com/api` and an Ollama API key from https://ollama.com/settings/keys
- Default model: `deepseek-v4-flash`
- Image reading automatically routes to `kimi-k2.7-code` when the primary model is text-only

Authored using OpenClacky.
