### PR TITLE
fix(tools): simplify TodoManager to single-value params to fix serialization

### DIFF
--- a/lib/clacky/tools/todo_manager.rb
+++ b/lib/clacky/tools/todo_manager.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "time"
 
 module Clacky
@@ -10,8 +9,8 @@ module Clacky
       self.tool_description = <<~DESC.strip
         Plan and track multi-step tasks. Skip for trivial single-step requests.
 
-        `task` and `id` accept a single value OR an array — always batch when you can
-        (e.g. `complete id:[1,2,3]` in one call, not three).
+        `task` accepts a single string, `id` accepts a single integer.
+        For batch operations, call the tool multiple times.
 
         Only `complete` a todo once it's truly done end-to-end, not per sub-step.
       DESC
@@ -25,18 +24,12 @@ module Clacky
             description: "add | list | complete | remove | clear"
           },
           task: {
-            description: "add: task description(s). Accepts a string OR an array of strings for batch add.",
-            oneOf: [
-              { type: "string" },
-              { type: "array", items: { type: "string" } }
-            ]
+            type: "string",
+            description: "add: task description (single string)"
           },
           id: {
-            description: "complete/remove: task id(s). Accepts an integer OR an array of integers for batch ops.",
-            oneOf: [
-              { type: "integer" },
-              { type: "array", items: { type: "integer" } }
-            ]
+            type: "integer",
+            description: "complete/remove: task id (single integer)"
           }
         },
         required: ["action"]
@@ -46,28 +39,15 @@ module Clacky
         # todos_storage is injected by Agent, stores todos in memory
         @todos = todos_storage || []
 
-        # Normalize polymorphic inputs: callers may pass scalar or array for
-        # `task` and `id`. We coerce both into arrays internally.
-        tasks_input = normalize_to_array(task)
-        ids_input   = normalize_to_array(id)
-
         case action
         when "add"
-          add_todos(tasks_input)
+          add_todo(task)
         when "list"
           list_todos
         when "complete"
-          if ids_input.size > 1
-            complete_todos(ids_input)
-          else
-            complete_todo(ids_input.first)
-          end
+          complete_todo(id)
         when "remove"
-          if ids_input.size > 1
-            remove_todos(ids_input)
-          else
-            remove_todo(ids_input.first)
-          end
+          remove_todo(id)
         when "clear"
           clear_todos
         else
@@ -75,37 +55,20 @@ module Clacky
         end
       end
 
-      # Coerce scalar/array/nil into an Array. Filters nil entries.
-      private def normalize_to_array(value)
-        return [] if value.nil?
-        Array(value).reject(&:nil?)
-      end
-
       def format_call(args)
         action = args[:action] || args['action']
         case action
         when 'add'
           task_arg = args[:task] || args['task']
-          count = task_arg.is_a?(Array) ? task_arg.size : 1
-          "TodoManager(add #{count} task#{count > 1 ? 's' : ''})"
+          "TodoManager(add: #{task_arg.to_s[0..30]})"
         when 'complete'
           id_arg = args[:id] || args['id']
-          if id_arg.is_a?(Array) && id_arg.size > 1
-            "TodoManager(complete #{id_arg.size} tasks: #{id_arg.join(', ')})"
-          else
-            single = id_arg.is_a?(Array) ? id_arg.first : id_arg
-            "TodoManager(complete ##{single})"
-          end
+          "TodoManager(complete ##{id_arg})"
         when 'list'
           "TodoManager(list)"
         when 'remove'
           id_arg = args[:id] || args['id']
-          if id_arg.is_a?(Array) && id_arg.size > 1
-            "TodoManager(remove #{id_arg.size} tasks: #{id_arg.join(', ')})"
-          else
-            single = id_arg.is_a?(Array) ? id_arg.first : id_arg
-            "TodoManager(remove ##{single})"
-          end
+          "TodoManager(remove ##{id_arg})"
         when 'clear'
           "TodoManager(clear all)"
         else
@@ -123,7 +86,6 @@ module Clacky
         end
       end
 
-
       def load_todos
         @todos
       end
@@ -134,13 +96,10 @@ module Clacky
         @todos.replace(todos)
       end
 
-      def add_todos(tasks_input)
-        # tasks_input is already a normalized array (possibly empty)
-        tasks_to_add = Array(tasks_input)
-                       .map { |t| t.is_a?(String) ? t.strip : t.to_s.strip }
-                       .reject(&:empty?)
+      def add_todo(task_input)
+        task_desc = task_input.to_s.strip
 
