### PR TITLE
fix(web): normalize session_update bridge shape and capture ext-workspace teardown

### DIFF
--- a/lib/clacky/web/app.js
+++ b/lib/clacky/web/app.js
@@ -65,6 +65,10 @@ const PANELS = [
 const Router = (() => {
   let _current     = null;  // current view name
   let _params      = {};    // current params (e.g. { id: "abc" } for session view)
+  // Teardown function returned by the current ext-workspace render (if any).
+  // Invoked when leaving the workspace so the extension's WS subscriptions /
+  // timers don't leak across re-entries. See the render contract in ext.js.
+  let _wsTeardown  = null;
   let _skipNextHashChange = false;  // prevent echo loop when we set hash ourselves
 
   // Hide all panels.
@@ -154,6 +158,12 @@ const Router = (() => {
     _mobileCloseSidebar();
 
     // ── Clean up previous state ──────────────────────────────────────────
+    // Leaving the current view — if it was an ext-workspace, run its teardown
+    // so the extension's WS subscriptions / timers don't leak across re-entries.
+    if (typeof _wsTeardown === "function") {
+      try { _wsTeardown(); } catch (_e) { /* extension teardown errors are non-fatal */ }
+      _wsTeardown = null;
+    }
     if (Sessions.activeId) {
       Sessions._cacheActiveAndDeselect();
     }
@@ -316,7 +326,7 @@ const Router = (() => {
         const container = $("ext-slot-main-workspace");
         container.replaceChildren();
         container.style.display = "block";
-        try { ws.render(container, {}); }
+        try { _wsTeardown = ws.render(container, {}); }
         catch (err) { console.error("ext workspace render failed:", err); }
         Sessions.renderList();
         break;

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -172,7 +172,19 @@ WS.onEvent(ev => {
   if (window.Clacky && Clacky.ext) {
     const extName = SESSION_EXT_EVENTS[ev.type];
     if (extName) {
-      Clacky.ext.emit(extName, { sessionId: ev.session_id, ...ev });
+      // session_update arrives in two payload shapes: shape (1) from http_server
+      // broadcast_session_update is { type, session: {...} } with no top-level
+      // session_id/status; shape (2) from web_ui_controller emit is flat. The
+      // host-side switch (see `case "session_update"` below) already normalizes
+      // both shapes; mirror that here so extension subscribers see a consistent
+      // sessionId/status regardless of source. The original session object is
+      // preserved via ...ev so shape-aware extensions keep working.
+      let payload = ev;
+      if (ev.type === "session_update" && ev.session) {
+        payload = { ...ev, session_id: ev.session.id, status: ev.session.status };
+      }
+      const sid = payload.session_id || (ev.session && ev.session.id);
+      Clacky.ext.emit(extName, { sessionId: sid, ...payload, session_id: sid });
     }
   }
 

--- a/spec/clacky/web/extension_architecture_spec.rb
+++ b/spec/clacky/web/extension_architecture_spec.rb
@@ -129,6 +129,64 @@ RSpec.describe "WebUI extension architecture" do
     end
   end
 
+  # ─── ws-dispatcher ext bridge contract ──────────────────────────────────────
+
+  describe "ws-dispatcher session_update bridge normalization" do
+    let(:ws_js) { File.read(File.join(web_dir, "ws-dispatcher.js")) }
+
+    it "normalizes session_update shape (1) (nested ev.session) by lifting session_id and status to the top level" do
+      # http_server broadcast_session_update sends { type, session: { id, status, ... } }
+      # with no top-level session_id. The bridge must lift session.id and session.status
+      # so extension subscribers see a consistent sessionId/status regardless of source.
+      expect(ws_js).to match(/session_update.*ev\.session.*session_id:\s*ev\.session\.id/m),
+        "bridge must lift ev.session.id to session_id for session_update shape (1)"
+      expect(ws_js).to match(/status:\s*ev\.session\.status/),
+        "bridge must lift ev.session.status to top-level status for session_update shape (1)"
+    end
+
+    it "preserves the original ev spread so shape-aware extensions are not broken" do
+      # ...ev (or ...payload) keeps the nested session object; extensions reading
+      # ev.session.status still work. New top-level keys are additive, not replacing.
+      expect(ws_js).to match(/\.\.\.(ev|payload)/),
+        "bridge must spread original event fields (additive normalization, not replacement)"
+    end
+
+    it "emits a truthy sessionId for both shapes" do
+      # For shape (1) ev.session_id is undefined; the bridge must fall back to ev.session.id
+      # so sessionId is never undefined for session_update subscribers.
+      expect(ws_js).to match(/payload\.session_id\s*\|\|\s*\(ev\.session\s*&&\s*ev\.session\.id\)/),
+        "bridge must fall back to ev.session.id when top-level session_id is absent"
+    end
+  end
+
+  # ─── app.js ext-workspace teardown contract ─────────────────────────────────
+
+  describe "app.js ext-workspace teardown" do
+    let(:app_js) { File.read(File.join(web_dir, "app.js")) }
+
+    it "saves the return value of ws.render() as a potential teardown function" do
+      # ext.js render contract: returning a function registers it as a teardown.
+      # app.js must not discard that return value.
+      expect(app_js).to match(/_wsTeardown\s*=\s*ws\.render\(/),
+        "app.js ext-workspace branch must assign ws.render() return value to _wsTeardown"
+    end
+
+    it "invokes the teardown when leaving the workspace view" do
+      # Teardown must run on any view transition away from ext-workspace, not only
+      # on re-entry into another workspace. Placing the cleanup at the top of _apply
+      # covers all leaving paths.
+      expect(app_js).to match(/if\s*\(\s*typeof\s+_wsTeardown\s*===\s*["']function["']\s*\)/),
+        "_apply must invoke _wsTeardown when it is a function"
+      expect(app_js).to match(/_wsTeardown\(\)/),
+        "_apply must call the teardown function"
+    end
+
+    it "resets _wsTeardown to null after invoking it" do
+      expect(app_js).to match(/_wsTeardown\s*=\s*null/),
+        "_wsTeardown must be reset to null after invocation to avoid double-calling"
+    end
+  end
+
   # ─── index.html wiring ──────────────────────────────────────────────────────
 
   describe "index.html extension wiring" do


### PR DESCRIPTION
Fixes #435.

## Problem

Two infra-side contract bugs in the WebUI extension layer caused third-party extensions to silently lose events and leak resources.

1. **`session:update` bridge not normalized across two payload shapes.** `ws-dispatcher.js` forwarded all WS events via `Clacky.ext.emit(extName, { sessionId: ev.session_id, ...ev })` with no per-event normalization. `session_update` arrives in two shapes:
   - shape (1) from `http_server.rb` `broadcast_session_update`: `{ type, session: { id, status, ... } }` — no top-level `session_id`.
   - shape (2) from `web_ui_controller.rb` `emit`: `{ type, session_id, status, cost, ... }` — flat.
   The host-side switch (`ws-dispatcher.js` `case "session_update"`) already normalizes both shapes, but the ext bridge assumed a single shape — so for shape (1) extensions got `sessionId: undefined` and `status` nested under `ev.session.status`, failing their guards.

2. **`ext-workspace` discarded `render()` teardown.** `app.js` `case "ext-workspace"` called `ws.render(container, {})` and threw away the return value, violating the `ext.js` render contract (returning a function registers a teardown). The teardown was never saved (`ctx={}` has no `sessionId`, so `_rememberViewTeardown` bails) and never invoked (`_runViewTeardowns` only fires from `setContext`/`notifySessionRemoved`, not workspace nav). WS subscriptions and timers leaked linearly on each re-entry.

## Fix

- `ws-dispatcher.js`: for `session_update` with `ev.session` (shape 1), lift `session_id` and `status` to the top level; preserve the original spread so shape-aware extensions keep working. `sessionId` falls back to `ev.session.id` when `session_id` is absent.
- `app.js`: add a module-level `_wsTeardown`; capture `ws.render()`'s return value in the `ext-workspace` branch; invoke it at the top of `_apply` (covers every leaving path) with a `typeof === "function"` guard; reset to `null` after.

Both changes are additive and minimal (~14 LOC). Neither touches the host-side switch or the `ext.js` teardown mechanism.

## Tests

Added source-level contract assertions in `spec/clacky/web/extension_architecture_spec.rb` (two new describe blocks, 6 assertions). Each assertion fails if the corresponding fix is reverted. `rspec spec/clacky/web/extension_architecture_spec.rb` → 35 examples, 0 failures.

`node --check` passes on both edited JS files.

## Out of scope

- Unifying the two server-side send sources / routing (`broadcast_all` vs `broadcast`) — bridge normalizes at the frontend, smaller and reversible.
- Routing workspace through `renderSlot`/`_invokeRender` — larger change; `total_cost`/`total_tasks` naming consistency across shapes is tracked as a follow-up.