### PR TITLE
feat: expose project_manager and project_id to extensions

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
+++ b/lib/clacky/default_extensions/ext-studio/skills/ext-develop/SKILL.md
@@ -202,7 +202,7 @@ Response helpers: `json` / `text(str)` / `send_data(bytes, content_type:, filena
   dir (`ext_dir` / `File.join(ext_dir, ...)`) — uninstall deletes the whole package, so
   anything there is lost. Package-internal writes are only for disposable caches.
 - Host context (white-listed): `session_manager`, `registry`, `agent_config`, `config`
-  (from ext.yml), `logger`, `ext_id`, `ext_dir`.
+  (from ext.yml), `logger`, `ext_id`, `ext_dir`, `project_manager`.
 - Drive sessions from the backend: `create_session(prompt:, profile:, …)`,
   `submit_task(session_id, prompt)`, `dispatch_to_session(session_id, prompt)` (runs a
   side task on a fork and returns its reply without touching the conversation).
@@ -210,6 +210,12 @@ Response helpers: `json` / `text(str)` / `send_data(bytes, content_type:, filena
   and the 200-session cleanup skips - use it for dedicated extension sessions you
   manage yourself. Still reachable by `session_id` via `submit_task` /
   `dispatch_to_session` / `registry.with_session`; forking resets `hidden` to false.
+- **Projects**: `project_manager.all` lists projects, `find(id)` returns one (or
+  `nil`), `create(name:, working_dir:, …)` / `update(id, …)` / `delete(id)` mutate.
+  Pass `project_id:` to `create_session` to bind a session to a project - its
+  `working_dir` is inherited (unless overridden) and `agent.project_id` is persisted.
+  A panel can also `fetch("/api/projects")` directly (same-origin, no-auth; see
+  [Host API](/docs/extend-host-api)).
 - Public (no-auth) endpoints: call `public_endpoint("/path")` in the class **and** set
   `public: true` at ext.yml top level — both are required.
 

--- a/lib/clacky/extension/api_extension.rb
+++ b/lib/clacky/extension/api_extension.rb
@@ -276,15 +276,12 @@ module Clacky
       if project_id
         project_id = project_id.to_s.strip
         project_id = nil if project_id.empty?
-        if project_id && project_manager&.find(project_id).nil?
-          error!("Project not found", status: 400)
-        end
       end
 
-      if working_dir.nil? && project_id
-        project = project_manager&.find(project_id)
-        working_dir = File.expand_path(project[:working_dir]) if project && project[:working_dir].to_s.strip != ""
-      end
+      project = project_id ? project_manager&.find(project_id) : nil
+      error!("Project not found", status: 404) if project_id && project.nil?
+
+      working_dir = File.expand_path(project[:working_dir]) if working_dir.nil? && project && project[:working_dir].to_s.strip != ""
 
       session_id = @http_server.send(
         :build_session,

--- a/lib/clacky/extension/api_extension.rb
+++ b/lib/clacky/extension/api_extension.rb
@@ -258,13 +258,33 @@ module Clacky
       @http_server&.instance_variable_get(:@registry)
     end
 
+    def project_manager
+      @http_server&.instance_variable_get(:@project_manager)
+    end
+
     # Create a brand-new session and optionally kick off its first task.
     # Returns the new session_id. When a prompt is given, the task is
     # submitted immediately (the session starts running); display_message
     # controls the user-facing bubble shown in place of the raw prompt.
+    # When `project_id` is given, the project's working_dir is inherited
+    # (unless an explicit working_dir overrides it) and the session is
+    # associated with the project.
     def create_session(name: nil, prompt: nil, working_dir: nil, profile: "general",
-                       source: :manual, display_message: nil, hidden: false)
+                       source: :manual, display_message: nil, hidden: false, project_id: nil)
       error!("server not ready", status: 503) unless @http_server
+
+      if project_id
+        project_id = project_id.to_s.strip
+        project_id = nil if project_id.empty?
+        if project_id && project_manager&.find(project_id).nil?
+          error!("Project not found", status: 400)
+        end
+      end
+
+      if working_dir.nil? && project_id
+        project = project_manager&.find(project_id)
+        working_dir = File.expand_path(project[:working_dir]) if project && project[:working_dir].to_s.strip != ""
+      end
 
       session_id = @http_server.send(
         :build_session,
@@ -274,6 +294,15 @@ module Clacky
         source: source,
         hidden: hidden
       )
+
+      if project_id
+        agent = nil
+        registry.with_session(session_id) { |s| agent = s[:agent] }
+        if agent
+          agent.project_id = project_id
+          session_manager&.save(agent.to_session_data)
+        end
+      end
 
       submit_task(session_id, prompt, display_message: display_message) if prompt && !prompt.strip.empty?
 

--- a/spec/clacky/default_extensions_spec.rb
+++ b/spec/clacky/default_extensions_spec.rb
@@ -168,13 +168,28 @@ RSpec.describe "ApiExtension#create_session with project_id" do
     expect(session_manager).to have_received(:save)
   end
 
-  it "raises 400 when the project does not exist" do
+  it "raises 404 when the project does not exist" do
     allow(project_manager).to receive(:find).with("nope").and_return(nil)
 
     expect {
       instance.create_session(project_id: "nope")
     }.to raise_error(Clacky::ApiExtension::Halt) { |halt|
-      expect(halt.status).to eq(400)
+      expect(halt.status).to eq(404)
     }
+  end
+
+  it "does not override an explicit working_dir with the project's" do
+    project = { id: "p1", name: "Proj", working_dir: "/tmp/proj" }
+    allow(project_manager).to receive(:find).with("p1").and_return(project)
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: "/custom/dir", profile: "general", source: :manual, hidden: false).and_return("sess-2")
+    allow(registry).to receive(:with_session).with("sess-2").and_yield({ agent: agent })
+    allow(agent).to receive(:project_id=).with("p1")
+    allow(agent).to receive(:to_session_data).and_return({ id: "sess-2" })
+    allow(session_manager).to receive(:save)
+    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-2")
+
+    result = instance.create_session(project_id: "p1", working_dir: "/custom/dir")
+    expect(result).to eq("sess-2")
+    expect(agent).to have_received(:project_id=).with("p1")
   end
 end

