### PR TITLE
fix(ollama): correct base URL from /api to root domain

### DIFF
--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -483,7 +483,7 @@ module Clacky
         # cloud models. Cloud models are available immediately without pulling.
         # Authentication: API key via Authorization: Bearer <key> header.
         # Create API keys at: https://ollama.com/settings/keys
-        "base_url" => "https://ollama.com/api",
+        "base_url" => "https://ollama.com",
         "api" => "openai-completions",
         "default_model" => "deepseek-v4-flash",
         # Curated list of cloud-enabled models from the Ollama library.

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Clacky::Providers do
       end
 
       it "has correct base_url and api type" do
-        expect(described_class.base_url("ollama")).to eq("https://ollama.com/api")
+        expect(described_class.base_url("ollama")).to eq("https://ollama.com")
         expect(described_class.api_type("ollama")).to eq("openai-completions")
       end
 
@@ -182,8 +182,8 @@ RSpec.describe Clacky::Providers do
       end
 
       it "resolves provider by base_url" do
-        expect(described_class.find_by_base_url("https://ollama.com/api")).to eq("ollama")
-        expect(described_class.find_by_base_url("https://ollama.com/api/v1/chat/completions")).to eq("ollama")
+        expect(described_class.find_by_base_url("https://ollama.com")).to eq("ollama")
+        expect(described_class.find_by_base_url("https://ollama.com/v1/chat/completions")).to eq("ollama")
       end
 
       it "has a website_url for API keys" do


### PR DESCRIPTION
The upstream squash-merge of PR #424 lost the second commit that fixed the base URL. The current upstream has `https://ollama.com/api` but Ollama's OpenAI-compatible endpoints are at the root domain.

Tested and verified working with the live Ollama Cloud API.

Changes:
- `base_url`: `https://ollama.com/api` → `https://ollama.com`
- Updated tests to match