### PR TITLE
Fix tool result pairing during session context updates

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -112,6 +112,7 @@ module Clacky
       @pending_injections = []     # Pending inline skill injections to flush after observe()
       @pending_subagent_transcript = nil # Subagent trail to attach to the next tool result (observe)
       @pending_script_tmpdirs = [] # Decrypted-script tmpdirs that live for the agent's lifetime
+      @pending_session_context_refresh = false # Defer path/model context changes until tool results are paired
       @pending_error_rollback = false  # Deferred rollback flag set by restore_session on error
       @last_run_interrupted = false    # Set when run() exits via AgentInterrupted; tells the next run() to keep the task-start snapshot (continuation of the same task across a relay, not a brand-new task)
 
@@ -235,7 +236,10 @@ module Clacky
     # Change the working directory for this session
     # Injects a new session context to notify the AI of the directory change
     def change_working_dir(new_dir)
-      @working_dir = new_dir
+      expanded_dir = File.expand_path(new_dir.to_s)
+      return true if File.expand_path(@working_dir.to_s) == expanded_dir
+
+      @working_dir = expanded_dir
       inject_session_context
       true
     end
@@ -1394,6 +1398,11 @@ module Clacky
           task_id:          @current_task_id
         })
       end
+
+      # A working-directory/model change may arrive from the WebUI while a
+      # tool is executing. Inject its Session context only after observe() has
+      # appended every tool result, preserving the required tool_call pairing.
+      inject_session_context if @pending_session_context_refresh
     end
 
     # Attach the captured subagent transcript (set by execute_skill_with_subagent)
@@ -2064,6 +2073,11 @@ module Clacky
     # Cache-safe: always inserted just before the current user message,
     # so no historical cache entries are ever invalidated.
     private def inject_session_context_if_needed
+      if @pending_session_context_refresh
+        inject_session_context
+        return
+      end
+
       today = Time.now.strftime("%Y-%m-%d")
 
       # Skip if we already have a context for today
@@ -2087,6 +2101,14 @@ module Clacky
       # inject_session_context_if_needed which runs inside run()
       # after the system prompt has been built.
       return unless @history.has_system_prompt?
+
+      # Never place a synthetic user message between assistant.tool_calls and
+      # their tool results. The external change is already reflected by the
+      # instance fields; only the explanatory history message is deferred.
+      if @history.pending_tool_calls?
+        @pending_session_context_refresh = true
+        return false
+      end
 
       today   = Time.now.strftime("%Y-%m-%d")
       os      = Clacky::Utils::EnvironmentDetector.os_type
@@ -2115,6 +2137,8 @@ module Clacky
         session_context: true,
         session_date: today
       })
+      @pending_session_context_refresh = false
+      true
     end
 
     # Parse markdown file:// links from assistant message content.

--- a/lib/clacky/message_history.rb
+++ b/lib/clacky/message_history.rb
@@ -131,16 +131,10 @@ module Clacky
       @messages.any? { |m| m[:role] == "system" }
     end
 
-    # True when the last assistant message has tool_calls but no
-    # tool_result has been appended yet (would cause a 400 from the API).
+    # True when the most recent assistant tool-call group is still missing one
+    # or more results. Multi-tool groups remain pending until every id is paired.
     def pending_tool_calls?
-      return false if @messages.empty?
-
-      last = @messages.last
-      return false unless last[:role] == "assistant" && last[:tool_calls]&.any?
-
-      last_assistant_idx = @messages.rindex { |m| m == last }
-      @messages[(last_assistant_idx + 1)..].none? { |m| m[:role] == "tool" || m[:tool_results] }
+      !pending_tool_group_start.nil?
     end
 
     # Return the session_date value from the most recent session_context message.
@@ -267,13 +261,31 @@ module Clacky
       end
     end
 
-    # Drop the trailing assistant message if it has tool_calls with no subsequent
-    # tool_result — i.e. the tool call was never answered (dangling).
+    # Drop the trailing assistant tool-call group if one or more results are
+    # missing. Partial results must be removed with the assistant message; keeping
+    # either side would leave an invalid provider payload.
     # Called automatically before appending any user message.
     private def drop_dangling_tool_calls!
-      return unless pending_tool_calls?
+      start = pending_tool_group_start
+      return unless start
 
-      @messages.pop
+      @messages.slice!(start..-1)
+    end
+
+    private def pending_tool_group_start
+      assistant_idx = @messages.rindex do |message|
+        message[:role] == "assistant" && message[:tool_calls].is_a?(Array) && !message[:tool_calls].empty?
+      end
+      return nil unless assistant_idx
+
+      trailing = @messages[(assistant_idx + 1)..] || []
+      # Once a normal message follows, this is persisted corruption rather than
+      # an in-flight group; repair_tool_call_pairing handles it for the API copy.
+      return nil unless trailing.all? { |message| tool_result_message?(message) }
+
+      expected_ids = @messages[assistant_idx][:tool_calls].map { |call| call[:id] }.compact
+      seen_ids = trailing.flat_map { |message| tool_result_ids(message) }.uniq
+      (expected_ids - seen_ids).empty? ? nil : assistant_idx
     end
 
     private def strip_for_api(message)
