### PR TITLE
fix(utils): undouble-serialize tool call arguments

### DIFF
--- a/lib/clacky/utils/arguments_parser.rb
+++ b/lib/clacky/utils/arguments_parser.rb
@@ -88,8 +88,44 @@ module Clacky
         result
       end
 
+      # Undo one layer of accidental double-serialization.
+      #
+      # Some LLMs (e.g. glm-5.2) emit array/object parameters as a JSON
+      # *string* (e.g. {"task":"[\"a\",\"b\"]"}) instead of a native JSON value
+      # (e.g. {"task":["a","b"]}). JSON.parse only strips the outer layer, so
+      # such values arrive here as a literal String. When a downstream tool
+      # feeds that String straight into Array()/mapping, the whole payload
+      # becomes a single malformed entry (e.g. one todo whose text is the raw
+      # "[\"a\",\"b\"]"). Detect values that look like a serialized array or
+      # object and parse them once, so every tool receives the intended native
+      # type.
+      #
+      # Only top-level values are unwrapped. We deliberately do NOT recurse
+      # into Array elements: a String element that merely happens to look like
+      # JSON (e.g. file content, a code snippet) must be preserved verbatim,
+      # otherwise legitimate string payloads would be corrupted. Strings that
+      # fail to parse are left untouched, so genuine string values are safe.
+      def self.undouble_serialize_args(args)
+        args.transform_values do |value|
+          next value unless value.is_a?(String)
+
+          stripped = value.strip
+          next value unless stripped.start_with?("[") || stripped.start_with?("{")
+
+          begin
+            JSON.parse(value)
+          rescue JSON::ParserError
+            value
+          end
+        end
+      end
+
       # Validate required parameters and filter unknown parameters
       def self.validate_required_params(call, args, tool_registry)
+        # Undo accidental double-serialization before validation so downstream
+        # tools receive native arrays/objects (see undouble_serialize_args).
+        args = undouble_serialize_args(args)
+
         tool = tool_registry.get(call[:name])
         required = tool.parameters&.dig(:required) || []
         properties = tool.parameters&.dig(:properties) || {}

--- a/spec/clacky/utils/arguments_parser_spec.rb
+++ b/spec/clacky/utils/arguments_parser_spec.rb
@@ -180,6 +180,131 @@ RSpec.describe Clacky::Utils::ArgumentsParser do
         }.to raise_error(StandardError, /Failed to parse arguments.*file_reader/)
       end
     end
+
+    context "with double-serialized parameters" do
+      # Some LLMs emit array/object params as a JSON *string* (e.g.
+      # {"task":"[\"a\",\"b\"]"}) instead of native JSON. End-to-end check that
+      # parse_and_validate unwraps one serialization layer.
+      let(:todo_registry) do
+        registry = instance_double("Clacky::ToolRegistry")
+        tool = double("TodoTool",
+          name: "todo_manager",
+          description: "todo",
+          parameters: {
+            required: ["action"],
+            properties: {
+              "action" => { "type" => "string" },
+              "task" => { "description" => "task" },
+              "id" => { "description" => "id" }
+            }
+          }
+        )
+        allow(registry).to receive(:get).with("todo_manager").and_return(tool)
+        registry
+      end
+
+      it "unwraps a double-serialized array parameter" do
+        call = { name: "todo_manager", arguments: '{"action":"add","task":"[\"a\",\"b\",\"c\"]"}' }
+
+        result = described_class.parse_and_validate(call, todo_registry)
+
+        expect(result[:task]).to eq(%w[a b c])
+      end
+
+      it "unwraps a double-serialized integer array parameter" do
+        call = { name: "todo_manager", arguments: '{"action":"complete","id":"[1,2,3]"}' }
+
+        result = described_class.parse_and_validate(call, todo_registry)
+
+        expect(result[:id]).to eq([1, 2, 3])
+      end
+
+      it "unwraps a double-serialized object parameter" do
+        call = { name: "todo_manager", arguments: '{"action":"add","task":"{\"x\":1,\"y\":[2,3]}"}' }
+
+        result = described_class.parse_and_validate(call, todo_registry)
+
+        expect(result[:task]).to eq("x" => 1, "y" => [2, 3])
+      end
+
+      it "preserves a genuine single-string task" do
+        call = { name: "todo_manager", arguments: '{"action":"add","task":"完成季度报告"}' }
+
+        result = described_class.parse_and_validate(call, todo_registry)
+
+        expect(result[:task]).to eq("完成季度报告")
+      end
+    end
+  end
+
+  describe ".undouble_serialize_args" do
+    it "unwraps a stringified JSON array into a native Array" do
+      result = described_class.undouble_serialize_args(task: '["a","b","c"]')
+
+      expect(result[:task]).to eq(%w[a b c])
+    end
+
+    it "unwraps a stringified JSON object into a native Hash" do
+      result = described_class.undouble_serialize_args(meta: '{"x":1,"y":[2,3]}')
+
+      expect(result[:meta]).to eq("x" => 1, "y" => [2, 3])
+    end
+
+    it "preserves a plain string value" do
+      result = described_class.undouble_serialize_args(task: "完成季度报告")
+
+      expect(result[:task]).to eq("完成季度报告")
+    end
+
+    it "preserves a string that starts with [ but is not valid JSON" do
+      result = described_class.undouble_serialize_args(task: "[未闭合")
+
+      expect(result[:task]).to eq("[未闭合")
+    end
+
+    it "preserves a string that starts with { but is not valid JSON" do
+      result = described_class.undouble_serialize_args(task: "{未闭合")
+
+      expect(result[:task]).to eq("{未闭合")
+    end
+
+    it "preserves non-string values" do
+      result = described_class.undouble_serialize_args(a: 1, b: nil, c: %w[x y], d: { k: 1 })
+
+      expect(result).to eq(a: 1, b: nil, c: %w[x y], d: { k: 1 })
+    end
+
+    it "does not recurse into array elements" do
+      # A string element that merely looks like JSON (e.g. file content) must
+      # stay a string; otherwise legitimate string payloads get corrupted.
+      result = described_class.undouble_serialize_args(items: ['["a","b"]', "[1,2]"])
+
+      expect(result[:items]).to eq(['["a","b"]', "[1,2]"])
+    end
+
+    it "does not recurse into nested hash values" do
+      # Only top-level values are unwrapped. A stringified JSON nested inside a
+      # native object is preserved verbatim by design.
+      result = described_class.undouble_serialize_args(meta: { k: '["a","b"]' })
+
+      expect(result[:meta]).to eq(k: '["a","b"]')
+    end
+
+    it "leaves sibling values untouched while unwrapping one" do
+      result = described_class.undouble_serialize_args(action: "add", task: '["a","b"]', id: 5)
+
+      expect(result).to eq(action: "add", task: %w[a b], id: 5)
+    end
+
+    it "handles leading/trailing whitespace around JSON-looking strings" do
+      result = described_class.undouble_serialize_args(task: '  ["a","b"]  ')
+
+      expect(result[:task]).to eq(%w[a b])
+    end
+
+    it "returns an empty hash unchanged" do
+      expect(described_class.undouble_serialize_args({})).to eq({})
+    end
   end
 
   describe ".repair_json (private method)" do


