### PR TITLE
fix: preserve head+tail for oversized terminal output

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -1345,9 +1345,17 @@ module Clacky
       # the new task's @current_task_id, orphaned from its assistant.
       check_stale!
 
+      # Build a tool_call_id → tool_name lookup so truncate_oversized_tool_content
+      # can apply tool-specific truncation strategies (e.g. terminal head+tail).
+      tool_name_by_id = {}
+      response[:tool_calls]&.each do |tc|
+        tool_name_by_id[tc[:id]] = tc[:name]
+      end
+
       formatted_messages = @client.format_tool_results(response, tool_results, model: current_model)
       formatted_messages.each do |msg|
-        truncated = truncate_oversized_tool_content(msg)
+        tool_name = tool_name_by_id[msg[:tool_call_id]]
+        truncated = truncate_oversized_tool_content(msg, tool_name: tool_name)
         @history.append(truncated.merge(task_id: @current_task_id))
       end
 
@@ -1422,16 +1430,37 @@ module Clacky
     # are handled by the image_inject path above.
     MAX_TOOL_RESULT_CHARS = 80_000
 
-    private def truncate_oversized_tool_content(msg)
+    # For terminal output, keep both head and tail because build/test logs
+    # put the most actionable information (error summaries, exit codes) at
+    # the end. Splitting the budget evenly preserves both the command echo
+    # and the final error summary.
+    TERMINAL_HEAD_CHARS = 40_000
+    TERMINAL_TAIL_CHARS = 40_000
+
+    private def truncate_oversized_tool_content(msg, tool_name: nil)
       content = msg[:content]
       return msg unless content.is_a?(String) && content.length > MAX_TOOL_RESULT_CHARS
 
       original_len = content.length
-      head = content[0, MAX_TOOL_RESULT_CHARS]
-      truncated = head + "\n\n[Tool result truncated: #{original_len} chars total, " \
-        "showing first #{MAX_TOOL_RESULT_CHARS}. Use a more specific query/limit, " \
-        "or read the raw output via file_reader/grep on the underlying source.]"
-      msg.merge(content: truncated)
+
+      if tool_name == "terminal"
+        head = content[0, TERMINAL_HEAD_CHARS]
+        tail_start = content.length - TERMINAL_TAIL_CHARS
+        tail = content[tail_start, TERMINAL_TAIL_CHARS]
+        omitted = original_len - TERMINAL_HEAD_CHARS - TERMINAL_TAIL_CHARS
+        truncated = head + "\n\n" \
+          "[... #{omitted} chars omitted — terminal output truncated: " \
+          "#{original_len} chars total, showing first #{TERMINAL_HEAD_CHARS} + " \
+          "last #{TERMINAL_TAIL_CHARS}. Use a more specific command or redirect " \
+          "to a file and read the relevant section. ...]\n\n" + tail
+        msg.merge(content: truncated)
+      else
+        head = content[0, MAX_TOOL_RESULT_CHARS]
+        truncated = head + "\n\n[Tool result truncated: #{original_len} chars total, " \
+          "showing first #{MAX_TOOL_RESULT_CHARS}. Use a more specific query/limit, " \
+          "or read the raw output via file_reader/grep on the underlying source.]"
+        msg.merge(content: truncated)
+      end
     end
 
     # Enqueue an inline skill injection to be flushed after observe().

