### PR TITLE
fix: WSL path translation and CRLF line-ending preservation

### DIFF
--- a/lib/clacky/tools/base.rb
+++ b/lib/clacky/tools/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../utils/environment_detector"
+
 module Clacky
   module Tools
     class Base
@@ -29,12 +31,20 @@ module Clacky
       end
 
       # Expand ~ to home directory only if path starts with ~
-      # Relative paths are resolved against working_dir if provided
+      # Relative paths are resolved against working_dir if provided.
+      # On WSL, Windows-style paths (C:\..., C:/..., /C:/...) are translated to
+      # their /mnt/<drive>/... equivalents so that paths copied from Windows
+      # (clipboard, error messages, file dialogs) work unchanged.
       # @param path [String, nil] The path to expand
       # @param working_dir [String, nil] The working directory to resolve relative paths against
       # @return [String, nil] The expanded path, or original if no ~ present
       private def expand_path(path, working_dir: nil)
         return path if path.nil? || path.strip.empty?
+
+        # WSL: normalize Windows drive paths BEFORE anything else, otherwise
+        # the leading "C:" makes File.expand_path treat them as relative.
+        path = Clacky::Utils::EnvironmentDetector.win_to_linux_path(path)
+
         return File.expand_path(path) if path.start_with?("~")
         return File.expand_path(path, working_dir) if working_dir && !path.start_with?("/")
         # Always resolve relative paths to absolute (even without working_dir), so callers

--- a/lib/clacky/tools/edit.rb
+++ b/lib/clacky/tools/edit.rb
@@ -49,6 +49,14 @@ module Clacky
           # and cause JSON.generate to fail during replay.
           content = safe_utf8(File.read(path))
 
+          # Detect the file's dominant line-ending style BEFORE any
+          # modification. Windows-created files (and /mnt/c on WSL) use
+          # CRLF; AI-supplied old_string/new_string always use LF. Without
+          # preservation, the replaced fragment introduces LF into a CRLF
+          # file, creating mixed line endings that confuse Git diff and
+          # Windows IDEs.
+          preserve_crlf = content.include?("\r\n")
+
           # Find matching string using layered strategy (shared with preview)
           match_result = Utils::StringMatcher.find_match(content, old_string)
 
@@ -81,6 +89,11 @@ module Clacky
                     else
                       content.sub(actual_old_string) { new_string }
                     end
+
+          # Preserve the original line-ending style: if the file was CRLF,
+          # re-normalize the entire content to CRLF so the newly inserted
+          # LF fragments (from new_string) match the rest of the file.
+          content = normalize_line_endings(content, :crlf) if preserve_crlf
 
           File.write(path, content)
 
@@ -141,6 +154,21 @@ module Clacky
 
         replacements = result[:replacements] || result["replacements"] || 1
         "Modified #{replacements} occurrence#{replacements > 1 ? "s" : ""}"
+      end
+
+      # Normalize all line endings in `content` to the given style.
+      # Works by first collapsing everything to LF, then expanding to the
+      # target — this avoids double-converting existing CRLF into CRCRLF.
+      # @param content [String]
+      # @param style [Symbol] :crlf or :lf
+      # @return [String]
+      private def normalize_line_endings(content, style)
+        case style
+        when :crlf
+          content.gsub(/\r\n/, "\n").gsub(/\r/, "\n").gsub(/\n/, "\r\n")
+        else
+          content.gsub(/\r\n/, "\n").gsub(/\r/, "\n")
+        end
       end
 
       # Scrub invalid UTF-8 byte sequences (see file_reader.rb for rationale).

--- a/lib/clacky/tools/terminal.rb
+++ b/lib/clacky/tools/terminal.rb
@@ -223,6 +223,11 @@ module Clacky
         timeout = (timeout || DEFAULT_TIMEOUT).to_f
         idle_ms = (idle_ms || DEFAULT_IDLE_MS).to_i
         cwd ||= working_dir