--- a/spec/clacky/default_extensions_spec.rb
+++ b/spec/clacky/default_extensions_spec.rb
@@ -119,3 +119,62 @@ RSpec.describe "ApiExtension#submit_task" do
     }
   end
 end
+
+RSpec.describe "ApiExtension#create_session with project_id" do
+  before { Clacky::ApiExtension.reset_registry! }
+
+  let(:dummy_route) do
+    Clacky::ApiExtension::Route.new(
+      method: :get, pattern: "/", regex: /\A\/\z/, param_names: [],
+      block: proc {}, options: {}
+    )
+  end
+
+  let(:project_manager) { double("project_manager") }
+  let(:registry) { double("registry") }
+  let(:session_manager) { double("session_manager") }
+  let(:agent) { double("agent") }
+  let(:http_server) do
+    server = double("http_server")
+    allow(server).to receive(:instance_variable_get).with(:@registry).and_return(registry)
+    allow(server).to receive(:instance_variable_get).with(:@session_manager).and_return(session_manager)
+    allow(server).to receive(:instance_variable_get).with(:@project_manager).and_return(project_manager)
+    server
+  end
+
+  let(:instance) do
+    Clacky::ApiExtension.allocate.tap do |inst|
+      inst.instance_variable_set(:@req, nil)
+      inst.instance_variable_set(:@res, nil)
+      inst.instance_variable_set(:@route, dummy_route)
+      inst.instance_variable_set(:@params, {})
+      inst.instance_variable_set(:@http_server, http_server)
+    end
+  end
+
+  it "inherits the project working_dir and persists agent.project_id" do
+    project = { id: "p1", name: "Proj", working_dir: "/tmp/proj" }
+    allow(project_manager).to receive(:find).with("p1").and_return(project)
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: File.expand_path("/tmp/proj"), profile: "general", source: :manual, hidden: false).and_return("sess-1")
+    allow(registry).to receive(:with_session).with("sess-1").and_yield({ agent: agent })
+    allow(agent).to receive(:project_id=).with("p1")
+    allow(agent).to receive(:to_session_data).and_return({ id: "sess-1" })
+    allow(session_manager).to receive(:save)
+    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-1")
+
+    result = instance.create_session(project_id: "p1")
+    expect(result).to eq("sess-1")
+    expect(agent).to have_received(:project_id=).with("p1")
+    expect(session_manager).to have_received(:save)
+  end
+
+  it "raises 400 when the project does not exist" do
+    allow(project_manager).to receive(:find).with("nope").and_return(nil)
+
+    expect {
+      instance.create_session(project_id: "nope")
+    }.to raise_error(Clacky::ApiExtension::Halt) { |halt|
+      expect(halt.status).to eq(400)
+    }
+  end
+end


### PR DESCRIPTION
## What

Exposes native project functionality (ProjectManager CRUD + project-scoped sessions) to extension handlers.

## Changes

- **api_extension.rb** (+31/-1): Add `project_manager` accessor and `project_id` parameter to `create_session`. When provided, the session inherits the project's `working_dir` and `agent.project_id` is persisted.
- **ext-develop/SKILL.md** (+8/-1): Document `project_manager` in host context whitelist and add Projects capability section.
- **default_extensions_spec.rb** (+59): Tests for `create_session` with `project_id` — working_dir inheritance, agent.project_id persistence, 400 on unknown project.

## Testing

- `bundle exec rspec` — 3010 examples, 0 failures
- Verified end-to-end with `ext-project-demo` extension (project list, create project, create project-scoped session, verify agent.project_id + working_dir)

## Related

- Platform docs: openclacky-platform `docs/extend-project-support`