-        return { error: "At least one task description is required" } if tasks_to_add.empty?
+        return { error: "Task description is required" } if task_desc.empty?
 
         existing_todos = load_todos
 
@@ -152,23 +111,19 @@ module Clacky
 
         next_id = existing_todos.empty? ? 1 : existing_todos.map { |t| t[:id] }.max + 1
 
-        added_todos = []
-        tasks_to_add.each_with_index do |task_desc, index|
-          new_todo = {
-            id: next_id + index,
-            task: task_desc,
-            status: "pending",
-            created_at: Time.now.iso8601
-          }
-          existing_todos << new_todo
-          added_todos << new_todo
-        end
+        new_todo = {
+          id: next_id,
+          task: task_desc,
+          status: "pending",
+          created_at: Time.now.iso8601
+        }
+        existing_todos << new_todo
 
         save_todos(existing_todos)
 
         {
-          message: added_todos.size == 1 ? "TODO added successfully" : "#{added_todos.size} TODOs added successfully",
-          todos: added_todos,
+          message: "TODO added successfully",
+          todos: [new_todo],
           total: existing_todos.size,
           reminder: "⚠️ IMPORTANT: You have added TODO(s) but have NOT started working yet! You MUST now use other tools (write, edit, shell, etc.) to actually complete these tasks. DO NOT stop here!"
         }
@@ -212,7 +167,7 @@ module Clacky
 
         # Find the next pending task
         next_pending = todos.find { |t| t[:status] == "pending" }
-        
+
         # Count statistics
         completed_count = todos.count { |t| t[:status] == "completed" }
         total_count = todos.size
@@ -266,94 +221,6 @@ module Clacky
           message: "All TODOs cleared",
           cleared_count: count
         }
-      end
-
-      def remove_todos(ids)
-        return { error: "Task IDs array is required" } if ids.nil? || ids.empty?
-
-        todos = load_todos
-        removed_todos = []
-        not_found_ids = []
-
-        ids.each do |id|
-          todo = todos.find { |t| t[:id] == id }
-          if todo
-            removed_todos << todo
-          else
-            not_found_ids << id
-          end
-        end
-
-        # Remove all found todos
-        todos.reject! { |t| ids.include?(t[:id]) }
-        save_todos(todos)
-
-        result = {
-          message: "#{removed_todos.size} task(s) removed",
-          removed: removed_todos,
-          remaining: todos.size
-        }
-
-        # Add warning about not found IDs
-        result[:not_found] = not_found_ids unless not_found_ids.empty?
-
-        result
-      end
-
-      # Mark several tasks completed in one call.
-      # Behavior mirrors `complete_todo` but aggregates over `ids`.
-      # Tolerates already-completed and not-found ids (returned in result).
-      def complete_todos(ids)
-        return { error: "Task IDs array is required" } if ids.nil? || ids.empty?
-
-        todos = load_todos
-        now = Time.now.iso8601
-        completed_now = []
-        already_completed = []
-        not_found = []
-
-        ids.each do |id|
-          todo = todos.find { |t| t[:id] == id }
-          if todo.nil?
-            not_found << id
-          elsif todo[:status] == "completed"
-            already_completed << todo
-          else
-            todo[:status] = "completed"
-            todo[:completed_at] = now
-            completed_now << todo
-          end
-        end
-
-        save_todos(todos)
-
-        completed_count = todos.count { |t| t[:status] == "completed" }
-        total_count    = todos.size
-        next_pending   = todos.find { |t| t[:status] == "pending" }
-
-        result = {
-          message: "#{completed_now.size} task(s) marked as completed",
-          completed: completed_now,
-          progress: "#{completed_count}/#{total_count}"
-        }
-
-        result[:already_completed] = already_completed unless already_completed.empty?
-        result[:not_found]         = not_found          unless not_found.empty?
-
-        if next_pending
-          result[:next_task] = next_pending
-          result[:next_task_info] =
-            "Progress: #{completed_count}/#{total_count}. " \
-            "Next task: ##{next_pending[:id]} - #{next_pending[:task]}"
-        else
-          # All tasks completed — auto-clear to match single-complete behavior
-          save_todos([])
-          result[:all_completed] = true
-          result[:completion_message] =
-            "All tasks completed and cleared! (#{completed_count}/#{total_count})"
-        end
-
-        result
       end
     end
   end

--- a/spec/clacky/tools/todo_manager_spec.rb
+++ b/spec/clacky/tools/todo_manager_spec.rb
@@ -17,68 +17,18 @@ RSpec.describe Clacky::Tools::TodoManager do
         expect(storage.size).to eq(1)
       end
 