### PR DESCRIPTION
## Problem

Some LLMs (e.g. `glm-5.2`) emit array/object tool parameters as a JSON **string** instead of a native JSON value:

```json
{"action":"add","task":"[\"任务A\",\"任务B\",\"任务C\"]"}
```

instead of

```json
{"action":"add","task":["任务A","任务B","任务C"]}
```

`JSON.parse` only strips the outer layer, so such values reach a tool as a literal `String`. When a tool feeds that string straight into `Array()` / mapping, the whole payload becomes a **single malformed entry**. The most visible symptom: `todo_manager` creates **ONE** todo whose text is the raw `[\"任务A\",\"任务B\",\"任务C\"]` — i.e. multiple tasks squashed into one line.

This affects **every** tool that accepts array/object params, not just `todo_manager`.

## Root cause

`Clacky::Utils::ArgumentsParser` parses `arguments` exactly once. There is no "detect a value that is a JSON string and unwrap it" step, so double-serialized values pass through as literal strings.

## Fix

Add `ArgumentsParser.undouble_serialize_args` and call it at the top of `validate_required_params`. It detects top-level values that look like a serialized array/object and parses them once, so **every** tool receives the intended native type. This is a single global fix — no per-tool schema changes needed.

### Design choices (boundary cases considered)

- **Only top-level values are unwrapped** (`transform_values`). We deliberately do **not** recurse into Array/Hash elements: a string that merely *looks* like JSON (file content, code snippets) must be preserved verbatim, otherwise legitimate string payloads get corrupted.
- **Strings that fail `JSON.parse` are left untouched**, so genuine string values are never corrupted.
- **Only one layer is unwrapped** (no recursive loop / runaway parsing).

## Tests

Added 15 specs in `spec/clacky/utils/arguments_parser_spec.rb`:

- unwraps a double-serialized array / integer-array / object
- preserves a genuine single-string task (the most important non-regression)
- preserves a string that starts with `[` / `{` but is not valid JSON
- preserves non-string values (integer, nil, native array/hash)
- **does not recurse into array elements** (file-content safety)
- **does not recurse into nested hash values**
- leaves sibling values untouched while unwrapping one
- handles leading/trailing whitespace around JSON-looking strings
- end-to-end via `parse_and_validate` (incl. a genuine single-string task)

## Verification

- `bundle exec rspec spec/clacky/utils/arguments_parser_spec.rb` → 27 examples, 0 failures
- Full suite: 3086 examples, 0 regressions (6 pre-existing env/config failures unrelated to this change)
- End-to-end live check with the running server: double-serialized `task` now creates N separate todos; genuine single-string tasks are unaffected.

## Changes

- `lib/clacky/utils/arguments_parser.rb` — new `undouble_serialize_args` + call site
- `spec/clacky/utils/arguments_parser_spec.rb` — 15 new specs
