### PR TITLE
fix(extension): include hidden in verifier AGENT_KEYS

### DIFF
--- a/lib/clacky/extension/verifier.rb
+++ b/lib/clacky/extension/verifier.rb
@@ -22,7 +22,7 @@ module Clacky
     PANEL_KEYS   = %w[id title title_zh description description_zh view order attach entry_points].freeze
     API_KEYS     = %w[id handler].freeze
     SKILL_KEYS   = %w[id dir protected].freeze
-    AGENT_KEYS   = %w[id title title_zh description description_zh order prompt panels skills avatar].freeze
+    AGENT_KEYS   = %w[id title title_zh description description_zh order prompt panels skills avatar hidden].freeze
     CHANNEL_KEYS = %w[id platform adapter].freeze
     PATCH_KEYS   = %w[target file fingerprint on_mismatch].freeze
     HOOK_KEYS    = %w[event file].freeze

--- a/spec/clacky/extension_verifier_spec.rb
+++ b/spec/clacky/extension_verifier_spec.rb
@@ -78,6 +78,26 @@ RSpec.describe Clacky::ExtensionVerifier do
     expect(field_issue.message).to include("mistypedField")
   end
 
+  it "accepts the hidden field on agents without warning" do
+    manifest = <<~YAML
+      id: hidden-agent-pack
+      origin: self
+      contributes:
+        agents:
+          - id: secret
+            title: Secret
+            description: x
+            prompt: prompt.md
+            hidden: true
+    YAML
+    make_ext(local, "hidden-agent-pack", manifest, "prompt.md" => "hi")
+    result = reload_layers
+
+    issues = described_class.verify(result)
+    unknown = issues.select { |i| i.code == "schema.unknown_field" && i.unit == "secret" }
+    expect(unknown).to be_empty
+  end
+
   it "flags an agent referencing a non-existent panel" do
     manifest = <<~YAML
       id: ghost-ref


### PR DESCRIPTION
**Problem**

The `hidden` field was added to extension agent units (loader.rb parses it, AgentProfile.all filters by it), but the ext-studio verifier's `AGENT_KEYS` schema list was not updated. As a result, `clacky ext verify` flags `hidden` as an unknown field with a false `schema.unknown_field` warning.

**Fix**

Add `hidden` to `AGENT_KEYS` in `verifier.rb` so the schema check recognizes it as a valid agent field.

**Test**

- ✅ RSpec 2937 examples, 0 failures
- ✅ Added test case verifying that an agent with `hidden: true` produces no `schema.unknown_field` warning