### PR TITLE
feat: support max reasoning effort level beyond xhigh

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -53,7 +53,7 @@ module Clacky
     attr_accessor :channel_info
     attr_accessor :project_id
 
-    REASONING_EFFORTS = %w[low medium high xhigh].freeze
+    REASONING_EFFORTS = %w[low medium high xhigh max].freeze
 
     def permission_mode
       @config&.permission_mode&.to_s || ""

--- a/lib/clacky/message_format/anthropic.rb
+++ b/lib/clacky/message_format/anthropic.rb
@@ -114,7 +114,7 @@ module Clacky
       private_class_method def self.normalized_effort(effort)
         return nil if effort.nil? || effort.to_s.empty?
         s = effort.to_s
-        %w[low medium high].include?(s) ? s : nil
+        %w[low medium high xhigh max].include?(s) ? s : nil
       end
 
       # Merge consecutive tool_result user messages into a single user message.

--- a/lib/clacky/message_format/bedrock.rb
+++ b/lib/clacky/message_format/bedrock.rb
@@ -91,7 +91,7 @@ module Clacky
 
       private_class_method def self.additional_fields_for_effort(effort)
         return nil if effort.nil? || effort.to_s.empty?
-        return nil unless %w[low medium high].include?(effort.to_s)
+        return nil unless %w[low medium high xhigh max].include?(effort.to_s)
         {
           thinking: { type: "adaptive" },
           output_config: { effort: effort.to_s }

--- a/lib/clacky/message_format/open_ai.rb
+++ b/lib/clacky/message_format/open_ai.rb
@@ -279,6 +279,14 @@ module Clacky
           elsif !effort_str.empty?
             body[:thinking] = { type: "adaptive" }
           end
+        elsif model.to_s.match?(/deepseek/i)
+          # DeepSeek V4 reasoning_effort only accepts low/high/max.
+          # xhigh is not recognized — map it to max.
+          effort = case effort_str
+                   when "xhigh" then "max"
+                   else effort_str
+                   end
+          body[:reasoning_effort] = effort unless effort.empty?
         elsif reasoning_effort && !effort_str.empty?
           body[:reasoning_effort] = effort_str
         end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -6264,7 +6264,7 @@ module Clacky
       end
 
       # PATCH /api/sessions/:id/reasoning_effort
-      # Body: { "reasoning_effort": "off" | "low" | "medium" | "high" | "xhigh" }
+      # Body: { "reasoning_effort": "off" | "low" | "medium" | "high" | "xhigh" | "max" }
       def api_switch_session_reasoning_effort(session_id, req, res)
         body = parse_json_body(req)
         raw = body["reasoning_effort"]

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -201,6 +201,7 @@ const I18n = (() => {
       "sib.reasoning.medium":    "Medium",
       "sib.reasoning.high":      "High",
       "sib.reasoning.xhigh": "XHigh",
+      "sib.reasoning.max": "Max",
       "sessions.thinking":      "Thinking…",
       "sessions.default_name":  "Session {{n}}",
       "sessions.cronGroup":     "Scheduled Tasks",
@@ -1244,6 +1245,7 @@ const I18n = (() => {
       "sib.reasoning.medium":    "中",
       "sib.reasoning.high":      "高",
       "sib.reasoning.xhigh": "超高",
+      "sib.reasoning.max": "Max",
       "sessions.thinking":      "思考中…",
       "sessions.default_name":  "会话 {{n}}",
       "sessions.cronGroup":     "定时任务",
@@ -2168,7 +2170,7 @@ const I18n = (() => {
       let ph = t(key, vars);
       // On mobile: strip the parenthetical hint so placeholder doesn't wrap
       if (window.innerWidth <= 768) {
-        ph = ph.replace(/\s*[\(（].*[\)）]/, "").trim();
+        ph = ph.replace(/\s*[(（].*[)）]/, "").trim();
       }
       el.placeholder = ph;
     });

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -168,13 +168,13 @@ const Sessions = (() => {
         });
 
       const renderer = new marked.Renderer();
-      renderer.link = function({ href, title, text }) {
+      renderer.link = ({ href, title, text }) => {
         const titleAttr = title ? ` title="${title}"` : "";
         return `<a href="${_normalizeFileHref(href)}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
       };
       // Override code block rendering: apply syntax highlighting + header with
       // language label and copy button.
-      renderer.code = function({ text: code, lang }) {
+      renderer.code = ({ text: code, lang }) => {
         code = restoreMathInCode(code);
         const language = (lang || "").split(/\s+/)[0]; // strip extra info after lang
         const highlighted = _highlightCode(code, language);
@@ -197,9 +197,7 @@ const Sessions = (() => {
         );
       };
       // Inline code: same restoration, then plain <code> with HTML escaping.
-      renderer.codespan = function({ text }) {
-        return `<code>${escapeHtml(restoreMathInCode(text))}</code>`;
-      };
+      renderer.codespan = ({ text }) => `<code>${escapeHtml(restoreMathInCode(text))}</code>`;
       try {
         html = marked.parse(prepared, { breaks: true, gfm: true, renderer });
       } catch (_) {
@@ -255,7 +253,7 @@ const Sessions = (() => {
       { re: /\\\[([\s\S]+?)\\\]/g,                                          display: true,  wrap: (b) => `\\[${b}\\]`   },
       { re: /\\\(([\s\S]+?)\\\)/g,                                          display: false, wrap: (b) => `\\(${b}\\)`   },
       // Inline $...$: avoid $$, escaped \$, and prevent crossing newlines/blanks.
-      { re: /(^|[^\$])\$(?!\s)([^\$\n]+?)(?<!\s)\$(?!\d)/g, display: false, hasPrefix: true, wrap: (b) => `$${b}$` },
+      { re: /(^|[^$])\$(?!\s)([^$\n]+?)(?<!\s)\$(?!\d)/g, display: false, hasPrefix: true, wrap: (b) => `$${b}$` },
     ];
     let result = text;
     for (const { re, display, hasPrefix, wrap } of patterns) {
@@ -4175,14 +4173,14 @@ const Sessions = (() => {
 // ─────────────────────────────────────────────────────────────────────────
 
 // ── Session Info Bar Model Switcher ───────────────────────────────────────
-(function() {
+(() => {
   let _isOpen = false;
   // Cache of the most recent benchmark results, keyed by model_id. Kept at
   // closure scope so the numbers survive closing & reopening the dropdown —
   // the user shouldn't have to re-run the test just to peek at results. We
   // intentionally do NOT persist this to disk: latency is a point-in-time
   // measurement, and yesterday's numbers are misleading.
-  let _benchCache = {};        // { [model_id]: { ttft_ms, ok, error, ts } }
+  const _benchCache = {};        // { [model_id]: { ttft_ms, ok, error, ts } }
   let _benchInFlight = false;  // prevent double-click spam
 
   // Toggle model dropdown when clicking on model name
@@ -4709,7 +4707,7 @@ const Sessions = (() => {
 })();
 
 // ── Session Info Bar Working Directory Switcher ───────────────────────────
-(function() {
+(() => {
   // Directory picker with predefined list
   // ── Tree-based directory picker ─────────────────────────────────────────
   const ICON_FOLDER_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>';
@@ -5350,9 +5348,9 @@ const Sessions = (() => {
 })();
 
 // ── Session Info Bar Reasoning Effort Switcher ────────────────────────────
-(function() {
+(() => {
   let _isOpen = false;
-  const LEVELS = ["off", "low", "medium", "high", "xhigh"];
+  const LEVELS = ["off", "low", "medium", "high", "xhigh", "max"];
 
   document.addEventListener("click", async (e) => {
     const el = e.target.closest("#sib-reasoning");
@@ -5451,7 +5449,7 @@ document.addEventListener("currencychange", () => {
   if (Sessions._lastSession) Sessions.updateInfoBar(Sessions._lastSession);
 });
 
-(function () {
+(() => {
   const sidebarList = document.getElementById("sidebar-list");
   if (!sidebarList) return;
   let scrollTimer = null;


### PR DESCRIPTION
## What

Adds `max` as a valid `reasoning_effort` level beyond `xhigh`, and fixes `xhigh`→`max` mapping for models that don't support `xhigh`.

## Why

Several models support a `max` reasoning effort level that is more powerful than `xhigh`:
- **Claude Fable 5 / Opus 5**: support 5 levels: low/medium/high/xhigh/max (both distinct)
- **DeepSeek V4 Flash/Pro**: support low/high/max (no xhigh — selecting xhigh causes API errors)
- **GLM series**: support high/max (already correctly mapped)
- **Kimi K3**: support low/high/max (already correctly mapped)

Previously `Agent::REASONING_EFFORTS` only included `%w[low medium high xhigh]`, so `normalize_reasoning_effort("max")` silently returned `nil`, making the `max` level completely inaccessible.

## Changes (7 files)

| File | Change |
|---|---|
| `lib/clacky/agent.rb` | Add `"max"` to `REASONING_EFFORTS` |
| `lib/clacky/web/sessions.js` | Add `"max"` to dropdown `LEVELS` |
| `lib/clacky/web/i18n.js` | Add `"sib.reasoning.max"` (untranslated `"Max"`) |
| `lib/clacky/message_format/open_ai.rb` | Add DeepSeek special case: `xhigh`→`max` |
| `lib/clacky/message_format/anthropic.rb` | Expand `normalized_effort` to accept `xhigh`/`max` |
| `lib/clacky/message_format/bedrock.rb` | Expand `additional_fields_for_effort` to accept `xhigh`/`max` |
| `lib/clacky/server/http_server.rb` | Update API doc comment |

## Per-model mapping

| Model family | `xhigh` → | `max` → |
|---|---|---|
| Claude (Anthropic/Bedrock) | `xhigh` (kept) | `max` (kept) |
| DeepSeek V4 | `max` (mapped) | `max` |
| GLM | `max` (mapped, unchanged) | `max` |
| Kimi K3 | `max` (mapped, unchanged) | `max` |
| Others (generic) | pass-through | pass-through |

Authored using OpenClacky.