+        # Normalize cwd the same way file tools do: on WSL translate Windows
+        # drive paths (C:\..., C:/...) to /mnt, expand ~ and relative paths.
+        # Without this, a Windows-style cwd fails the Dir.exist? check below
+        # and the agent gets a misleading "cwd does not exist".
+        cwd = expand_path(cwd) if cwd
 
         # Kill
         if kill

--- a/lib/clacky/tools/trash_manager.rb
+++ b/lib/clacky/tools/trash_manager.rb
@@ -93,7 +93,7 @@ module Clacky
 
       def restore_file(trash_dir, file_path, project_root)
         deleted_files = get_deleted_files(trash_dir, project_root)
-        expanded_path = File.expand_path(file_path, project_root)
+        expanded_path = expand_path(file_path, working_dir: project_root)
 
         target_file = deleted_files.find { |f| f[:original_path] == expanded_path }
 

--- a/spec/clacky/tools/edit_spec.rb
+++ b/spec/clacky/tools/edit_spec.rb
@@ -280,6 +280,65 @@ RSpec.describe Clacky::Tools::Edit do
     end
   end
   
+  describe "CRLF line-ending preservation" do
+    it "preserves CRLF endings when editing a Windows-style file with LF old_string" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "crlf.rb")
+        # File uses CRLF (Windows style)
+        File.binwrite(file_path, "class Foo\r\n  def bar\r\n    'baz'\r\n  end\r\nend\r\n")
+
+        result = tool.execute(
+          path: file_path,
+          old_string: "    'baz'",        # AI provides LF-style string
+          new_string: "    'qux'"
+        )
+
+        expect(result[:error]).to be_nil
+        written = File.binread(file_path)
+        # No mixed line endings: every \n must be preceded by \r
+        expect(written.scan(/(?<!\r)\n/)).to be_empty
+        expect(written).to include("    'qux'\r\n")
+      end
+    end
+
+    it "preserves CRLF endings on replace_all in a CRLF file" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "crlf_all.rb")
+        File.binwrite(file_path, "foo\r\nfoo\r\nbar\r\n")
+
+        result = tool.execute(
+          path: file_path,
+          old_string: "foo",
+          new_string: "FOO",
+          replace_all: true
+        )
+
+        expect(result[:error]).to be_nil
+        written = File.binread(file_path)
+        expect(written.scan(/(?<!\r)\n/)).to be_empty
+        expect(written).to eq("FOO\r\nFOO\r\nbar\r\n")
+      end
+    end
+
+    it "does not add CRLF to an LF-only file" do
+      Dir.mktmpdir do |dir|
+        file_path = File.join(dir, "lf.rb")
+        File.write(file_path, "line1\nline2\nline3\n")
+
+        result = tool.execute(
+          path: file_path,
+          old_string: "line2",
+          new_string: "LINE2"
+        )
+
+        expect(result[:error]).to be_nil
+        written = File.binread(file_path)
+        expect(written).not_to include("\r")
+        expect(written).to eq("line1\nLINE2\nline3\n")
+      end
+    end
+  end
+
   describe "#to_function_definition" do
     it "returns OpenAI function calling format" do
       definition = tool.to_function_definition

--- a/spec/clacky/tools/file_reader_spec.rb
+++ b/spec/clacky/tools/file_reader_spec.rb
@@ -45,6 +45,34 @@ RSpec.describe Clacky::Tools::FileReader do
         expect(result[:content]).to be_nil
       end
 