@@ -319,6 +331,16 @@ module Clacky
       i = 0
       while i < msgs.size
         msg = msgs[i]
+
+        # A persisted role:tool message without an immediately active
+        # assistant.tool_calls group can never be valid for OpenAI-compatible
+        # providers. Drop it from the API payload instead of poisoning every
+        # future turn in the session. The canonical history is left untouched.
+        if tool_result_message?(msg)
+          i += 1
+          next
+        end
+
         result << msg
 
         if msg[:role] == "assistant" && msg[:tool_calls].is_a?(Array) && !msg[:tool_calls].empty?
@@ -327,8 +349,15 @@ module Clacky
 
           j = i + 1
           while j < msgs.size && tool_result_message?(msgs[j])
-            result << msgs[j]
-            seen_ids.concat(tool_result_ids(msgs[j]))
+            ids = tool_result_ids(msgs[j])
+            matching_ids = ids & expected_ids
+            # Preserve only results belonging to this assistant call group,
+            # and only the first result for each id. This keeps legitimate
+            # multi-tool sequences while discarding stale/duplicate results.
+            unless (matching_ids - seen_ids).empty?
+              result << msgs[j]
+              seen_ids.concat(matching_ids)
+            end
             j += 1
           end
 

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -6649,6 +6649,13 @@ module Clacky
 
         agent = nil
         @registry.with_session(session_id) { |s| agent = s[:agent] }
+
+        # Idempotent updates must not inject another Session context, rewrite a
+        # large session file, or broadcast a fake directory change. Extensions
+        # may remount their panels repeatedly and submit the current path again.
+        if File.expand_path(agent.working_dir.to_s) == expanded_dir
+          return json_response(res, 200, { ok: true, unchanged: true, working_dir: expanded_dir })
+        end
         
         # Change the agent's working directory
         agent.change_working_dir(expanded_dir)

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -26,6 +26,39 @@ RSpec.describe Clacky::Agent do
     end
   end
 