-      it "adds multiple todos at once when task is an array" do
-        storage = []
-        result = tool.execute(
-          action: "add",
-          task: ["Task 1", "Task 2", "Task 3"],
-          todos_storage: storage
-        )
-
-        expect(result[:message]).to eq("3 TODOs added successfully")
-        expect(result[:todos].size).to eq(3)
-        expect(result[:todos][0][:id]).to eq(1)
-        expect(result[:todos][1][:id]).to eq(2)
-        expect(result[:todos][2][:id]).to eq(3)
-        expect(storage.size).to eq(3)
-      end
-
-      it "increments todo IDs correctly when adding multiple batches" do
-        storage = []
-        tool.execute(action: "add", task: "First task", todos_storage: storage)
-        result = tool.execute(
-          action: "add",
-          task: ["Second task", "Third task"],
-          todos_storage: storage
-        )
-
-        expect(result[:todos][0][:id]).to eq(2)
-        expect(result[:todos][1][:id]).to eq(3)
-        expect(storage.size).to eq(3)
-      end
-
       it "returns error when task is empty string" do
         storage = []
         result = tool.execute(action: "add", task: "", todos_storage: storage)
 
-        expect(result[:error]).to eq("At least one task description is required")
+        expect(result[:error]).to eq("Task description is required")
       end
 
       it "returns error when task is nil" do
         storage = []
         result = tool.execute(action: "add", todos_storage: storage)
 
-        expect(result[:error]).to eq("At least one task description is required")
-      end
-
-      it "returns error when task array is empty" do
-        storage = []
-        result = tool.execute(action: "add", task: [], todos_storage: storage)
-
-        expect(result[:error]).to eq("At least one task description is required")
-      end
-
-      it "filters out empty entries in a task array" do
-        storage = []
-        result = tool.execute(
-          action: "add",
-          task: ["Task 1", "", "  ", "Task 2"],
-          todos_storage: storage
-        )
-
-        expect(result[:todos].size).to eq(2)
-        expect(result[:todos][0][:task]).to eq("Task 1")
-        expect(result[:todos][1][:task]).to eq("Task 2")
+        expect(result[:error]).to eq("Task description is required")
       end
 
       it "tolerates unknown extra keyword args (e.g. legacy clients)" do
@@ -135,7 +85,7 @@ RSpec.describe Clacky::Tools::TodoManager do
     end
 
     describe "complete action" do
-      it "marks a single todo as completed (integer id)" do
+      it "marks a single todo as completed" do
         storage = []
         tool.execute(action: "add", task: "Task to complete", todos_storage: storage)
         result = tool.execute(action: "complete", id: 1, todos_storage: storage)
@@ -145,49 +95,7 @@ RSpec.describe Clacky::Tools::TodoManager do
         expect(result[:todo][:completed_at]).not_to be_nil
       end
 
-      it "marks a single todo as completed when id is a single-element array" do
-        storage = []
-        tool.execute(action: "add", task: ["Task A", "Task B"], todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1], todos_storage: storage)
-
-        expect(result[:message]).to eq("Task marked as completed")
-        expect(result[:todo][:id]).to eq(1)
-      end
-
-      it "batch completes several todos when id is an array" do
-        storage = []
-        tool.execute(action: "add", task: ["T1", "T2", "T3"], todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1, 2], todos_storage: storage)
-
-        expect(result[:message]).to eq("2 task(s) marked as completed")
-        expect(result[:completed].size).to eq(2)
-        expect(result[:completed].map { |t| t[:id] }).to eq([1, 2])
-        expect(result[:progress]).to eq("2/3")
-        expect(result[:next_task][:id]).to eq(3)
-      end
-
-      it "batch complete reports already-completed and not-found ids separately" do
-        storage = []
-        tool.execute(action: "add", task: ["T1", "T2"], todos_storage: storage)
-        tool.execute(action: "complete", id: 1, todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1, 2, 999], todos_storage: storage)
-
-        expect(result[:completed].map { |t| t[:id] }).to eq([2])
-        expect(result[:already_completed].map { |t| t[:id] }).to eq([1])
-        expect(result[:not_found]).to eq([999])
-      end
-
-      it "batch complete auto-clears when all todos are completed" do
-        storage = []
-        tool.execute(action: "add", task: ["T1", "T2", "T3"], todos_storage: storage)
-        result = tool.execute(action: "complete", id: [1, 2, 3], todos_storage: storage)
-
-        expect(result[:all_completed]).to be true
-        expect(result[:completion_message]).to eq("All tasks completed and cleared! (3/3)")
-        expect(storage).to be_empty
-      end
-
-      it "returns message if already completed (single)" do
+      it "returns message if already completed" do
         storage = []
         tool.execute(action: "add", task: "Task", todos_storage: storage)
         tool.execute(action: "add", task: "Task 2", todos_storage: storage)
