### PR TITLE
feat(compression): split idle and threshold compression switches

### DIFF
--- a/lib/clacky/agent/message_compressor_helper.rb
+++ b/lib/clacky/agent/message_compressor_helper.rb
@@ -23,6 +23,7 @@ module Clacky
           Clacky::Logger.info(
             "Idle compression skipped",
             enable_compression: @config.enable_compression,
+            enable_idle_compression: @config.enable_idle_compression,
             previous_total_tokens: @previous_total_tokens,
             history_size: @history.size,
             idle_threshold: IDLE_COMPRESSION_THRESHOLD,
@@ -129,8 +130,10 @@ module Clacky
         # (force: true) is still allowed as a safety net for long-running subagents.
         return nil if @is_subagent && !force
 
-        # Check if compression is enabled
+        # Check if compression is enabled (master switch)
         return nil unless @config.enable_compression
+        # Idle compression has its own sub-switch under the master
+        return nil if force && !@config.enable_idle_compression
 
         # Use the larger of: API-reported tokens from last response, or current
         # estimated history size. The estimate guards the case where a single

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -224,6 +224,7 @@ module Clacky
             # (falling back to the current default if the model no longer exists).
             permission_mode: @config.permission_mode.to_s,
             enable_compression: @config.enable_compression,
+            enable_idle_compression: @config.enable_idle_compression,
             enable_prompt_caching: @config.enable_prompt_caching,
             max_tokens: @config.max_tokens,
             verbose: @config.verbose,

--- a/lib/clacky/agent_config.rb
+++ b/lib/clacky/agent_config.rb
@@ -159,7 +159,7 @@ module Clacky
     DEFAULT_MESSAGE_COUNT_THRESHOLD = 200
 
     attr_accessor :permission_mode, :max_tokens, :verbose,
-                  :enable_compression, :enable_prompt_caching,
+                  :enable_compression, :enable_idle_compression, :enable_prompt_caching,
                   :compression_threshold, :message_count_threshold,
                   :models, :current_model_index, :current_model_id,
                   :memory_update_enabled, :skill_evolution,
@@ -173,6 +173,7 @@ module Clacky
       @max_tokens = options[:max_tokens] || 16384
       @verbose = options[:verbose] || false
       @enable_compression = options[:enable_compression].nil? ? true : options[:enable_compression]
+      @enable_idle_compression = options[:enable_idle_compression].nil? ? true : options[:enable_idle_compression]
       # Enable prompt caching by default for cost savings
       @enable_prompt_caching = options[:enable_prompt_caching].nil? ? true : options[:enable_prompt_caching]
       # Token threshold that triggers proactive history compression. Local models
@@ -411,7 +412,7 @@ module Clacky
     # Settings keys that are persisted to config.yml.
     # These map directly to AgentConfig accessors.
     CONFIG_SETTINGS_KEYS = %w[
-      enable_compression enable_prompt_caching
+      enable_compression enable_idle_compression enable_prompt_caching
       compression_threshold message_count_threshold
       memory_update_enabled
       skill_evolution max_running_agents max_idle_agents
@@ -428,6 +429,7 @@ module Clacky
       end
       settings = {
         "enable_compression" => @enable_compression,
+        "enable_idle_compression" => @enable_idle_compression,
         "enable_prompt_caching" => @enable_prompt_caching,
         "compression_threshold" => @compression_threshold,
         "message_count_threshold" => @message_count_threshold,

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -5667,6 +5667,7 @@ module Clacky
         json_response(res, 200, {
           ok: true,
           enable_compression: @agent_config.enable_compression,
+          enable_idle_compression: @agent_config.enable_idle_compression,
           enable_prompt_caching: @agent_config.enable_prompt_caching,
           memory_update_enabled: @agent_config.memory_update_enabled,
           proxy_url: @agent_config.proxy_url.to_s,
@@ -5691,6 +5692,9 @@ module Clacky
 
         if body.key?("enable_compression")
           @agent_config.enable_compression = !!body["enable_compression"]
+        end
+        if body.key?("enable_idle_compression")
+          @agent_config.enable_idle_compression = !!body["enable_idle_compression"]
         end
         if body.key?("enable_prompt_caching")
           @agent_config.enable_prompt_caching = !!body["enable_prompt_caching"]

--- a/spec/clacky/agent/compression_system_prompt_dup_spec.rb
+++ b/spec/clacky/agent/compression_system_prompt_dup_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "Compression system-prompt duplication bug" do
         @session_id            = nil   # disable chunk saving
         @created_at            = nil
         # MessageCompressorHelper accesses @config directly as an ivar
-        config_klass = Struct.new(:enable_compression)
-        @config      = config_klass.new(true)
+        config_klass = Struct.new(:enable_compression, :enable_idle_compression)
+        @config      = config_klass.new(true, true)
         # compress_messages_if_needed calls @message_compressor.build_compression_message
         @message_compressor = Clacky::MessageCompressor.new(nil)
       end


### PR DESCRIPTION
**Problem**

`enable_compression` is a single master switch that controls both idle compression (proactive, low-threshold, cost optimization) and threshold compression (reactive, high-threshold, prevents context-overflow crashes). Disabling it to avoid one mode kills both — users lose cost optimization and the overflow safety net at the same time.

**Fix**

Split into a master + sub-switch model:

- `enable_compression` (master, unchanged): gates both modes. `false` still disables everything (backward compatible).
- `enable_idle_compression` (new, default `true`): sub-switch for idle compression only. Only takes effect when the master is on.

The check in `compress_messages_if_needed` becomes:

    return nil unless @config.enable_compression
    return nil if force && !@config.enable_idle_compression

Now users can set `enable_idle_compression: false` in config.yml to skip idle compression while keeping the threshold safety net active.

**Test**

- ✅ RSpec 2936 examples, 0 failures
- ✅ Updated compression_system_prompt_dup_spec config Struct to include the new field