--- a/spec/clacky/agent_truncate_tool_content_spec.rb
+++ b/spec/clacky/agent_truncate_tool_content_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Clacky::Agent, "#truncate_oversized_tool_content" do
+  let(:client) do
+    instance_double(Clacky::Client).tap { |c| c.instance_variable_set(:@api_key, "k") }
+  end
+  let(:config) do
+    c = Clacky::AgentConfig.new(permission_mode: :auto_approve)
+    c.add_model(model: "claude-sonnet-4.5", api_key: "k", base_url: "https://api.anthropic.com")
+    c
+  end
+  let(:agent) do
+    described_class.new(client, config, working_dir: Dir.pwd, ui: nil,
+                        profile: "coding", session_id: Clacky::SessionManager.generate_id, source: :manual)
+  end
+
+  def truncate(msg, tool_name: nil)
+    agent.send(:truncate_oversized_tool_content, msg, tool_name: tool_name)
+  end
+
+  describe "terminal output (head + tail)" do
+    let(:content) { "X" * 200_000 }
+    let(:msg) { { role: "tool", tool_call_id: "abc", content: content } }
+
+    it "preserves both the first 40k and the last 40k" do
+      result = truncate(msg, tool_name: "terminal")
+      written = result[:content]
+
+      # Head portion
+      expect(written).to start_with("X" * 40_000)
+      # Tail portion
+      expect(written).to end_with("X" * 40_000)
+      # Omitted chars notice
+      omitted = 200_000 - 40_000 - 40_000
+      expect(written).to include("#{omitted} chars omitted")
+    end
+
+    it "keeps total result well under 100k chars" do
+      result = truncate(msg, tool_name: "terminal")
+      # 40k head + 40k tail + notice (~300 chars) should be well under 100k
+      expect(result[:content].length).to be < 81_000
+    end
+  end
+
+  describe "non-terminal output (head only)" do
+    let(:content) { "Y" * 200_000 }
+    let(:msg) { { role: "tool", tool_call_id: "abc", content: content } }
+
+    it "keeps only the first 80k with a standard truncation notice" do
+      result = truncate(msg, tool_name: "grep")
+      written = result[:content]
+
+      expect(written).to start_with("Y" * 80_000)
+      expect(written).to include("showing first 80000")
+      # No tail content
+      expect(written).not_to include("chars omitted")
+    end
+
+    it "applies head-only when tool_name is nil" do
+      result = truncate(msg)
+      expect(result[:content]).to start_with("Y" * 80_000)
+    end
+  end
+
+  describe "short results" do
+    it "leaves short terminal results untouched" do
+      msg = { role: "tool", tool_call_id: "x", content: "exit code 0\nbuild succeeded" }
+      result = truncate(msg, tool_name: "terminal")
+      expect(result[:content]).to eq("exit code 0\nbuild succeeded")
+    end
+
+    it "leaves short non-terminal results untouched" do
+      msg = { role: "tool", tool_call_id: "x", content: "found 3 matches" }
+      result = truncate(msg, tool_name: "grep")
+      expect(result[:content]).to eq("found 3 matches")
+    end
+  end
+
+  describe "non-string content" do
+    it "leaves array content (image blocks) untouched" do
+      content = [{ type: "image_url", image_url: { url: "data:..." } }]
+      msg = { role: "tool", tool_call_id: "x", content: content }
+      result = truncate(msg, tool_name: "file_reader")
+      expect(result[:content]).to eq(content)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When a terminal command produces more than 80k chars of output (e.g. `npm run build`, `bundle exec rspec`, `cargo build`), the agent truncates the result before feeding it to the LLM. The previous implementation kept **only the first 80k** and discarded the rest.

This is problematic for terminal commands because the most actionable information — **error summaries, exit codes, stack traces, test failure details** — appears at the **end** of the output. With head-only truncation, the agent sees hundreds of lines of compile/test progress but loses the final error message, forcing an extra round-trip (file_reader/grep) to find out what went wrong.

## Solution

Tool-specific truncation strategy: for `terminal` results, preserve both **head (40k)** and **tail (40k)**, with an omitted-chars notice in between. The total budget remains 80k chars — no extra token cost.

All other tools (file_reader, grep, glob, etc.) keep the existing head-only behavior.

### Before
```
[first 80k chars of output]
[Tool result truncated: 200000 chars total, showing first 80000. ...]
```
→ The agent never sees the error at the end.

### After (terminal only)
```
[first 40k chars of output]

[... 120000 chars omitted — terminal output truncated: 200000 chars total,
 showing first 40000 + last 40000. Use a more specific command or redirect
 to a file and read the relevant section. ...]

[last 40k chars of output]
```
→ The agent sees both the command context (head) and the result/error (tail).

## Implementation

`truncate_oversized_tool_content` now accepts an optional `tool_name` parameter:
- `tool_name == "terminal"` → split into head + tail
- otherwise → head only (unchanged)

The caller (`agent.rb`) builds a `tool_call_id → tool_name` lookup from the model response so each tool result is paired with its tool name.

## Tests

New spec file `spec/clacky/agent_truncate_tool_content_spec.rb` (7 tests):

| Scenario | What it verifies |
|---|---|
| Terminal 200k output | Head (40k) + tail (40k) both preserved |
| Terminal 200k output | Total result < 81k chars |
| Non-terminal 200k output | Head-only (80k), standard notice |
| tool_name=nil | Falls back to head-only |
| Short terminal result | Unchanged |
| Short non-terminal result | Unchanged |
| Array content (image blocks) | Unchanged |

**Full suite: 3063 examples, 0 regressions** (4 pre-existing environment failures unrelated to this PR).