@@ -197,7 +105,7 @@ RSpec.describe Clacky::Tools::TodoManager do
         expect(result[:message]).to eq("Task already completed")
       end
 
-      it "returns error when task not found (single)" do
+      it "returns error when task not found" do
         storage = []
         result = tool.execute(action: "complete", id: 999, todos_storage: storage)
 
@@ -211,16 +119,10 @@ RSpec.describe Clacky::Tools::TodoManager do
         expect(result[:error]).to eq("Task ID is required")
       end
 
-      it "returns error when id is an empty array" do
-        storage = []
-        result = tool.execute(action: "complete", id: [], todos_storage: storage)
-
-        expect(result[:error]).to eq("Task ID is required")
-      end
-
       it "auto-clears all todos when last pending task is completed" do
         storage = []
-        tool.execute(action: "add", task: ["Task 1", "Task 2"], todos_storage: storage)
+        tool.execute(action: "add", task: "Task 1", todos_storage: storage)
+        tool.execute(action: "add", task: "Task 2", todos_storage: storage)
         tool.execute(action: "complete", id: 1, todos_storage: storage)
         result = tool.execute(action: "complete", id: 2, todos_storage: storage)
 
@@ -231,7 +133,8 @@ RSpec.describe Clacky::Tools::TodoManager do
 
       it "auto-clears old completed todos when adding new ones" do
         storage = []
-        tool.execute(action: "add", task: ["Old Task 1", "Old Task 2"], todos_storage: storage)
+        tool.execute(action: "add", task: "Old Task 1", todos_storage: storage)
+        tool.execute(action: "add", task: "Old Task 2", todos_storage: storage)
         tool.execute(action: "complete", id: 1, todos_storage: storage)
         # Task 2 still pending, Task 1 completed. Add new task cycle.
         result = tool.execute(action: "add", task: "New Task", todos_storage: storage)
@@ -244,22 +147,13 @@ RSpec.describe Clacky::Tools::TodoManager do
     end
 
     describe "remove action" do
-      it "removes a todo (integer id)" do
+      it "removes a todo" do
         storage = []
         tool.execute(action: "add", task: "Task to remove", todos_storage: storage)
         result = tool.execute(action: "remove", id: 1, todos_storage: storage)
 
         expect(result[:message]).to eq("Task removed")
         expect(result[:remaining]).to eq(0)
-      end
-
-      it "removes a todo when id is a single-element array" do
-        storage = []
-        tool.execute(action: "add", task: ["a", "b"], todos_storage: storage)
-        result = tool.execute(action: "remove", id: [1], todos_storage: storage)
-
-        expect(result[:message]).to eq("Task removed")
-        expect(result[:remaining]).to eq(1)
       end
 
       it "returns error when task not found" do
@@ -272,38 +166,6 @@ RSpec.describe Clacky::Tools::TodoManager do
       it "returns error when id is nil" do
         storage = []
         result = tool.execute(action: "remove", todos_storage: storage)
-
-        expect(result[:error]).to eq("Task ID is required")
-      end
-
-      it "batch removes multiple todos when id is an array" do
-        storage = []
-        tool.execute(action: "add", task: ["Task 1", "Task 2", "Task 3", "Task 4"], todos_storage: storage)
-        result = tool.execute(action: "remove", id: [1, 3], todos_storage: storage)
-
-        expect(result[:message]).to eq("2 task(s) removed")
-        expect(result[:removed].size).to eq(2)
-        expect(result[:removed][0][:id]).to eq(1)
-        expect(result[:removed][1][:id]).to eq(3)
-        expect(result[:remaining]).to eq(2)
-        expect(storage.size).to eq(2)
-        expect(storage.map { |t| t[:id] }).to eq([2, 4])
-      end
-
-      it "handles batch remove with some non-existent IDs" do
-        storage = []
-        tool.execute(action: "add", task: ["Task 1", "Task 2"], todos_storage: storage)
-        result = tool.execute(action: "remove", id: [1, 999, 2, 888], todos_storage: storage)
-
-        expect(result[:message]).to eq("2 task(s) removed")
-        expect(result[:removed].size).to eq(2)
-        expect(result[:not_found]).to eq([999, 888])
-        expect(result[:remaining]).to eq(0)
-      end
-
-      it "returns error when id is an empty array" do
-        storage = []
-        result = tool.execute(action: "remove", id: [], todos_storage: storage)
 
         expect(result[:error]).to eq("Task ID is required")
       end
