### PR TITLE
feat: make version number in sidebar a clickable link to changelog

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -10178,6 +10178,7 @@ body.setup-mode[data-theme="dark"] {
   letter-spacing: 0.03em;
   transition: color .15s;
   line-height: 1;
+  text-decoration: none;
 }
 /* Highlight version text when badge is actionable and btn is hovered */
 .version-badge:hover .version-text { color: var(--color-text-tertiary); }

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -10453,6 +10453,15 @@ body.setup-mode[data-theme="dark"] {
 .vup-btn-restart:hover  { background: var(--color-button-primary-hover); }
 .vup-btn-restart:active { transform: scale(.97); }
 
+/* Popover hint text */
+.vup-hint {
+  margin: 0.375rem 0 0;
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  opacity: 0.7;
+  text-align: center;
+}
+
 /* Reconnect state */
 .vup-reconnect {
   text-align: center;

--- a/lib/clacky/web/features/version/view.js
+++ b/lib/clacky/web/features/version/view.js
@@ -133,6 +133,7 @@ const VersionView = (() => {
         <span class="vup-check-icon">✓</span>
         ${I18n.t("upgrade.tooltip.ok", { current: s.current })}
       </p>
+      <p class="vup-hint">${I18n.t("upgrade.click_hint")}</p>
     `;
     setTimeout(() => { if (_popoverOpen) _closePopover(); }, 2000);
   }

--- a/lib/clacky/web/features/version/view.js
+++ b/lib/clacky/web/features/version/view.js
@@ -41,6 +41,7 @@ const VersionView = (() => {
     if (!badge || !text) return;
 
     text.textContent = s.current ? `v${s.current}` : "";
+    text.href = "https://github.com/clacky-ai/openclacky/releases";
 
     if (dot)        dot.style.display        = "none";
     if (restartDot) restartDot.style.display = "none";

--- a/lib/clacky/web/features/version/view.js
+++ b/lib/clacky/web/features/version/view.js
@@ -101,6 +101,7 @@ const VersionView = (() => {
     else if (s.upgradeDone)   _renderDoneState(pop);
     else if (s.needsUpdate)   _renderConfirmState(pop, s);
     else                      _renderUpToDateState(pop, s);
+    pop.innerHTML += `<p class="vup-hint">${I18n.t("upgrade.click_hint")}</p>`;
   }
 
   function _openPopover() {
@@ -133,7 +134,6 @@ const VersionView = (() => {
         <span class="vup-check-icon">✓</span>
         ${I18n.t("upgrade.tooltip.ok", { current: s.current })}
       </p>
-      <p class="vup-hint">${I18n.t("upgrade.click_hint")}</p>
     `;
     setTimeout(() => { if (_popoverOpen) _closePopover(); }, 2000);
   }

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -279,7 +279,7 @@ const I18n = (() => {
       "upgrade.tooltip.ok":          "v{{current}} (up to date)",
       "upgrade.tooltip.needs_restart": "Upgrade complete — click to restart",
       "upgrade.tooltip.done":        "Restarted successfully",
-      "upgrade.click_hint":          "Click to view changelog",
+      "upgrade.click_hint":          "Click for changelog",
 
       // ── Tasks panel ──
       "tasks.title":          "Scheduled Tasks",
@@ -1330,7 +1330,7 @@ const I18n = (() => {
       "upgrade.tooltip.ok":          "v{{current}}（已是最新）",
       "upgrade.tooltip.needs_restart": "升级完成，点击重启",
       "upgrade.tooltip.done":        "重启成功",
-      "upgrade.click_hint":          "点击查看更新日志",
+      "upgrade.click_hint":          "查看更新日志",
 
       // ── Tasks panel ──
       "tasks.title":          "定时任务",

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -279,6 +279,7 @@ const I18n = (() => {
       "upgrade.tooltip.ok":          "v{{current}} (up to date)",
       "upgrade.tooltip.needs_restart": "Upgrade complete — click to restart",
       "upgrade.tooltip.done":        "Restarted successfully",
+      "upgrade.click_hint":          "Click to view changelog",
 
       // ── Tasks panel ──
       "tasks.title":          "Scheduled Tasks",
@@ -1329,6 +1330,7 @@ const I18n = (() => {
       "upgrade.tooltip.ok":          "v{{current}}（已是最新）",
       "upgrade.tooltip.needs_restart": "升级完成，点击重启",
       "upgrade.tooltip.done":        "重启成功",
+      "upgrade.click_hint":          "点击查看更新日志",
 
       // ── Tasks panel ──
       "tasks.title":          "定时任务",
@@ -2186,7 +2188,7 @@ const I18n = (() => {
       let ph = t(key, vars);
       // On mobile: strip the parenthetical hint so placeholder doesn't wrap
       if (window.innerWidth <= 768) {
-        ph = ph.replace(/\s*[\(（].*[\)）]/, "").trim();
+        ph = ph.replace(/\s*[(（].*[)）]/, "").trim();
       }
       el.placeholder = ph;
     });

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -279,7 +279,7 @@ const I18n = (() => {
       "upgrade.tooltip.ok":          "v{{current}} (up to date)",
       "upgrade.tooltip.needs_restart": "Upgrade complete — click to restart",
       "upgrade.tooltip.done":        "Restarted successfully",
-      "upgrade.click_hint":          "Click for changelog",
+      "upgrade.click_hint":          "click for changelog 👇",
 
       // ── Tasks panel ──
       "tasks.title":          "Scheduled Tasks",
@@ -1330,7 +1330,7 @@ const I18n = (() => {
       "upgrade.tooltip.ok":          "v{{current}}（已是最新）",
       "upgrade.tooltip.needs_restart": "升级完成，点击重启",
       "upgrade.tooltip.done":        "重启成功",
-      "upgrade.click_hint":          "查看更新日志",
+      "upgrade.click_hint":          "点击查看更新日志 👇",
 
       // ── Tasks panel ──
       "tasks.title":          "定时任务",

--- a/lib/clacky/web/index.html
+++ b/lib/clacky/web/index.html
@@ -327,7 +327,7 @@
         </button>
         <!-- Version badge: independent button, right side of the row -->
         <span id="version-badge" class="version-badge" style="display:none">
-          <span id="version-text" class="version-text"></span>
+          <a id="version-text" class="version-text" target="_blank" rel="noopener noreferrer"></a>
           <span id="version-update-dot"   class="version-update-dot"   style="display:none"></span>
           <span id="version-restart-dot"  class="version-restart-dot"  style="display:none"></span>
           <span id="version-spinner"      class="version-spinner"       style="display:none"></span>


### PR DESCRIPTION
The version badge in the sidebar footer now renders the version number as a clickable link to GitHub Releases, so users can click to view release notes instead of only seeing the version number on hover.

Changes:
- `index.html`: `<span>` → `<a>` with `target="_blank"`
- `view.js`: set `text.href` to GitHub Releases URL
- `app.css`: add `text-decoration: none` to preserve original appearance