+  describe "#change_working_dir" do
+    it "is a no-op when the expanded directory has not changed" do
+      expect(agent).not_to receive(:inject_session_context)
+
+      expect(agent.change_working_dir(agent.working_dir)).to be true
+    end
+
+    it "defers Session context until a pending tool result has been appended" do
+      agent.history.append(role: "system", content: "system")
+      agent.history.append(
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "call_1", type: "function",
+                       function: { name: "terminal", arguments: "{}" } }]
+      )
+      allow(client).to receive(:format_tool_results).and_return([
+        { role: "tool", tool_call_id: "call_1", content: "done" }
+      ])
+
+      agent.change_working_dir(File.join(Dir.pwd, "another-case"))
+
+      expect(agent.history.to_a.map { |m| m[:role] }).to eq(%w[system assistant])
+      expect(agent.instance_variable_get(:@pending_session_context_refresh)).to be true
+
+      agent.send(:observe, { tool_calls: [{ id: "call_1", name: "terminal", arguments: "{}" }] },
+                 [{ id: "call_1", content: "done" }])
+
+      expect(agent.history.to_a.map { |m| m[:role] }).to eq(%w[system assistant tool user])
+      expect(agent.history.to_a.last).to include(system_injected: true, session_context: true)
+      expect(agent.instance_variable_get(:@pending_session_context_refresh)).to be false
+    end
+  end
+
   describe "#run" do
     let(:tool_call_response) do
       mock_api_response(

--- a/spec/clacky/message_history_spec.rb
+++ b/spec/clacky/message_history_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe Clacky::MessageHistory do
         history.append(user_msg("next"))
         expect(history.size).to eq(4)
       end
+
+      it "drops an entire partially answered multi-tool group" do
+        history.append(user_msg)
+        history.append({
+          role: "assistant", content: "",
+          tool_calls: [{ id: "tc_1", name: "grep", arguments: "{}" },
+                       { id: "tc_2", name: "grep", arguments: "{}" }]
+        })
+        history.append(tool_result_msg("tc_1"))
+
+        history.append(user_msg("follow-up"))
+
+        expect(history.to_a.map { |message| message[:role] }).to eq(%w[user user])
+      end
     end
   end
 
@@ -156,6 +170,18 @@ RSpec.describe Clacky::MessageHistory do
       history.append(assistant_with_tool_calls)
       history.append(tool_result_msg)
       expect(history.pending_tool_calls?).to be false
+    end
+
+    it "stays true while a multi-tool group is only partially answered" do
+      history.append(user_msg)
+      history.append({
+        role: "assistant", content: "",
+        tool_calls: [{ id: "tc_1", name: "grep", arguments: "{}" },
+                     { id: "tc_2", name: "grep", arguments: "{}" }]
+      })
+      history.append(tool_result_msg("tc_1"))
+
+      expect(history.pending_tool_calls?).to be true
     end
 
     it "returns false when last message is plain assistant" do
@@ -369,6 +395,41 @@ RSpec.describe Clacky::MessageHistory do
         api_msgs = history.to_api
         expect(api_msgs.size).to eq(4)
         expect(api_msgs.count { |m| m[:role] == "tool" }).to eq(1)
+      end
+
+      it "drops an orphan tool result from a corrupted persisted session" do
+        msgs = history.instance_variable_get(:@messages)
+        msgs << system_msg
+        msgs << user_msg("[Session context: directory changed]", system_injected: true)
+        msgs << tool_result_msg("lost_call")
+
+        api_msgs = history.to_api
+        expect(api_msgs.map { |m| m[:role] }).to eq(%w[system user])
+        expect(api_msgs.none? { |m| m[:tool_call_id] == "lost_call" }).to be true
+      end
+
+      it "keeps consecutive results for a legitimate multi-tool assistant call" do
+        msgs = history.instance_variable_get(:@messages)
+        msgs << user_msg
+        msgs << { role: "assistant", content: "",
+                  tool_calls: [{ id: "tc_1", name: "grep", arguments: "{}" },
+                               { id: "tc_2", name: "grep", arguments: "{}" }] }
+        msgs << tool_result_msg("tc_1")
+        msgs << tool_result_msg("tc_2")
+
+        api_msgs = history.to_api
+        expect(api_msgs.select { |m| m[:role] == "tool" }.map { |m| m[:tool_call_id] }).to eq(%w[tc_1 tc_2])
+      end
+
+      it "drops an unexpected tool result even when it follows another assistant tool group" do
+        msgs = history.instance_variable_get(:@messages)
+        msgs << user_msg
+        msgs << assistant_with_tool_calls
+        msgs << tool_result_msg("tc_1")
+        msgs << tool_result_msg("stale_call")
+
+        api_msgs = history.to_api
+        expect(api_msgs.select { |m| m[:role] == "tool" }.map { |m| m[:tool_call_id] }).to eq(["tc_1"])
       end
 
       it "is deterministic — calling to_api twice on the same history produces identical output (cache-safe)" do

--- a/spec/clacky/server/http_server_spec.rb
+++ b/spec/clacky/server/http_server_spec.rb
@@ -1044,6 +1044,29 @@ RSpec.describe Clacky::Server::HttpServer do
     end
   end
 
+  describe "PATCH /api/sessions/:id/working_dir" do
+    it "returns unchanged without mutating history when the directory is already active" do
+      with_server(agent_config: agent_config) do |server|
+        create_res = fake_res
+        dispatch(server, fake_req(method: "POST", path: "/api/sessions",
+                                  body: { name: "case", working_dir: tmpdir }), create_res)
+        session_id = parsed_body(create_res).dig("session", "id")
+        agent = server.instance_variable_get(:@registry).get(session_id)[:agent]
+        history_size = agent.history.size
+        expect(agent).not_to receive(:change_working_dir)
+
+        res = fake_res
+        dispatch(server, fake_req(method: "PATCH",
+                                  path: "/api/sessions/#{session_id}/working_dir",
+                                  body: { working_dir: tmpdir }), res)
+
+        expect(res.status).to eq(200)
+        expect(parsed_body(res)).to include("ok" => true, "unchanged" => true)
+        expect(agent.history.size).to eq(history_size)
+      end
+    end
+  end
+
   # ── 404 for unknown routes ────────────────────────────────────────────────
 
   describe "unknown routes" do


### PR DESCRIPTION
## What changed

- make working-directory updates idempotent when the requested directory is already active
- defer injected Session context messages until all pending tool results have been appended
- track partially answered multi-tool groups correctly
- repair malformed API payloads by dropping orphan, stale, or duplicate tool results while preserving valid multi-tool sequences
- add regression coverage for agent, message history, and working-directory HTTP behavior

## Root cause

An extension could re-send the session's current working directory while a tool call was in flight. OpenClacky injected a synthetic Session context user message at that moment. Appending the user-role context caused the dangling-tool cleanup to remove the assistant tool-call message, while the later tool result was still persisted. The next LLM request then failed with:

`Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

The problem is timing-based and platform-independent, although Windows/WSL folder workflows make repeated directory synchronization more likely.

## Impact

Existing corrupted sessions can be sent safely again because orphan tool results are filtered from the provider payload. New sessions keep assistant tool calls and their tool results adjacent even when their working directory changes during execution.

## Validation

- `rspec spec/clacky/message_history_spec.rb spec/clacky/agent_spec.rb spec/clacky/server/http_server_spec.rb` — 183 examples, 0 failures
- full `rspec` suite before rebasing onto the latest main — 3025 examples, 0 failures
- `git diff --check`