@@ -343,29 +205,11 @@ RSpec.describe Clacky::Tools::TodoManager do
 
   describe "#format_call" do
     it "formats add with string task" do
-      expect(tool.format_call(action: "add", task: "x")).to eq("TodoManager(add 1 task)")
-    end
-
-    it "formats add with array task" do
-      expect(tool.format_call(action: "add", task: ["a", "b"])).to eq("TodoManager(add 2 tasks)")
+      expect(tool.format_call(action: "add", task: "x")).to eq("TodoManager(add: x)")
     end
 
     it "formats complete with integer id" do
       expect(tool.format_call(action: "complete", id: 5)).to eq("TodoManager(complete #5)")
-    end
-
-    it "formats complete with array id (batch)" do
-      expect(tool.format_call(action: "complete", id: [1, 2, 3]))
-        .to eq("TodoManager(complete 3 tasks: 1, 2, 3)")
-    end
-
-    it "formats complete with single-element array id" do
-      expect(tool.format_call(action: "complete", id: [7])).to eq("TodoManager(complete #7)")
-    end
-
-    it "formats remove with array id" do
-      expect(tool.format_call(action: "remove", id: [4, 5]))
-        .to eq("TodoManager(remove 2 tasks: 4, 5)")
     end
 
     it "formats clear" do
@@ -389,30 +233,20 @@ RSpec.describe Clacky::Tools::TodoManager do
       expect(actions).to include("add", "list", "complete", "remove", "clear")
     end
 
-    it "exposes polymorphic task parameter with oneOf string|array" do
+    it "exposes single string task parameter" do
       definition = tool.to_function_definition
       task_prop = definition[:function][:parameters][:properties][:task]
 
-      expect(task_prop).to have_key(:oneOf)
-      types = task_prop[:oneOf].map { |s| s[:type] }
-      expect(types).to contain_exactly("string", "array")
+      expect(task_prop[:type]).to eq("string")
+      expect(task_prop).not_to have_key(:oneOf)
     end
 
-    it "exposes polymorphic id parameter with oneOf integer|array" do
+    it "exposes single integer id parameter" do
       definition = tool.to_function_definition
       id_prop = definition[:function][:parameters][:properties][:id]
 
-      expect(id_prop).to have_key(:oneOf)
-      types = id_prop[:oneOf].map { |s| s[:type] }
-      expect(types).to contain_exactly("integer", "array")
-    end
-
-    it "no longer exposes legacy `tasks` or `ids` fields" do
-      definition = tool.to_function_definition
-      props = definition[:function][:parameters][:properties]
-
-      expect(props).not_to have_key(:tasks)
-      expect(props).not_to have_key(:ids)
+      expect(id_prop[:type]).to eq("integer")
+      expect(id_prop).not_to have_key(:oneOf)
     end
   end
 end


### PR DESCRIPTION
## Problem

LLM sometimes double-serializes array parameters as JSON strings:

```ruby
# Expected:
task: ["Write report", "Write article"]

# Actual (LLM sometimes sends this):
task: "[\\"Write report\\",\\"Write article\\"]"
```

This causes `normalize_to_array` to treat the entire JSON string as a single task name.

## Root Cause

The polymorphic `oneOf[string, array]` parameter definition leads LLM to occasionally serialize arrays as JSON strings. The `normalize_to_array` method cannot distinguish between:
- A legitimate string: `"Write report"` 
- A serialized array: `"[\\"Write report\\",\\"Write article\\"]"`

## Solution

Simplify the interface to accept only single values:

```ruby
# Before (polymorphic - causes serialization issues)
task: { oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }] }

# After (single value - no ambiguity)
task: { type: "string" }
```

## Changes

- **Simplify parameters**: `task` (string only), `id` (integer only)
- **Remove** `normalize_to_array` method (no longer needed)
- **Rename** `add_todos` to `add_todo` (single item)
- **Remove** `complete_todos` and `remove_todos` batch methods
- **Update** tool description to guide LLM for multiple calls
- **Update** tests to match simplified interface (26 tests pass)

## Why Not Keep Arrays?

Adding JSON.parse detection is a workaround, not a fix:
- Still relies on LLM sending valid JSON (not guaranteed)
- Adds complexity for edge case handling
- Doesn't solve the fundamental ambiguity

Removing array support eliminates the issue entirely. For batch operations, LLM should call the tool multiple times - this is more explicit and debuggable.