+      context "on WSL — Windows-style path normalization" do
+        before do
+          # Force WSL path translation regardless of the host running this spec.
+          allow(Clacky::Utils::EnvironmentDetector).to receive(:os_type).and_return(:wsl)
+        end
+
+        it "normalizes a backslash drive-letter path to /mnt before lookup" do
+          result = tool.execute(path: 'C:\\Users\\spl\\nonexistent.txt')
+
+          expect(result[:error]).to include("File not found")
+          # Path must be the normalized /mnt form, NOT the raw Windows string
+          # (which File.expand_path would wrongly treat as relative).
+          expect(result[:path]).to eq("/mnt/c/Users/spl/nonexistent.txt")
+        end
+
+        it "normalizes a forward-slash drive-letter path to /mnt before lookup" do
+          result = tool.execute(path: "C:/Users/spl/missing.txt")
+
+          expect(result[:path]).to eq("/mnt/c/Users/spl/missing.txt")
+        end
+
+        it "leaves an existing /mnt path untouched" do
+          result = tool.execute(path: "/mnt/c/Users/spl/missing.txt")
+
+          expect(result[:path]).to eq("/mnt/c/Users/spl/missing.txt")
+        end
+      end
+
       it "expands ~ to home directory" do
         Dir.mktmpdir do |dir|
           # Create a test file in temp directory


### PR DESCRIPTION
## Problem

On WSL, two issues affect file tools:

1. **Windows-style paths are not translated.** When an AI model or user passes a Windows-style path (`C:\Users\...`, `C:/Users/...`) to file tools (`file_reader`, `edit`, `write`, `grep`), `File.expand_path` treats the leading `C:` as a relative path, resulting in a misleading "file not found" error.

2. **Editing CRLF files creates mixed line endings.** AI-supplied `old_string`/`new_string` always use LF. When editing a Windows CRLF file (common on `/mnt/c` mounts), the substituted fragment introduces bare LF into a CRLF file, creating mixed line endings that confuse Git diff and Windows IDEs.

## Solution

### WSL Path Translation
- **`base.rb`**: Call `win_to_linux_path` at the start of `expand_path`, so all tools that inherit from `Base` (file_reader, edit, write, glob, grep) automatically translate `C:\...` → `/mnt/c/...` before any path resolution.
- **`terminal.rb`**: Normalize `cwd` through `expand_path` to avoid misleading "cwd does not exist" when a Windows path is passed.
- **`trash_manager.rb`**: Use `expand_path` instead of raw `File.expand_path` for consistent WSL path handling during file restore.

### CRLF Line-Ending Preservation (`edit.rb`)
- Detect CRLF presence in file content **before** any modification (`preserve_crlf = content.include?("\r\n")`).
- After substitution, re-normalize the entire content to CRLF via `normalize_line_endings`, which collapses all line endings to LF first (avoiding CRCRLF), then expands back to CRLF.
- This is a no-op for LF-only files (no CRLF detected → no re-normalization).

## Tests

| File | New tests |
|---|---|
| `file_reader_spec.rb` | 3: backslash path → /mnt, forward-slash path → /mnt, existing /mnt path untouched |
| `edit_spec.rb` | 3: CRLF basic edit, CRLF replace_all, LF-only negative test |

**Edge cases verified** (7 scenarios, all pass): empty file, single-line no-newline, CRLF + new_string containing CRLF, mixed LF/CRLF file, CRLF replace_all with multiline, CR-only (old Mac) file not triggered, CRLF no-match leaves file unchanged.

## Test Results

Full suite: **3062 examples, 0 regressions** (4 pre-existing environment failures unrelated to this PR — verified via `git stash` comparison).

## Files Changed

| File | Change |
|---|---|
| `lib/clacky/tools/base.rb` | +`win_to_linux_path` in `expand_path` |
| `lib/clacky/tools/terminal.rb` | +`expand_path(cwd)` normalization |
| `lib/clacky/tools/trash_manager.rb` | `File.expand_path` → `expand_path` |
| `lib/clacky/tools/edit.rb` | +CRLF detection & `normalize_line_endings` |
| `spec/clacky/tools/file_reader_spec.rb` | +3 WSL path tests |
| `spec/clacky/tools/edit_spec.rb` | +3 CRLF preservation tests |