### PR TITLE
feat(mcp): add OAuth for remote HTTP servers

### DIFF
--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -1,10 +1,10 @@
 # MCP Support — Design Notes
 
 OpenClacky speaks the **Model Context Protocol** (MCP) so users can plug in
-the same servers they already use with Claude Desktop, Cursor, etc. The
-config format is identical (`mcpServers` map in `mcp.json`), but the
-internal architecture is different — designed to keep main-context tokens
-flat as users add more servers.
+the same servers they already use with Claude Desktop, Cursor, etc. Both
+local stdio servers and remote Streamable HTTP servers are supported. The
+config uses an `mcpServers` map in `mcp.json`, while the internal architecture
+keeps main-context tokens flat as users add more servers.
 
 ## The problem with naive MCP integration
 
@@ -63,11 +63,10 @@ Why a user message and not the system prompt:
 
 ### 4. Lazy startup, idle reaping
 
-`Mcp::Registry` does **not** spawn server processes at boot. The first
+`Mcp::Registry` does **not** start a connection at boot. The first
 `call_tool` (or first time a subagent fetches the catalog) triggers
-`ensure_started`. A background reaper shuts servers down after five
-minutes of inactivity. This keeps the "no gateway" promise — MCP is just
-local processes the agent talks to over stdio.
+`ensure_started`. A background reaper closes local processes and remote
+sessions after five minutes of inactivity.
 
 ## Token-budget summary
 
@@ -82,7 +81,9 @@ naive integration: ~6 000 × 10 ≈ 60 000 tokens up front.
 
 ## Files
 
-- `lib/clacky/mcp/client.rb` — stdio JSON-RPC 2.0 client
+- `lib/clacky/mcp/client.rb` — JSON-RPC 2.0 client for stdio and HTTP
+- `lib/clacky/mcp/http_transport.rb` — Streamable HTTP transport
+- `lib/clacky/mcp/oauth/` — OAuth discovery, PKCE, refresh, and credential storage
 - `lib/clacky/mcp/registry.rb` — config loading, lazy starts, idle reaping
 - `lib/clacky/mcp/virtual_skill.rb` — synthesized Skill per server
 - `lib/clacky/tools/mcp_call.rb` — the single bridge tool
@@ -112,3 +113,39 @@ Format matches Claude Desktop / Cursor:
 
 `description` is OpenClacky-specific and recommended — it's what the main
 agent sees when deciding whether to call into a given server.
+
+### Remote HTTP with OAuth
+
+OAuth-protected remote servers use the standard protected-resource metadata,
+authorization-server metadata, dynamic client registration, PKCE S256, and
+refresh-token flow:
+
+```json
+{
+  "mcpServers": {
+    "video-editor": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "auth": {
+        "type": "oauth",
+        "resource": "https://mcp.example.com/mcp"
+      },
+      "description": "Create and edit videos."
+    }
+  }
+}
+```
+
+Manage authorization from the CLI:
+
+```sh
+clacky mcp capabilities --json
+clacky mcp login video-editor
+clacky mcp status video-editor --json
+clacky mcp logout video-editor
+```
+
+Credentials are stored outside `mcp.json` under
+`~/.clacky/mcp/oauth/`, with owner-only permissions. OAuth endpoints
+must use HTTPS; callback redirects bind to a random loopback port. Access and
+refresh tokens are never included in MCP error messages.

--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -148,4 +148,6 @@ clacky mcp logout video-editor
 Credentials are stored outside `mcp.json` under
 `~/.clacky/mcp/oauth/`, with owner-only permissions. OAuth endpoints
 must use HTTPS; callback redirects bind to a random loopback port. Access and
-refresh tokens are never included in MCP error messages.
+refresh tokens are never interpolated into MCP error messages. HTTP 401 response
+bodies are omitted; other HTTP error bodies retain at most 500 characters for
+diagnostics, matching the existing HTTP transport behavior.

--- a/docs/mcp.example.json
+++ b/docs/mcp.example.json
@@ -17,6 +17,15 @@
       "command": "uvx",
       "args": ["mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"],
       "description": "Query a local SQLite database."
+    },
+    "remote-oauth": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "auth": {
+        "type": "oauth",
+        "resource": "https://mcp.example.com/mcp"
+      },
+      "description": "Example OAuth-protected remote MCP server."
     }
   }
 }

--- a/docs/superpowers/plans/2026-08-09-chatcut-extension-bridge.md
+++ b/docs/superpowers/plans/2026-08-09-chatcut-extension-bridge.md
@@ -1,0 +1,191 @@
+# ChatCut Extension Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use box:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone ChatCut extension that works on existing OpenClacky clients through an OAuth-aware stdio bridge and automatically switches to native OAuth when available.
+
+**Architecture:** A setup command owns conflict-safe MCP configuration, capability detection, and cleanup. A focused Ruby bridge composes OAuth discovery/session classes with an MCP HTTP forwarder while keeping stdout protocol-only. Extension skills call the setup command and delegate all video work to `mcp:chatcut` and ChatCut's remote playbooks.
+
+**Tech Stack:** Ruby 2.6+, Net::HTTP, WEBrick, JSON, minitest, OpenClacky `ext.yml` and MCP configuration.
+
+---
+
+### Task 1: Standalone extension skeleton
+
+**Files:**
+- Create: `openclacky-chatcut/ext.yml`
+- Create: `openclacky-chatcut/README.md`
+- Create: `openclacky-chatcut/LICENSE`
+- Create: `openclacky-chatcut/Rakefile`
+- Create: `openclacky-chatcut/test/test_helper.rb`
+
+- [ ] **Step 1: Write a manifest validation test**
+
+Create a minitest that loads `ext.yml`, asserts `id == "chatcut"`, and asserts the three skill directories exist.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run: `ruby -Itest test/manifest_test.rb`
+Expected: FAIL because `ext.yml` does not exist.
+
+- [ ] **Step 3: Add the minimal extension skeleton**
+
+Declare `chatcut-setup`, `chatcut`, and `chatcut-disconnect` under `contributes.skills`, add MIT project metadata for original adapter code, and add a Rake test task.
+
+- [ ] **Step 4: Run the test to verify GREEN**
+
+Run: `ruby -Itest test/manifest_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add . && git commit -m "chore: scaffold chatcut extension"`
+
+### Task 2: Conflict-safe MCP configuration
+
+**Files:**
+- Create: `openclacky-chatcut/lib/chatcut_extension/configurator.rb`
+- Create: `openclacky-chatcut/bin/chatcut-extension`
+- Create: `openclacky-chatcut/test/configurator_test.rb`
+
+- [ ] **Step 1: Write failing configuration tests**
+
+Cover merging a bridge entry while preserving another server, selecting native mode from `{"remote_oauth":true}`, falling back when the command is absent, refusing to replace an unowned conflicting `chatcut` entry, and disconnecting only an owned entry.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `ruby -Itest test/configurator_test.rb`
+Expected: FAIL because `ChatcutExtension::Configurator` is undefined.
+
+- [ ] **Step 3: Implement the configurator and executable**
+
+Implement `setup`, `status`, and `disconnect`. Probe `clacky mcp capabilities --json`; native mode writes `type`, `url`, and `auth`, while fallback writes `command` and absolute bridge path. Save a SHA-256 fingerprint of the managed entry under the extension data directory and chmod configuration/state files to 0600.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `ruby -Itest test/configurator_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add bin lib test && git commit -m "feat: configure chatcut mcp with native fallback"`
+
+### Task 3: OAuth discovery and credential storage
+
+**Files:**
+- Create: `openclacky-chatcut/lib/chatcut_bridge/credential_store.rb`
+- Create: `openclacky-chatcut/lib/chatcut_bridge/oauth_client.rb`
+- Create: `openclacky-chatcut/test/credential_store_test.rb`
+- Create: `openclacky-chatcut/test/oauth_client_test.rb`
+
+- [ ] **Step 1: Write failing OAuth unit tests**
+
+Test mode-0600 atomic persistence, protected-resource and authorization-server discovery, PKCE S256 calculation, state mismatch rejection, successful code exchange, refresh-token rotation, and redacted HTTP errors using a local WEBrick server.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `ruby -Itest test/credential_store_test.rb test/oauth_client_test.rb`
+Expected: FAIL because the bridge classes are undefined.
+
+- [ ] **Step 3: Implement minimal OAuth classes**
+
+Use `SecureRandom.urlsafe_base64`, SHA-256 PKCE, loopback callbacks on `127.0.0.1`, `Net::HTTP`, bounded JSON reads, endpoint HTTPS validation, and atomic JSON writes. Return an authorization header without logging credential values.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `ruby -Itest test/credential_store_test.rb test/oauth_client_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib test && git commit -m "feat: add chatcut bridge oauth session"`
+
+### Task 4: MCP stdio-to-HTTP bridge
+
+**Files:**
+- Create: `openclacky-chatcut/lib/chatcut_bridge/http_forwarder.rb`
+- Create: `openclacky-chatcut/lib/chatcut_bridge/server.rb`
+- Create: `openclacky-chatcut/bridge/chatcut_mcp_bridge.rb`
+- Create: `openclacky-chatcut/test/http_forwarder_test.rb`
+- Create: `openclacky-chatcut/test/server_test.rb`
+
+- [ ] **Step 1: Write failing bridge tests**
+
+Test JSON-RPC line forwarding, SSE `data:` extraction, session-id propagation, bearer injection, proactive refresh, a single refresh-and-retry on 401, notification handling, protocol-only stdout, and redacted diagnostics.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `ruby -Itest test/http_forwarder_test.rb test/server_test.rb`
+Expected: FAIL because forwarder and server classes are undefined.
+
+- [ ] **Step 3: Implement the bridge**
+
+Read one JSON-RPC object per stdin line, POST it to ChatCut, emit response objects as compact JSON lines, send diagnostics only to stderr, preserve `Mcp-Session-Id`, and use the OAuth client for authorization.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `ruby -Itest test/http_forwarder_test.rb test/server_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add bridge lib test && git commit -m "feat: bridge chatcut remote mcp over stdio"`
+
+### Task 5: Skills, packaging, and local installation
+
+**Files:**
+- Create: `openclacky-chatcut/skills/chatcut-setup/SKILL.md`
+- Create: `openclacky-chatcut/skills/chatcut/SKILL.md`
+- Create: `openclacky-chatcut/skills/chatcut-disconnect/SKILL.md`
+- Create: `openclacky-chatcut/test/skills_test.rb`
+
+- [ ] **Step 1: Write failing skill contract tests**
+
+Assert setup runs the extension executable, chatcut invokes `mcp:chatcut` and instructs the subagent to use `list_skills`/`load_skill`, and disconnect runs conflict-safe cleanup.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `ruby -Itest test/skills_test.rb`
+Expected: FAIL because the skills do not exist.
+
+- [ ] **Step 3: Write the three skills and local install instructions**
+
+Keep host-specific instructions in setup/disconnect and all editing knowledge remote. Document the local symlink into `~/.clacky/ext/local/chatcut` and the requirement to start a new session after first registration.
+
+- [ ] **Step 4: Verify GREEN and package**
+
+Run: `bundle exec rake test` and `bundle exec ruby bin/clacky ext verify` from the OpenClacky worktree with the symlink installed.
+Expected: all extension tests pass and verifier reports no ChatCut errors.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add skills test README.md && git commit -m "feat: add chatcut setup and editing skills"`
+
+### Task 6: End-to-end fallback and native-mode verification
+
+**Files:**
+- Create: `openclacky-chatcut/test/integration/setup_modes_test.rb`
+- Create: `openclacky-chatcut/test/integration/bridge_mcp_test.rb`
+
+- [ ] **Step 1: Write integration tests**
+
+Run setup against fake old/new `clacky` executables, launch the bridge against a local OAuth/MCP fixture, complete the callback programmatically, call `initialize`, `tools/list`, and `tools/call`, expire the token, and verify refresh.
+
+- [ ] **Step 2: Run and fix only implementation defects**
+
+Run: `bundle exec rake test`
+Expected: all tests pass with no token values in captured stdout/stderr.
+
+- [ ] **Step 3: Create the authorized local symlink**
+
+Run: `ln -sfn /Users/seng/Documents/GitHub/clacky/openclacky-chatcut ~/.clacky/ext/local/chatcut`
+Expected: the symlink resolves to the standalone repository.
+
+- [ ] **Step 4: Verify with local OpenClacky**
+
+Run: `bundle exec ruby bin/clacky ext verify` and inspect `bundle exec ruby bin/clacky ext list`.
+Expected: ChatCut and all three skills are resolved without errors.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add test && git commit -m "test: verify chatcut bridge fallback modes"`

--- a/docs/superpowers/plans/2026-08-09-native-mcp-oauth.md
+++ b/docs/superpowers/plans/2026-08-09-native-mcp-oauth.md
@@ -1,0 +1,243 @@
+# Native Remote MCP OAuth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use box:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add provider-neutral OAuth 2.1 support for remote MCP servers to OpenClacky, including secure credentials, CLI lifecycle commands, automatic refresh, and transport integration.
+
+**Architecture:** OAuth metadata/session logic is isolated from MCP JSON-RPC transport. A credential store persists per-server grants outside `mcp.json`; an authorization manager discovers metadata, performs DCR and PKCE, and supplies valid bearer tokens. HTTP transport accepts an authorization provider and retries exactly once after an authenticated 401.
+
+**Tech Stack:** Ruby 2.6+, Thor, Net::HTTP, WEBrick, JSON, RSpec.
+
+---
+
+### Task 1: OAuth configuration and capability contract
+
+**Files:**
+- Create: `lib/clacky/mcp/oauth/config.rb`
+- Create: `spec/clacky/mcp/oauth/config_spec.rb`
+- Modify: `lib/clacky/mcp/client.rb`
+- Modify: `lib/clacky/mcp/skill_provider.rb`
+- Modify: `lib/clacky/mcp/registry.rb`
+
+- [ ] **Step 1: Write failing configuration specs**
+
+Cover `auth: {type: oauth}`, explicit resource parsing, default resource equal to MCP URL, rejection of OAuth on non-HTTPS resources, and preservation of static-header servers.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/config_spec.rb`
+Expected: FAIL because `Clacky::Mcp::OAuth::Config` is undefined.
+
+- [ ] **Step 3: Implement minimal configuration parsing**
+
+Add a value object with `enabled?`, `resource`, and validation. Pass parsed OAuth configuration from registry specs into HTTP client construction without provider-specific constants.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/config_spec.rb spec/clacky/mcp/skill_provider_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib spec && git commit -m "feat(mcp): define remote oauth configuration"`
+
+### Task 2: Secure OAuth credential store
+
+**Files:**
+- Create: `lib/clacky/mcp/oauth/credential_store.rb`
+- Create: `spec/clacky/mcp/oauth/credential_store_spec.rb`
+
+- [ ] **Step 1: Write failing credential specs**
+
+Cover deterministic per-server lookup, mode-0600 writes, atomic replacement, refresh-token rotation, deletion, malformed-file recovery, and absence of token values from `inspect`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/credential_store_spec.rb`
+Expected: FAIL because the store is undefined.
+
+- [ ] **Step 3: Implement the file-backed store**
+
+Persist JSON below `~/.clacky/mcp/oauth/`, sanitize server names for paths, serialize writes with a lock file, write to a same-directory temporary file, chmod 0600, fsync, and rename atomically.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/credential_store_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib spec && git commit -m "feat(mcp): store oauth credentials securely"`
+
+### Task 3: Metadata discovery, DCR, and PKCE authorization
+
+**Files:**
+- Create: `lib/clacky/mcp/oauth/http_client.rb`
+- Create: `lib/clacky/mcp/oauth/authorization_manager.rb`
+- Create: `spec/clacky/mcp/oauth/authorization_manager_spec.rb`
+- Create: `spec/support/oauth_mcp_server.rb`
+
+- [ ] **Step 1: Write failing authorization specs**
+
+Use a local HTTPS-capable fixture abstraction to test challenge parsing, RFC 9728 protected-resource discovery, RFC 8414 authorization-server discovery, DCR request fields, S256 PKCE, loopback-only callbacks, state verification, code exchange, denied consent, bounded responses, and redacted errors.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/authorization_manager_spec.rb`
+Expected: FAIL because the manager is undefined.
+
+- [ ] **Step 3: Implement authorization manager**
+
+Generate a random loopback port and state, register `application_type: native`, open the system browser, capture the callback, exchange the code, persist expiry and refresh credentials, and validate all remote endpoints as HTTPS.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/authorization_manager_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib spec && git commit -m "feat(mcp): authorize remote servers with pkce"`
+
+### Task 4: Token refresh session
+
+**Files:**
+- Create: `lib/clacky/mcp/oauth/session.rb`
+- Create: `spec/clacky/mcp/oauth/session_spec.rb`
+
+- [ ] **Step 1: Write failing session specs**
+
+Cover valid-token reuse, refresh within a one-minute expiry skew, refresh-token rotation, concurrent refresh serialization, invalid-grant cleanup, missing-login errors, one forced refresh, and secret-redacted exceptions.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/session_spec.rb`
+Expected: FAIL because `Session` is undefined.
+
+- [ ] **Step 3: Implement the session**
+
+Expose `authorization_headers` and `invalidate!`; refresh through the token endpoint when needed and persist only successful responses.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `bundle exec rspec spec/clacky/mcp/oauth/session_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib spec && git commit -m "feat(mcp): refresh oauth sessions automatically"`
+
+### Task 5: HTTP transport authentication integration
+
+**Files:**
+- Modify: `lib/clacky/mcp/http_transport.rb`
+- Modify: `lib/clacky/mcp/client.rb`
+- Modify: `spec/clacky/mcp/http_transport_spec.rb`
+
+- [ ] **Step 1: Write failing transport specs**
+
+Cover bearer injection without mutating static headers, proactive refresh use, exactly one invalidate-and-retry on 401, no retry for non-authenticated servers, no retry after the second 401, and redacted transport errors.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bundle exec rspec spec/clacky/mcp/http_transport_spec.rb`
+Expected: FAIL because transport has no authorization provider.
+
+- [ ] **Step 3: Integrate OAuth session**
+
+Accept an optional authorization provider, merge its headers per request, capture the 401 challenge, invalidate once, retry the same body once, and preserve MCP session headers and existing static-header behavior.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `bundle exec rspec spec/clacky/mcp/http_transport_spec.rb spec/clacky/mcp/skill_provider_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib spec && git commit -m "feat(mcp): authenticate remote http transports"`
+
+### Task 6: MCP OAuth CLI
+
+**Files:**
+- Create: `lib/clacky/mcp/cli_commands.rb`
+- Create: `spec/clacky/mcp/cli_commands_spec.rb`
+- Modify: `lib/clacky/cli.rb`
+- Modify: `lib/clacky.rb`
+
+- [ ] **Step 1: Write failing CLI specs**
+
+Cover `mcp capabilities --json`, `mcp login SERVER`, `mcp status SERVER --json`, `mcp logout SERVER`, unknown servers, non-OAuth servers, and output that contains status metadata but no tokens.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bundle exec rspec spec/clacky/mcp/cli_commands_spec.rb`
+Expected: FAIL because `Clacky::Mcp::CliCommands` is undefined.
+
+- [ ] **Step 3: Implement and register the Thor subcommand**
+
+Expose `remote_oauth: true` as a capability, authorize configured servers, report connected/expired/disconnected states, and delete credentials on logout.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `bundle exec rspec spec/clacky/mcp/cli_commands_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add lib spec && git commit -m "feat(mcp): add oauth lifecycle commands"`
+
+### Task 7: Documentation and complete verification
+
+**Files:**
+- Modify: `docs/mcp-architecture.md`
+- Modify: `docs/mcp.example.json`
+- Modify: `README.md`
+- Modify: `README_CN.md`
+- Create: `spec/clacky/mcp/oauth/integration_spec.rb`
+
+- [ ] **Step 1: Write the end-to-end integration spec**
+
+Exercise login callback, credential persistence, MCP initialize/tools list/tool call, expiry refresh, 401 retry, status, and logout against the local fixture.
+
+- [ ] **Step 2: Verify the integration RED then GREEN**
+
+Run before final wiring: `bundle exec rspec spec/clacky/mcp/oauth/integration_spec.rb`; confirm the expected missing wiring failure. Complete wiring and rerun for PASS.
+
+- [ ] **Step 3: Document configuration and security behavior**
+
+Add a generic OAuth MCP example, CLI instructions, credential location, HTTPS and loopback rules, and automatic refresh behavior in English and Chinese user-facing documentation.
+
+- [ ] **Step 4: Run full verification**
+
+Run: `bundle exec rspec`, `bundle exec rubocop`, and `bundle exec rake build`.
+Expected: zero test failures, zero lint errors, and a successfully built gem.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add docs README.md README_CN.md spec lib && git commit -m "docs(mcp): document remote oauth connections"`
+
+### Task 8: Upstream PR preparation
+
+**Files:**
+- Inspect: all files changed from `upstream/main`
+
+- [ ] **Step 1: Perform structured self-review**
+
+Run: `git diff upstream/main...HEAD`, inspect every changed file for provider-specific code, token leakage, compatibility regressions, unsupported Ruby syntax, debug output, and missing tests.
+
+- [ ] **Step 2: Run clean-room verification**
+
+Run the full test, lint, build, and gem-content checks from a clean checkout of the branch.
+
+- [ ] **Step 3: Push the feature branch**
+
+Run: `git push -u origin feature/mcp-oauth`.
+
+- [ ] **Step 4: Create the upstream PR**
+
+Run `gh pr create --repo clacky-ai/openclacky --base main --head RLBox:feature/mcp-oauth` with a summary of protocol support, security boundaries, tests, and ChatCut as an external validation case.
+
+- [ ] **Step 5: Inspect PR state**
+
+Run: `gh pr view --repo clacky-ai/openclacky --json url,state,headRefName,baseRefName,statusCheckRollup`.
+Expected: an OPEN PR targeting `main` from `feature/mcp-oauth`, with the URL recorded for handoff.

--- a/docs/superpowers/specs/2026-08-09-mcp-oauth-extension-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-09-mcp-oauth-extension-fallback-design.md
@@ -1,0 +1,115 @@
+# Remote MCP OAuth and Extension Fallback Design
+
+## Purpose
+
+OpenClacky extensions need to connect users to OAuth-protected remote MCP servers without embedding access tokens in `mcp.json`. ChatCut is the first integration, but the client capability must remain provider-neutral.
+
+The delivery has two independently usable versions:
+
+1. A pure ChatCut extension that works on current OpenClacky releases by registering a local stdio bridge. The bridge owns OAuth and forwards MCP traffic to ChatCut's hosted Streamable HTTP endpoint.
+2. Native OpenClacky remote MCP OAuth. Once present, the same extension detects it and registers ChatCut as a direct HTTP MCP server; on older clients it falls back to the bridge.
+
+## User Experience
+
+Installing the ChatCut extension adds setup, status, and disconnect skills. Setup examines the installed OpenClacky capability instead of asking the user which mode to use.
+
+- On a client with native OAuth support, setup writes a direct HTTP server entry with `auth.type: oauth`, then runs the native login command.
+- On an older client, setup writes a stdio server entry pointing at the extension bridge. The bridge opens the browser when authorization is first required.
+- Both modes expose the same `mcp:chatcut` virtual skill and the same remote ChatCut tools and playbooks.
+- Setup merges the `chatcut` entry without overwriting other MCP servers. Disconnect removes only the entry owned by the extension and deletes only ChatCut credentials.
+- A newly registered MCP is used from a new session on current clients. Native hot reload may be added independently and is not required for protocol correctness.
+
+## Shared Configuration Contract
+
+Native mode uses a direct remote server:
+
+```json
+{
+  "mcpServers": {
+    "chatcut": {
+      "type": "http",
+      "url": "https://api.chatcut.io/api/external-mcp/mcp",
+      "auth": {
+        "type": "oauth",
+        "resource": "https://api.chatcut.io/api/external-mcp/mcp"
+      },
+      "description": "Edit and create videos through ChatCut"
+    }
+  }
+}
+```
+
+Fallback mode uses the installed extension bridge:
+
+```json
+{
+  "mcpServers": {
+    "chatcut": {
+      "command": "ruby",
+      "args": ["/absolute/extension/path/bridge/chatcut_mcp_bridge.rb"],
+      "description": "Edit and create videos through ChatCut"
+    }
+  }
+}
+```
+
+The extension records its selected mode and managed configuration fingerprint under `~/.clacky/ext-data/chatcut/`. It does not silently replace a user-managed `chatcut` entry that differs from the recorded fingerprint.
+
+## Extension Bridge
+
+The bridge is a provider-specific compatibility adapter distributed with the extension. It speaks MCP JSON-RPC over stdin/stdout toward OpenClacky and Streamable HTTP toward ChatCut.
+
+The bridge performs OAuth protected-resource discovery, authorization-server discovery, dynamic client registration, Authorization Code with PKCE S256, loopback callback handling, access-token injection, refresh-token rotation, and one refresh-and-retry after a 401. It stores credentials in a mode-0600 JSON file below `~/.clacky/ext-data/chatcut/`; stdout remains protocol-only and diagnostics go to stderr with secrets redacted.
+
+The bridge validates that discovered authorization endpoints are HTTPS and belong to the authorization server advertised by the protected resource. Its callback binds only to `127.0.0.1`, uses a random available port, verifies `state`, and applies timeouts and response-size limits.
+
+## Native OpenClacky OAuth
+
+Native OAuth adds a provider-neutral authorization layer around HTTP MCP transport:
+
+- `clacky mcp login SERVER`, `status SERVER`, and `logout SERVER` commands.
+- OAuth metadata discovery from a 401 `WWW-Authenticate` challenge or an explicit resource URL.
+- Dynamic Client Registration and Authorization Code with PKCE for public native clients.
+- A credential store outside `mcp.json`, with mode-0600 files as the portable baseline.
+- Automatic bearer injection, proactive refresh near expiry, and one refresh-and-retry after a 401.
+- Secret-safe exceptions and logs.
+
+The HTTP transport remains responsible only for MCP HTTP semantics. An OAuth session supplies headers and handles authorization-specific retries. Static `headers` remain supported for non-OAuth servers.
+
+## Capability Detection
+
+The native client exposes capability detection through `clacky mcp capabilities --json`. The extension selects native mode only when the response includes `remote_oauth: true`. Absence of the command, invalid JSON, or a false value selects bridge mode.
+
+This avoids version string comparisons and permits backports. The bridge remains installed even in native mode so downgrading OpenClacky and rerunning setup produces a working fallback.
+
+## Security and Failure Behavior
+
+- Tokens, authorization codes, PKCE verifiers, client secrets, and refresh tokens never appear in `mcp.json`, agent prompts, or stdout protocol frames.
+- OAuth is refused for non-HTTPS remote resources and authorization endpoints; loopback HTTP is allowed only for the local callback.
+- A mismatched OAuth `state`, missing code, registration failure, denied consent, invalid refresh response, or malformed metadata produces an actionable error without leaking secrets.
+- Concurrent processes serialize credential updates and write through a temporary file followed by an atomic rename.
+- Refresh-token rotation replaces the stored refresh token only after a successful token response.
+- A user-managed conflicting MCP entry is preserved and setup stops with a clear conflict message.
+
+## Compatibility and Distribution
+
+The extension package contains Ruby source, skills, manifest, icon, tests, and documentation only. It does not bundle FFmpeg or copy ChatCut's Codex plugin. ChatCut playbooks are loaded from the MCP server through `list_skills` and `load_skill`.
+
+The OpenClacky change remains generic and carries no ChatCut constants, UI labels, endpoints, or business logic.
+
+## Acceptance Scenarios
+
+1. On an unmodified current OpenClacky build, extension setup installs a stdio `chatcut` entry without disturbing another MCP entry.
+2. First bridge use opens ChatCut authorization, persists protected credentials, lists ChatCut tools, and keeps stdout valid JSON-RPC.
+3. An expired access token is refreshed without user action, with rotated refresh credentials persisted.
+4. On a native-OAuth OpenClacky build, extension setup installs a direct HTTP entry and does not invoke the bridge.
+5. Native `mcp login`, `status`, and `logout` work against a standards-compliant local test authorization server.
+6. Native MCP calls inject the bearer token, refresh once after 401, and never expose tokens in errors.
+7. Downgrading to a client without the capability and rerunning setup changes the extension-managed entry back to bridge mode.
+8. Disconnect removes the managed ChatCut entry and ChatCut credentials while preserving unrelated MCP configuration.
+
+## Assumptions
+
+- ChatCut continues to support MCP protocol version `2024-11-05`, Dynamic Client Registration, PKCE S256, refresh tokens, `list_skills`, and `load_skill` as documented in its WorkBuddy integration.
+- The first release uses a protected file credential store for portability. OS keychain integration can be added behind the same store interface later.
+- Publishing the standalone extension repository is separate from the OpenClacky upstream PR; both artifacts are committed and testable locally before publication.

--- a/lib/clacky/cli.rb
+++ b/lib/clacky/cli.rb
@@ -8,6 +8,7 @@ require_relative "json_ui_controller"
 require_relative "plain_ui_controller"
 require_relative "brand_config"
 require_relative "extension/cli_commands"
+require_relative "mcp/cli_commands"
 
 module Clacky
   class CLI < Thor
@@ -1216,6 +1217,9 @@ module Clacky
 
     desc "ext SUBCOMMAND", "Manage extension containers (new, verify, list, pack, install, publish, search)"
     subcommand "ext", Clacky::CliExtensionCommands
+
+    desc "mcp SUBCOMMAND", "Manage MCP server connections and OAuth authorization"
+    subcommand "mcp", Clacky::Mcp::CliCommands
 
     desc "billing", "Show billing summary and usage statistics"
     long_desc <<-LONGDESC

--- a/lib/clacky/mcp/cli_commands.rb
+++ b/lib/clacky/mcp/cli_commands.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "thor"
+require "json"
+require_relative "connection_manager"
+
+module Clacky
+  module Mcp
+    class CliCommands < Thor
+      desc "capabilities", "Report MCP client capabilities"
+      option :json, type: :boolean, default: false
+      def capabilities
+        result = { "remote_oauth" => true }
+        emit(result, "Remote MCP OAuth: supported")
+      end
+
+      desc "login SERVER", "Authorize an OAuth-protected remote MCP server"
+      option :json, type: :boolean, default: false
+      def login(server)
+        result = manager(server).login
+        emit(result, "Connected MCP server '#{server}'.")
+      rescue ConnectionManager::Error => e
+        fail_with(e.message)
+      end
+
+      desc "status SERVER", "Show remote MCP authorization status"
+      option :json, type: :boolean, default: false
+      def status(server)
+        result = manager(server).status
+        label = result["connected"] ? "connected" : "disconnected"
+        emit(result, "MCP server '#{server}' is #{label}.")
+      rescue ConnectionManager::Error => e
+        fail_with(e.message)
+      end
+
+      desc "logout SERVER", "Delete credentials for a remote MCP server"
+      option :json, type: :boolean, default: false
+      def logout(server)
+        result = manager(server).logout
+        emit(result, "Disconnected MCP server '#{server}'.")
+      rescue ConnectionManager::Error => e
+        fail_with(e.message)
+      end
+
+      no_commands do
+        private def manager(server)
+          ConnectionManager.new(server_name: server)
+        end
+
+        private def emit(result, text)
+          puts(options[:json] ? JSON.generate(result) : text)
+        end
+
+        private def fail_with(message)
+          warn message
+          raise Thor::Error, message
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/mcp/client.rb
+++ b/lib/clacky/mcp/client.rb
@@ -33,7 +33,7 @@ module Clacky
       # Build a Client from an mcp.json spec hash.
       # Recognized fields:
       #   stdio: command (required), args, env, cwd
-      #   http:  type: "http", url (required), headers
+      #   http:  type: "http", url (required), headers, auth
       def self.from_spec(name, spec)
         type = (spec["type"] || (spec["url"] ? "http" : "stdio")).to_s
         case type

--- a/lib/clacky/mcp/client.rb
+++ b/lib/clacky/mcp/client.rb
@@ -6,6 +6,10 @@ require "monitor"
 require_relative "transport"
 require_relative "stdio_transport"
 require_relative "http_transport"
+require_relative "oauth/config"
+require_relative "oauth/credential_store"
+require_relative "oauth/authorization_manager"
+require_relative "oauth/session"
 
 module Clacky
   module Mcp
@@ -45,12 +49,24 @@ module Clacky
             )
           )
         when "http", "streamable-http"
+          oauth_config = OAuth::Config.from_server_spec(spec)
+          authorization = nil
+          if oauth_config.enabled?
+            store = OAuth::CredentialStore.new(server_name: name)
+            manager = OAuth::AuthorizationManager.new(
+              server_name: name,
+              config: oauth_config,
+              store: store
+            )
+            authorization = OAuth::Session.new(store: store, manager: manager)
+          end
           new(
             name:    name,
             transport: HttpTransport.new(
               name:    name,
               url:     spec["url"],
-              headers: spec["headers"] || {}
+              headers: spec["headers"] || {},
+              authorization: authorization
             )
           )
         else

--- a/lib/clacky/mcp/connection_manager.rb
+++ b/lib/clacky/mcp/connection_manager.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "oauth/config"
+require_relative "oauth/credential_store"
+require_relative "oauth/authorization_manager"
+require_relative "oauth/session"
+
+module Clacky
+  module Mcp
+    class ConnectionManager
+      class Error < StandardError; end
+
+      def initialize(server_name:, home: Dir.home, working_dir: Dir.pwd, session_factory: nil)
+        @server_name = server_name.to_s
+        @home = File.expand_path(home)
+        @working_dir = working_dir && File.expand_path(working_dir)
+        @session_factory = session_factory || lambda do |_config, store, manager|
+          OAuth::Session.new(store: store, manager: manager)
+        end
+      end
+
+      def login
+        session.login
+        safe_status
+      rescue OAuth::AuthorizationManager::Error, OAuth::Session::Error, OAuth::CredentialStore::Error => e
+        raise Error, e.message
+      end
+
+      def status
+        safe_status
+      rescue OAuth::CredentialStore::Error => e
+        raise Error, e.message
+      end
+
+      def logout
+        session.logout
+        { "server" => @server_name, "connected" => false }
+      rescue OAuth::Session::Error, OAuth::CredentialStore::Error => e
+        raise Error, e.message
+      end
+
+      private def safe_status
+        session.status.merge("server" => @server_name)
+      end
+
+      private def session
+        return @session if @session
+
+        spec = server_spec
+        raise Error, "MCP server '#{@server_name}' is not configured" unless spec
+        config = OAuth::Config.from_server_spec(spec)
+        raise Error, "MCP server '#{@server_name}' is not configured for OAuth" unless config.enabled?
+        store = OAuth::CredentialStore.new(server_name: @server_name, home: @home)
+        manager = OAuth::AuthorizationManager.new(
+          server_name: @server_name,
+          config: config,
+          store: store
+        )
+        @session = @session_factory.call(config, store, manager)
+      rescue OAuth::Config::Error => e
+        raise Error, e.message
+      end
+
+      private def server_spec
+        servers = {}
+        config_paths.each do |path|
+          next unless File.file?(path)
+          document = JSON.parse(File.read(path))
+          source = document["mcpServers"] || document["servers"] || {}
+          source.each { |name, spec| servers[name.to_s] = spec if spec.is_a?(Hash) }
+        end
+        servers[@server_name]
+      rescue JSON::ParserError => e
+        raise Error, "invalid MCP configuration: #{e.message}"
+      end
+
+      private def config_paths
+        paths = [File.join(@home, ".clacky", "mcp.json")]
+        paths << File.join(@working_dir, ".clacky", "mcp.json") if @working_dir
+        paths
+      end
+    end
+  end
+end

--- a/lib/clacky/mcp/connection_manager.rb
+++ b/lib/clacky/mcp/connection_manager.rb
@@ -69,10 +69,10 @@ module Clacky
           document = JSON.parse(File.read(path))
           source = document["mcpServers"] || document["servers"] || {}
           source.each { |name, spec| servers[name.to_s] = spec if spec.is_a?(Hash) }
+        rescue JSON::ParserError
+          raise Error, "invalid MCP configuration in #{path}"
         end
         servers[@server_name]
-      rescue JSON::ParserError => e
-        raise Error, "invalid MCP configuration: #{e.message}"
       end
 
       private def config_paths

--- a/lib/clacky/mcp/http_transport.rb
+++ b/lib/clacky/mcp/http_transport.rb
@@ -23,12 +23,15 @@ module Clacky
       DEFAULT_OPEN_TIMEOUT = 10
       DEFAULT_READ_TIMEOUT = 120
 
-      def initialize(name:, url:, headers: {}, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT)
+      def initialize(name:, url:, headers: {}, authorization: nil, requester: nil,
+                     open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT)
         @name = name
         @uri  = URI.parse(url)
         raise TransportError, "MCP server '#{name}' url is not http(s): #{url}" unless %w[http https].include?(@uri.scheme)
 
         @extra_headers = (headers || {}).transform_keys(&:to_s).transform_values(&:to_s)
+        @authorization = authorization
+        @requester = requester
         @open_timeout  = open_timeout
         @read_timeout  = read_timeout
 
@@ -79,21 +82,17 @@ module Clacky
         @last_error ? "last error: #{@last_error.class}: #{@last_error.message}" : ""
       end
 
-      private def dispatch_post(body, is_request:)
-        http = Net::HTTP.new(@uri.host, @uri.port)
-        http.use_ssl = (@uri.scheme == "https")
-        http.open_timeout = @open_timeout
-        http.read_timeout = @read_timeout
-
+      private def dispatch_post(body, is_request:, retried: false)
         req = Net::HTTP::Post.new(@uri.request_uri)
         req["Content-Type"] = "application/json"
         req["Accept"]       = "application/json, text/event-stream"
         req["MCP-Protocol-Version"] = Client::PROTOCOL_VERSION if defined?(Client::PROTOCOL_VERSION)
         @lock.synchronize { req["Mcp-Session-Id"] = @session_id if @session_id }
         @extra_headers.each { |k, v| req[k] = v }
+        @authorization&.authorization_headers&.each { |k, v| req[k] = v }
         req.body = body
 
-        http.request(req) do |res|
+        perform_request(req) do |res|
           if (sid = res["Mcp-Session-Id"])
             @lock.synchronize { @session_id = sid }
           end
@@ -102,9 +101,14 @@ module Clacky
           if status == 202
             return
           end
+          if status == 401 && @authorization && !retried
+            res.read_body.to_s
+            @authorization.invalidate!
+            return dispatch_post(body, is_request: is_request, retried: true)
+          end
           if status >= 400
-            text = res.read_body.to_s
-            raise TransportError, "HTTP #{status} from MCP server '#{@name}': #{text[0, 500]}"
+            res.read_body.to_s
+            raise TransportError, "HTTP #{status} from MCP server '#{@name}'"
           end
 
           ctype = (res["Content-Type"] || "").downcase
@@ -121,6 +125,16 @@ module Clacky
             deliver(msg)
           end
         end
+      end
+
+      private def perform_request(request, &block)
+        return @requester.call(request, &block) if @requester
+
+        http = Net::HTTP.new(@uri.host, @uri.port)
+        http.use_ssl = (@uri.scheme == "https")
+        http.open_timeout = @open_timeout
+        http.read_timeout = @read_timeout
+        http.request(request, &block)
       end
 
       private def consume_sse(res)

--- a/lib/clacky/mcp/http_transport.rb
+++ b/lib/clacky/mcp/http_transport.rb
@@ -107,8 +107,10 @@ module Clacky
             return dispatch_post(body, is_request: is_request, retried: true)
           end
           if status >= 400
-            res.read_body.to_s
-            raise TransportError, "HTTP #{status} from MCP server '#{@name}'"
+            text = res.read_body.to_s
+            message = "HTTP #{status} from MCP server '#{@name}'"
+            message += ": #{text[0, 500]}" unless status == 401
+            raise TransportError, message
           end
 
           ctype = (res["Content-Type"] || "").downcase

--- a/lib/clacky/mcp/oauth/authorization_manager.rb
+++ b/lib/clacky/mcp/oauth/authorization_manager.rb
@@ -99,6 +99,7 @@ module Clacky
           %w[issuer authorization_endpoint token_endpoint registration_endpoint].each do |key|
             metadata[key] = validate_https_url(metadata[key], key.tr("_", " "))
           end
+          raise Error, "authorization server metadata issuer does not match" unless metadata["issuer"] == server
           unless Array(metadata["code_challenge_methods_supported"]).include?("S256")
             raise Error, "authorization server does not support PKCE S256"
           end

--- a/lib/clacky/mcp/oauth/authorization_manager.rb
+++ b/lib/clacky/mcp/oauth/authorization_manager.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+require "net/http"
+require "securerandom"
+require "digest"
+require "base64"
+require "socket"
+require "timeout"
+
+module Clacky
+  module Mcp
+    module OAuth
+      class AuthorizationManager
+        Response = Struct.new(:status, :headers, :body)
+        MAX_RESPONSE_BYTES = 1_048_576
+
+        class Error < StandardError; end
+
+        def self.pkce_challenge(verifier)
+          Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
+        end
+
+        def initialize(server_name:, config:, store:, requester: nil, callback: nil, clock: nil)
+          @server_name = server_name
+          @config = config
+          @store = store
+          @requester = requester || method(:request)
+          @callback = callback
+          @clock = clock || -> { Time.now.to_i }
+        end
+
+        def login(resource_metadata_url: nil)
+          raise Error, "MCP server '#{@server_name}' is not configured for OAuth" unless @config.enabled?
+
+          receiver = @callback || CallbackReceiver.new
+          redirect_uri = receiver.respond_to?(:redirect_uri) ? receiver.redirect_uri : "http://127.0.0.1:52963/callback"
+          metadata = discover_metadata(resource_metadata_url)
+          client = register_client(metadata, redirect_uri)
+          verifier = SecureRandom.urlsafe_base64(48, false)
+          state = SecureRandom.urlsafe_base64(32, false)
+          authorization_url = build_authorization_url(metadata, client.fetch("client_id"), redirect_uri, verifier, state)
+          callback_result = receiver.call(authorization_url, state)
+          raise Error, "OAuth callback state mismatch" unless callback_result["state"].to_s == state
+          raise Error, "OAuth authorization returned no code" if callback_result["code"].to_s.empty?
+
+          token = token_request(metadata.fetch("token_endpoint"), {
+            "grant_type" => "authorization_code",
+            "code" => callback_result.fetch("code"),
+            "redirect_uri" => redirect_uri,
+            "client_id" => client.fetch("client_id"),
+            "code_verifier" => verifier
+          })
+          grant = normalize_token(token).merge(
+            "client_id" => client.fetch("client_id"),
+            "client_secret" => client["client_secret"],
+            "token_endpoint_auth_method" => client["token_endpoint_auth_method"] || "none",
+            "token_endpoint" => metadata.fetch("token_endpoint"),
+            "authorization_server" => metadata.fetch("issuer"),
+            "resource" => @config.resource
+          )
+          @store.save(grant)
+        ensure
+          receiver.close if defined?(receiver) && receiver.respond_to?(:close)
+        end
+
+        def refresh(grant)
+          refresh_token = grant["refresh_token"].to_s
+          raise Error, "OAuth refresh token is missing; log in again" if refresh_token.empty?
+
+          fields = {
+            "grant_type" => "refresh_token",
+            "refresh_token" => refresh_token,
+            "client_id" => grant.fetch("client_id")
+          }
+          token = token_request(grant.fetch("token_endpoint"), fields,
+                                client_secret: grant["client_secret"],
+                                auth_method: grant["token_endpoint_auth_method"])
+          updated = grant.merge(normalize_token(token))
+          updated["refresh_token"] = refresh_token if token["refresh_token"].to_s.empty?
+          updated
+        rescue KeyError
+          raise Error, "stored OAuth grant is incomplete; log in again"
+        end
+
+        private def discover_metadata(explicit_resource_metadata_url)
+          protected_url = explicit_resource_metadata_url || default_resource_metadata_url
+          protected = get_json(protected_url, "protected resource metadata")
+          if protected["resource"] && protected["resource"] != @config.resource
+            raise Error, "OAuth protected resource metadata does not match the configured MCP resource"
+          end
+
+          server = Array(protected["authorization_servers"]).first || protected["authorization_server"]
+          server = validate_https_url(server, "authorization server")
+          metadata_url = "#{server.sub(%r{/\z}, '')}/.well-known/oauth-authorization-server"
+          metadata = get_json(metadata_url, "authorization server metadata")
+          metadata["issuer"] ||= server
+          %w[issuer authorization_endpoint token_endpoint registration_endpoint].each do |key|
+            metadata[key] = validate_https_url(metadata[key], key.tr("_", " "))
+          end
+          unless Array(metadata["code_challenge_methods_supported"]).include?("S256")
+            raise Error, "authorization server does not support PKCE S256"
+          end
+          metadata
+        end
+
+        private def default_resource_metadata_url
+          resource = URI.parse(@config.resource)
+          origin = "#{resource.scheme}://#{resource.host}"
+          origin += ":#{resource.port}" unless resource.port == 443
+          "#{origin}/.well-known/oauth-protected-resource#{resource.path}"
+        end
+
+        private def register_client(metadata, redirect_uri)
+          response = @requester.call("POST", metadata.fetch("registration_endpoint"),
+                                     { "Content-Type" => "application/json" },
+                                     JSON.generate(
+                                       "client_name" => "openclacky",
+                                       "application_type" => "native",
+                                       "redirect_uris" => [redirect_uri],
+                                       "grant_types" => %w[authorization_code refresh_token],
+                                       "response_types" => ["code"],
+                                       "token_endpoint_auth_method" => "none",
+                                       "scope" => "openid profile email offline_access"
+                                     ))
+          client = parse_success_json(response, "OAuth client registration")
+          raise Error, "OAuth client registration returned no client_id" if client["client_id"].to_s.empty?
+          client
+        end
+
+        private def build_authorization_url(metadata, client_id, redirect_uri, verifier, state)
+          uri = URI.parse(metadata.fetch("authorization_endpoint"))
+          uri.query = URI.encode_www_form(
+            "response_type" => "code",
+            "client_id" => client_id,
+            "redirect_uri" => redirect_uri,
+            "scope" => "openid profile email offline_access",
+            "code_challenge" => self.class.pkce_challenge(verifier),
+            "code_challenge_method" => "S256",
+            "state" => state,
+            "resource" => @config.resource
+          )
+          uri.to_s
+        end
+
+        private def token_request(url, fields, client_secret: nil, auth_method: nil)
+          headers = { "Content-Type" => "application/x-www-form-urlencoded" }
+          if client_secret && auth_method == "client_secret_basic"
+            credentials = Base64.strict_encode64("#{fields['client_id']}:#{client_secret}")
+            headers["Authorization"] = "Basic #{credentials}"
+          elsif client_secret
+            fields = fields.merge("client_secret" => client_secret)
+          end
+          response = @requester.call("POST", validate_https_url(url, "token endpoint"), headers,
+                                     URI.encode_www_form(fields))
+          parse_success_json(response, "OAuth token exchange")
+        end
+
+        private def normalize_token(token)
+          access_token = token["access_token"].to_s
+          raise Error, "OAuth token response contained no access token" if access_token.empty?
+          {
+            "access_token" => access_token,
+            "refresh_token" => token["refresh_token"],
+            "token_type" => token["token_type"] || "Bearer",
+            "expires_at" => @clock.call + token.fetch("expires_in", 3600).to_i
+          }
+        end
+
+        private def get_json(url, label)
+          response = @requester.call("GET", validate_https_url(url, label), { "Accept" => "application/json" }, nil)
+          parse_success_json(response, label)
+        end
+
+        private def parse_success_json(response, label)
+          status = response.status.to_i
+          raise Error, "#{label} failed with HTTP #{status}" unless status >= 200 && status < 300
+          body = response.body.to_s
+          raise Error, "#{label} response was too large" if body.bytesize > MAX_RESPONSE_BYTES
+          value = JSON.parse(body)
+          raise JSON::ParserError unless value.is_a?(Hash)
+          value
+        rescue JSON::ParserError
+          raise Error, "#{label} returned invalid JSON"
+        end
+
+        private def validate_https_url(value, label)
+          uri = URI.parse(value.to_s)
+          unless uri.scheme == "https" && uri.host && !uri.host.empty? && !uri.user && !uri.password
+            raise Error, "#{label} must be an HTTPS URL without credentials"
+          end
+          uri.to_s
+        rescue URI::InvalidURIError
+          raise Error, "#{label} must be an HTTPS URL"
+        end
+
+        private def request(method, url, headers, body)
+          uri = URI.parse(url)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true
+          http.open_timeout = 10
+          http.read_timeout = 30
+          request_class = method == "GET" ? Net::HTTP::Get : Net::HTTP::Post
+          request = request_class.new(uri.request_uri)
+          headers.each { |key, value| request[key] = value }
+          request.body = body if body
+          response = http.request(request)
+          Response.new(response.code.to_i, response.each_header.to_h, response.body.to_s)
+        rescue StandardError => e
+          raise Error, "OAuth network request failed (#{e.class})"
+        end
+
+        class CallbackReceiver
+          attr_reader :redirect_uri
+
+          def initialize(timeout: 300)
+            @server = TCPServer.new("127.0.0.1", 0)
+            @timeout = timeout
+            @redirect_uri = "http://127.0.0.1:#{@server.addr[1]}/callback"
+          end
+
+          def call(authorization_url, _expected_state)
+            open_browser(authorization_url)
+            socket = Timeout.timeout(@timeout) { @server.accept }
+            request_line = socket.gets.to_s
+            path = request_line.split(" ")[1].to_s
+            query = URI.decode_www_form(URI.parse(path).query.to_s).to_h
+            socket.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\nOpenClacky authorization complete. You may close this tab.\n")
+            query
+          rescue Timeout::Error
+            raise Error, "OAuth authorization timed out"
+          ensure
+            socket.close if defined?(socket) && socket
+          end
+
+          def close
+            @server.close unless @server.closed?
+          end
+
+          private def open_browser(url)
+            command = if RUBY_PLATFORM.include?("darwin")
+                        ["open", url]
+                      elsif RUBY_PLATFORM =~ /mswin|mingw|cygwin/
+                        ["cmd", "/c", "start", "", url]
+                      else
+                        ["xdg-open", url]
+                      end
+            opened = system(*command, out: File::NULL, err: File::NULL)
+            raise Error, "could not open a browser for OAuth authorization" unless opened
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/mcp/oauth/config.rb
+++ b/lib/clacky/mcp/oauth/config.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Clacky
+  module Mcp
+    module OAuth
+      class Config
+        class Error < StandardError; end
+
+        attr_reader :resource
+
+        def self.from_server_spec(spec)
+          spec ||= {}
+          auth = spec["auth"]
+          enabled = auth.is_a?(Hash) && !auth.empty?
+          if enabled && auth["type"].to_s != "oauth"
+            raise Error, "unsupported MCP authentication type '#{auth['type']}'"
+          end
+
+          resource = enabled ? (auth["resource"] || spec["url"]) : spec["url"]
+          new(enabled: enabled, resource: resource)
+        end
+
+        def initialize(enabled:, resource:)
+          @enabled = enabled
+          @resource = resource.to_s
+          validate! if enabled?
+        end
+
+        def enabled?
+          @enabled == true
+        end
+
+        private def validate!
+          uri = URI.parse(@resource)
+          unless uri.scheme == "https" && uri.host && !uri.host.empty? && !uri.user && !uri.password
+            raise Error, "OAuth MCP resource must be an HTTPS URL without credentials"
+          end
+        rescue URI::InvalidURIError
+          raise Error, "OAuth MCP resource must be an HTTPS URL"
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/mcp/oauth/config.rb
+++ b/lib/clacky/mcp/oauth/config.rb
@@ -19,12 +19,13 @@ module Clacky
           end
 
           resource = enabled ? (auth["resource"] || spec["url"]) : spec["url"]
-          new(enabled: enabled, resource: resource)
+          new(enabled: enabled, resource: resource, endpoint: spec["url"])
         end
 
-        def initialize(enabled:, resource:)
+        def initialize(enabled:, resource:, endpoint: nil)
           @enabled = enabled
           @resource = resource.to_s
+          @endpoint = (endpoint || resource).to_s
           validate! if enabled?
         end
 
@@ -33,12 +34,16 @@ module Clacky
         end
 
         private def validate!
-          uri = URI.parse(@resource)
-          unless uri.scheme == "https" && uri.host && !uri.host.empty? && !uri.user && !uri.password
-            raise Error, "OAuth MCP resource must be an HTTPS URL without credentials"
-          end
+          validate_https_url(@endpoint, "OAuth MCP endpoint")
+          validate_https_url(@resource, "OAuth MCP resource")
+        end
+
+        private def validate_https_url(value, label)
+          uri = URI.parse(value)
+          raise Error, "#{label} must be an HTTPS URL without credentials" unless
+            uri.scheme == "https" && uri.host && !uri.host.empty? && !uri.user && !uri.password
         rescue URI::InvalidURIError
-          raise Error, "OAuth MCP resource must be an HTTPS URL"
+          raise Error, "#{label} must be an HTTPS URL"
         end
       end
     end

--- a/lib/clacky/mcp/oauth/credential_store.rb
+++ b/lib/clacky/mcp/oauth/credential_store.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "fileutils"
+require "digest"
 
 module Clacky
   module Mcp
@@ -12,8 +13,10 @@ module Clacky
         attr_reader :path
 
         def initialize(server_name:, home: Dir.home)
-          safe_name = server_name.to_s.gsub(/[^a-zA-Z0-9_.-]/, "_")
+          original_name = server_name.to_s
+          safe_name = original_name.gsub(/[^a-zA-Z0-9_.-]/, "_")
           safe_name = "server" if safe_name.empty?
+          safe_name = "#{safe_name}-#{Digest::SHA256.hexdigest(original_name)[0, 12]}" if safe_name != original_name
           @path = File.join(File.expand_path(home), ".clacky", "mcp", "oauth", "#{safe_name}.json")
         end
 

--- a/lib/clacky/mcp/oauth/credential_store.rb
+++ b/lib/clacky/mcp/oauth/credential_store.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+
+module Clacky
+  module Mcp
+    module OAuth
+      class CredentialStore
+        class Error < StandardError; end
+
+        attr_reader :path
+
+        def initialize(server_name:, home: Dir.home)
+          safe_name = server_name.to_s.gsub(/[^a-zA-Z0-9_.-]/, "_")
+          safe_name = "server" if safe_name.empty?
+          @path = File.join(File.expand_path(home), ".clacky", "mcp", "oauth", "#{safe_name}.json")
+        end
+
+        def load
+          return nil unless File.file?(@path)
+
+          with_lock(File::LOCK_SH) do
+            value = JSON.parse(File.read(@path))
+            raise JSON::ParserError unless value.is_a?(Hash)
+            value
+          end
+        rescue JSON::ParserError
+          raise Error, "invalid OAuth credential file; log in again"
+        end
+
+        def save(value)
+          ensure_directory
+          with_lock(File::LOCK_EX) do
+            temporary = "#{@path}.tmp-#{Process.pid}-#{rand(1_000_000)}"
+            File.open(temporary, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+              file.write(JSON.generate(value))
+              file.write("\n")
+              file.flush
+              file.fsync
+            end
+            File.rename(temporary, @path)
+            File.chmod(0o600, @path)
+          ensure
+            FileUtils.rm_f(temporary) if defined?(temporary) && temporary
+          end
+          value
+        end
+
+        def delete
+          return unless File.exist?(@path)
+
+          ensure_directory
+          with_lock(File::LOCK_EX) { FileUtils.rm_f(@path) }
+        end
+
+        def inspect
+          "#<#{self.class} path=#{@path.inspect}>"
+        end
+
+        private def ensure_directory
+          FileUtils.mkdir_p(File.dirname(@path), mode: 0o700)
+          File.chmod(0o700, File.dirname(@path))
+        end
+
+        private def with_lock(mode)
+          ensure_directory
+          lock_path = "#{@path}.lock"
+          File.open(lock_path, File::RDWR | File::CREAT, 0o600) do |lock|
+            lock.flock(mode)
+            yield
+          ensure
+            lock.flock(File::LOCK_UN) rescue nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/clacky/mcp/oauth/session.rb
+++ b/lib/clacky/mcp/oauth/session.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "monitor"
+
+module Clacky
+  module Mcp
+    module OAuth
+      class Session
+        EXPIRY_SKEW = 60
+
+        class Error < StandardError; end
+        class NotConnectedError < Error; end
+
+        def initialize(store:, manager:, clock: nil)
+          @store = store
+          @manager = manager
+          @clock = clock || -> { Time.now.to_i }
+          @force_refresh = false
+          @lock = Monitor.new
+        end
+
+        def authorization_headers
+          @lock.synchronize do
+            grant = @store.load
+            raise NotConnectedError, "OAuth MCP is not connected; run `clacky mcp login SERVER`" unless grant
+
+            if @force_refresh || expiring?(grant)
+              grant = @manager.refresh(grant)
+              @store.save(grant)
+              @force_refresh = false
+            end
+            token = grant["access_token"].to_s
+            raise Error, "stored OAuth grant has no access token; log in again" if token.empty?
+            { "Authorization" => "Bearer #{token}" }
+          end
+        rescue NotConnectedError, Error
+          raise
+        rescue StandardError => e
+          raise Error, "OAuth session failed (#{e.class}); log in again"
+        end
+
+        def invalidate!
+          @lock.synchronize { @force_refresh = true }
+        end
+
+        def login
+          @lock.synchronize do
+            grant = @manager.login
+            @force_refresh = false
+            grant
+          end
+        end
+
+        def logout
+          @lock.synchronize do
+            @store.delete
+            @force_refresh = false
+          end
+          true
+        end
+
+        def connected?
+          !@store.load.nil?
+        rescue StandardError
+          false
+        end
+
+        def status
+          grant = @store.load
+          return { "connected" => false } unless grant
+          {
+            "connected" => true,
+            "expires_at" => grant["expires_at"],
+            "expired" => grant.fetch("expires_at", 0).to_i <= @clock.call
+          }
+        end
+
+        def inspect
+          "#<#{self.class} connected=#{connected?}>"
+        end
+
+        private def expiring?(grant)
+          grant.fetch("expires_at", 0).to_i <= @clock.call + EXPIRY_SKEW
+        end
+      end
+    end
+  end
+end

--- a/spec/clacky/mcp/cli_commands_spec.rb
+++ b/spec/clacky/mcp/cli_commands_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "clacky/mcp/cli_commands"
+
+RSpec.describe Clacky::Mcp::CliCommands do
+  let(:manager) do
+    instance_double(
+      Clacky::Mcp::ConnectionManager,
+      login: { "connected" => true, "server" => "chatcut" },
+      status: { "connected" => true, "expired" => false, "server" => "chatcut" },
+      logout: { "connected" => false, "server" => "chatcut" }
+    )
+  end
+
+  before do
+    allow(Clacky::Mcp::ConnectionManager).to receive(:new).and_return(manager)
+  end
+
+  it "reports remote OAuth capability as JSON" do
+    expect do
+      described_class.start(%w[capabilities --json])
+    end.to output(/"remote_oauth":true/).to_stdout
+  end
+
+  it "logs in a configured server without printing tokens" do
+    expect do
+      described_class.start(%w[login chatcut --json])
+    end.to output { |text|
+      expect(JSON.parse(text)).to include("connected" => true, "server" => "chatcut")
+      expect(text).not_to include("access_token", "refresh_token")
+    }.to_stdout
+    expect(manager).to have_received(:login)
+  end
+
+  it "reports connection status without printing tokens" do
+    expect do
+      described_class.start(%w[status chatcut --json])
+    end.to output { |text|
+      expect(JSON.parse(text)).to include("connected" => true, "expired" => false)
+      expect(text).not_to include("token")
+    }.to_stdout
+  end
+
+  it "logs out a configured server" do
+    expect do
+      described_class.start(%w[logout chatcut --json])
+    end.to output(/"connected":false/).to_stdout
+    expect(manager).to have_received(:logout)
+  end
+end

--- a/spec/clacky/mcp/client_oauth_spec.rb
+++ b/spec/clacky/mcp/client_oauth_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/mcp/client"
+require "clacky/mcp/oauth/session"
+
+RSpec.describe Clacky::Mcp::Client do
+  it "builds an OAuth session for an authenticated HTTP server" do
+    client = described_class.from_spec("remote", {
+      "type" => "http",
+      "url" => "https://example.com/mcp",
+      "auth" => { "type" => "oauth" }
+    })
+
+    transport = client.instance_variable_get(:@transport)
+    expect(transport.instance_variable_get(:@authorization)).to be_a(Clacky::Mcp::OAuth::Session)
+  end
+
+  it "keeps static-header HTTP servers unauthenticated" do
+    client = described_class.from_spec("remote", {
+      "type" => "http",
+      "url" => "https://example.com/mcp",
+      "headers" => { "Authorization" => "Bearer static" }
+    })
+
+    transport = client.instance_variable_get(:@transport)
+    expect(transport.instance_variable_get(:@authorization)).to be_nil
+  end
+end

--- a/spec/clacky/mcp/connection_manager_spec.rb
+++ b/spec/clacky/mcp/connection_manager_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "clacky/mcp/connection_manager"
+
+RSpec.describe Clacky::Mcp::ConnectionManager do
+  let(:home) { Dir.mktmpdir }
+  let(:session) { instance_double(Clacky::Mcp::OAuth::Session) }
+
+  after { FileUtils.rm_rf(home) }
+
+  def write_config(spec)
+    directory = File.join(home, ".clacky")
+    FileUtils.mkdir_p(directory)
+    File.write(File.join(directory, "mcp.json"), JSON.generate("mcpServers" => { "remote" => spec }))
+  end
+
+  it "logs in an OAuth server and returns only safe status" do
+    write_config("url" => "https://example.com/mcp", "auth" => { "type" => "oauth" })
+    allow(session).to receive(:login).and_return("access_token" => "do-not-leak")
+    allow(session).to receive(:status).and_return("connected" => true, "expires_at" => 1_900_000_000)
+    manager = described_class.new(server_name: "remote", home: home, session_factory: ->(*_args) { session })
+
+    result = manager.login
+
+    expect(result).to include("server" => "remote", "connected" => true)
+    expect(JSON.generate(result)).not_to include("do-not-leak")
+  end
+
+  it "rejects an unknown server" do
+    manager = described_class.new(server_name: "missing", home: home)
+
+    expect { manager.status }.to raise_error(described_class::Error, /not configured/)
+  end
+
+  it "rejects a server without OAuth configuration" do
+    write_config("url" => "https://example.com/mcp")
+    manager = described_class.new(server_name: "remote", home: home)
+
+    expect { manager.login }.to raise_error(described_class::Error, /not configured for OAuth/)
+  end
+
+  it "logs out through the session" do
+    write_config("url" => "https://example.com/mcp", "auth" => { "type" => "oauth" })
+    allow(session).to receive(:logout).and_return(true)
+    manager = described_class.new(server_name: "remote", home: home, session_factory: ->(*_args) { session })
+
+    expect(manager.logout).to eq("server" => "remote", "connected" => false)
+  end
+end

--- a/spec/clacky/mcp/connection_manager_spec.rb
+++ b/spec/clacky/mcp/connection_manager_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe Clacky::Mcp::ConnectionManager do
     expect { manager.login }.to raise_error(described_class::Error, /not configured for OAuth/)
   end
 
+  it "does not include malformed configuration contents in errors" do
+    directory = File.join(home, ".clacky")
+    FileUtils.mkdir_p(directory)
+    File.write(File.join(directory, "mcp.json"), '{"token":"do-not-leak"')
+    manager = described_class.new(server_name: "remote", home: home)
+
+    expect { manager.status }.to raise_error(described_class::Error) do |error|
+      expect(error.message).not_to include("do-not-leak")
+    end
+  end
+
   it "logs out through the session" do
     write_config("url" => "https://example.com/mcp", "auth" => { "type" => "oauth" })
     allow(session).to receive(:logout).and_return(true)

--- a/spec/clacky/mcp/http_transport_spec.rb
+++ b/spec/clacky/mcp/http_transport_spec.rb
@@ -91,4 +91,93 @@ RSpec.describe Clacky::Mcp::HttpTransport do
       end
     end
   end
+
+  describe "OAuth authorization" do
+    class FakeAuthorization
+      attr_reader :invalidations
+
+      def initialize
+        @invalidations = 0
+      end
+
+      def authorization_headers
+        { "Authorization" => "Bearer protected-token" }
+      end
+
+      def invalidate!
+        @invalidations += 1
+      end
+    end
+
+    def response(status, body: "", headers: {})
+      instance_double("Net::HTTPResponse").tap do |res|
+        allow(res).to receive(:code).and_return(status.to_s)
+        allow(res).to receive(:[]).with(anything) do |key|
+          headers[key.to_s.downcase] || headers[key.to_s]
+        end
+        allow(res).to receive(:read_body).and_return(body)
+      end
+    end
+
+    it "injects OAuth headers without mutating static headers" do
+      authorization = FakeAuthorization.new
+      requests = []
+      requester = lambda do |request, &block|
+        requests << request
+        block.call(response(202))
+      end
+      transport = described_class.new(
+        name: "oauth",
+        url: "https://example.com/mcp",
+        headers: { "X-Static" => "yes" },
+        authorization: authorization,
+        requester: requester
+      )
+
+      transport.send(:dispatch_post, '{"id":1}', is_request: true)
+
+      expect(requests.first["Authorization"]).to eq("Bearer protected-token")
+      expect(requests.first["X-Static"]).to eq("yes")
+    end
+
+    it "invalidates and retries exactly once after a 401" do
+      authorization = FakeAuthorization.new
+      attempts = 0
+      requester = lambda do |_request, &block|
+        attempts += 1
+        block.call(response(attempts == 1 ? 401 : 202))
+      end
+      transport = described_class.new(
+        name: "oauth", url: "https://example.com/mcp",
+        authorization: authorization, requester: requester
+      )
+
+      transport.send(:dispatch_post, '{"id":1}', is_request: true)
+
+      expect(attempts).to eq(2)
+      expect(authorization.invalidations).to eq(1)
+    end
+
+    it "does not retry a second 401 or expose its response body" do
+      authorization = FakeAuthorization.new
+      attempts = 0
+      requester = lambda do |_request, &block|
+        attempts += 1
+        block.call(response(401, body: "protected-token"))
+      end
+      transport = described_class.new(
+        name: "oauth", url: "https://example.com/mcp",
+        authorization: authorization, requester: requester
+      )
+
+      expect do
+        transport.send(:dispatch_post, '{"id":1}', is_request: true)
+      end.to raise_error(Clacky::Mcp::Transport::TransportError) { |error|
+        expect(error.message).to include("HTTP 401")
+        expect(error.message).not_to include("protected-token")
+      }
+      expect(attempts).to eq(2)
+      expect(authorization.invalidations).to eq(1)
+    end
+  end
 end

--- a/spec/clacky/mcp/http_transport_spec.rb
+++ b/spec/clacky/mcp/http_transport_spec.rb
@@ -179,5 +179,24 @@ RSpec.describe Clacky::Mcp::HttpTransport do
       expect(attempts).to eq(2)
       expect(authorization.invalidations).to eq(1)
     end
+
+    it "preserves a capped response body for non-401 errors" do
+      diagnostic = "validation failed: #{'x' * 600}"
+      requester = lambda do |_request, &block|
+        block.call(response(422, body: diagnostic))
+      end
+      transport = described_class.new(
+        name: "oauth", url: "https://example.com/mcp",
+        authorization: FakeAuthorization.new, requester: requester
+      )
+
+      expect do
+        transport.send(:dispatch_post, '{"id":1}', is_request: true)
+      end.to raise_error(Clacky::Mcp::Transport::TransportError) { |error|
+        expect(error.message).to include("HTTP 422")
+        expect(error.message).to include(diagnostic[0, 500])
+        expect(error.message).not_to include(diagnostic[0, 501])
+      }
+    end
   end
 end

--- a/spec/clacky/mcp/oauth/authorization_manager_spec.rb
+++ b/spec/clacky/mcp/oauth/authorization_manager_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe Clacky::Mcp::OAuth::AuthorizationManager do
       .to raise_error(described_class::Error, /does not match/)
   end
 
+  it "rejects authorization metadata with a mismatched issuer" do
+    requester = lambda do |method, url, headers, body|
+      response = scripted_requester.call(method, url, headers, body)
+      if url.end_with?("/.well-known/oauth-authorization-server")
+        metadata = JSON.parse(response.body).merge("issuer" => "https://other.example.test")
+        Response.new(200, {}, JSON.generate(metadata))
+      else
+        response
+      end
+    end
+
+    expect { build_manager(requester: requester).login }
+      .to raise_error(described_class::Error, /issuer.*match/i)
+  end
+
   it "refreshes and rotates a refresh token" do
     manager = build_manager
     grant = {

--- a/spec/clacky/mcp/oauth/authorization_manager_spec.rb
+++ b/spec/clacky/mcp/oauth/authorization_manager_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "clacky/mcp/oauth/config"
+require "clacky/mcp/oauth/credential_store"
+require "clacky/mcp/oauth/authorization_manager"
+
+RSpec.describe Clacky::Mcp::OAuth::AuthorizationManager do
+  Response = Struct.new(:status, :headers, :body)
+
+  let(:home) { Dir.mktmpdir }
+  let(:store) { Clacky::Mcp::OAuth::CredentialStore.new(server_name: "example", home: home) }
+  let(:config) do
+    Clacky::Mcp::OAuth::Config.from_server_spec(
+      "url" => "https://mcp.example.test/service",
+      "auth" => { "type" => "oauth" }
+    )
+  end
+  let(:now) { 1_800_000_000 }
+  let(:requests) { [] }
+
+  after { FileUtils.rm_rf(home) }
+
+  it "performs metadata discovery, DCR, PKCE, and code exchange" do
+    callback = lambda do |url, state|
+      expect(url).to include("code_challenge_method=S256")
+      expect(url).to include("client_id=client-123")
+      { "code" => "code-456", "state" => state }
+    end
+    manager = build_manager(callback: callback)
+
+    grant = manager.login
+
+    expect(grant.fetch("access_token")).to eq("access-789")
+    expect(grant.fetch("refresh_token")).to eq("refresh-789")
+    expect(grant.fetch("expires_at")).to eq(now + 3600)
+    registration = requests.find { |request| request[1].end_with?("/register") }
+    expect(JSON.parse(registration[3])).to include(
+      "application_type" => "native",
+      "token_endpoint_auth_method" => "none"
+    )
+  end
+
+  it "rejects an OAuth callback with a mismatched state" do
+    manager = build_manager(callback: ->(_url, _state) { { "code" => "code", "state" => "wrong" } })
+
+    expect { manager.login }.to raise_error(described_class::Error, /state mismatch/)
+    expect(store.load).to be_nil
+  end
+
+  it "rejects metadata endpoints that are not HTTPS" do
+    requester = lambda do |method, url, headers, body|
+      if url.include?("oauth-protected-resource")
+        Response.new(200, {}, JSON.generate("authorization_servers" => ["http://auth.example.test"]))
+      else
+        scripted_requester.call(method, url, headers, body)
+      end
+    end
+
+    expect { build_manager(requester: requester).login }
+      .to raise_error(described_class::Error, /HTTPS/)
+  end
+
+  it "rejects resource metadata for a different resource" do
+    requester = lambda do |_method, url, _headers, _body|
+      if url.include?("oauth-protected-resource")
+        Response.new(200, {}, JSON.generate(
+          "resource" => "https://evil.example/mcp",
+          "authorization_servers" => ["https://auth.example.test"]
+        ))
+      else
+        Response.new(404, {}, "")
+      end
+    end
+
+    expect { build_manager(requester: requester).login }
+      .to raise_error(described_class::Error, /does not match/)
+  end
+
+  it "refreshes and rotates a refresh token" do
+    manager = build_manager
+    grant = {
+      "client_id" => "client-123",
+      "token_endpoint" => "https://auth.example.test/token",
+      "refresh_token" => "old-refresh"
+    }
+
+    refreshed = manager.refresh(grant)
+
+    expect(refreshed.fetch("access_token")).to eq("access-789")
+    expect(refreshed.fetch("refresh_token")).to eq("refresh-789")
+  end
+
+  it "does not include response bodies or token values in errors" do
+    requester = ->(*_args) { Response.new(400, {}, '{"access_token":"do-not-leak"}') }
+
+    expect { build_manager(requester: requester).login }
+      .to raise_error(described_class::Error) { |error| expect(error.message).not_to include("do-not-leak") }
+  end
+
+  def build_manager(requester: scripted_requester, callback: nil)
+    described_class.new(
+      server_name: "example",
+      config: config,
+      store: store,
+      requester: requester,
+      callback: callback || ->(_url, state) { { "code" => "code-456", "state" => state } },
+      clock: -> { now }
+    )
+  end
+
+  def scripted_requester
+    lambda do |method, url, headers, body|
+      requests << [method, url, headers, body]
+      case url
+      when "https://mcp.example.test/.well-known/oauth-protected-resource/service"
+        Response.new(200, {}, JSON.generate(
+          "resource" => "https://mcp.example.test/service",
+          "authorization_servers" => ["https://auth.example.test"]
+        ))
+      when "https://auth.example.test/.well-known/oauth-authorization-server"
+        Response.new(200, {}, JSON.generate(
+          "issuer" => "https://auth.example.test",
+          "authorization_endpoint" => "https://auth.example.test/authorize",
+          "token_endpoint" => "https://auth.example.test/token",
+          "registration_endpoint" => "https://auth.example.test/register",
+          "code_challenge_methods_supported" => ["S256"]
+        ))
+      when "https://auth.example.test/register"
+        Response.new(201, {}, JSON.generate("client_id" => "client-123"))
+      when "https://auth.example.test/token"
+        Response.new(200, {}, JSON.generate(
+          "access_token" => "access-789",
+          "refresh_token" => "refresh-789",
+          "expires_in" => 3600,
+          "token_type" => "Bearer"
+        ))
+      else
+        Response.new(404, {}, "")
+      end
+    end
+  end
+end

--- a/spec/clacky/mcp/oauth/config_spec.rb
+++ b/spec/clacky/mcp/oauth/config_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/mcp/oauth/config"
+
+RSpec.describe Clacky::Mcp::OAuth::Config do
+  it "is disabled when auth is absent" do
+    config = described_class.from_server_spec("url" => "https://example.com/mcp")
+
+    expect(config).not_to be_enabled
+    expect(config.resource).to eq("https://example.com/mcp")
+  end
+
+  it "defaults an OAuth resource to the MCP URL" do
+    config = described_class.from_server_spec(
+      "url" => "https://example.com/mcp",
+      "auth" => { "type" => "oauth" }
+    )
+
+    expect(config).to be_enabled
+    expect(config.resource).to eq("https://example.com/mcp")
+  end
+
+  it "accepts an explicit HTTPS resource" do
+    config = described_class.from_server_spec(
+      "url" => "https://gateway.example.com/mcp",
+      "auth" => { "type" => "oauth", "resource" => "https://resource.example.com/mcp" }
+    )
+
+    expect(config.resource).to eq("https://resource.example.com/mcp")
+  end
+
+  it "rejects OAuth for an insecure remote resource" do
+    expect do
+      described_class.from_server_spec(
+        "url" => "http://example.com/mcp",
+        "auth" => { "type" => "oauth" }
+      )
+    end.to raise_error(Clacky::Mcp::OAuth::Config::Error, /HTTPS/)
+  end
+
+  it "rejects unknown authentication types" do
+    expect do
+      described_class.from_server_spec(
+        "url" => "https://example.com/mcp",
+        "auth" => { "type" => "magic" }
+      )
+    end.to raise_error(Clacky::Mcp::OAuth::Config::Error, /unsupported/)
+  end
+end

--- a/spec/clacky/mcp/oauth/config_spec.rb
+++ b/spec/clacky/mcp/oauth/config_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe Clacky::Mcp::OAuth::Config do
     end.to raise_error(Clacky::Mcp::OAuth::Config::Error, /HTTPS/)
   end
 
+  it "rejects an insecure MCP endpoint even when the resource is HTTPS" do
+    expect do
+      described_class.from_server_spec(
+        "url" => "http://example.com/mcp",
+        "auth" => { "type" => "oauth", "resource" => "https://example.com/mcp" }
+      )
+    end.to raise_error(Clacky::Mcp::OAuth::Config::Error, /endpoint.*HTTPS/i)
+  end
+
   it "rejects unknown authentication types" do
     expect do
       described_class.from_server_spec(

--- a/spec/clacky/mcp/oauth/credential_store_spec.rb
+++ b/spec/clacky/mcp/oauth/credential_store_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Clacky::Mcp::OAuth::CredentialStore do
 
     expect(store.load.fetch("access_token")).to eq("access")
     expect(File.stat(store.path).mode & 0o777).to eq(0o600)
-    expect(store.path).to include("mcp/oauth/chat_cut.json")
+    expect(store.path).to match(%r{mcp/oauth/chat_cut-[0-9a-f]{12}\.json\z})
   end
 
   it "atomically replaces credentials without temporary files" do
@@ -51,5 +51,11 @@ RSpec.describe Clacky::Mcp::OAuth::CredentialStore do
     store.save("access_token" => "do-not-leak")
 
     expect(store.inspect).not_to include("do-not-leak")
+  end
+
+  it "does not collide when different server names sanitize the same way" do
+    other = described_class.new(server_name: "chat?cut", home: home)
+
+    expect(other.path).not_to eq(store.path)
   end
 end

--- a/spec/clacky/mcp/oauth/credential_store_spec.rb
+++ b/spec/clacky/mcp/oauth/credential_store_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "clacky/mcp/oauth/credential_store"
+
+RSpec.describe Clacky::Mcp::OAuth::CredentialStore do
+  let(:home) { Dir.mktmpdir }
+  subject(:store) { described_class.new(server_name: "chat/cut", home: home) }
+
+  after { FileUtils.rm_rf(home) }
+
+  it "stores credentials outside mcp.json with mode 0600" do
+    store.save("access_token" => "access", "refresh_token" => "refresh")
+
+    expect(store.load.fetch("access_token")).to eq("access")
+    expect(File.stat(store.path).mode & 0o777).to eq(0o600)
+    expect(store.path).to include("mcp/oauth/chat_cut.json")
+  end
+
+  it "atomically replaces credentials without temporary files" do
+    store.save("access_token" => "old")
+    store.save("access_token" => "new")
+
+    expect(store.load.fetch("access_token")).to eq("new")
+    expect(Dir.glob("#{store.path}.tmp-*")).to be_empty
+  end
+
+  it "deletes a grant" do
+    store.save("access_token" => "access")
+
+    store.delete
+
+    expect(store.load).to be_nil
+  end
+
+  it "reports malformed credentials without their contents" do
+    FileUtils.mkdir_p(File.dirname(store.path))
+    File.write(store.path, '{"access_token":"do-not-leak"')
+
+    expect { store.load }.to raise_error(described_class::Error, /invalid OAuth credential file/)
+    begin
+      store.load
+    rescue described_class::Error => e
+      expect(e.message).not_to include("do-not-leak")
+    end
+  end
+
+  it "does not expose credentials from inspect" do
+    store.save("access_token" => "do-not-leak")
+
+    expect(store.inspect).not_to include("do-not-leak")
+  end
+end

--- a/spec/clacky/mcp/oauth/session_spec.rb
+++ b/spec/clacky/mcp/oauth/session_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/mcp/oauth/session"
+
+RSpec.describe Clacky::Mcp::OAuth::Session do
+  class MemoryStore
+    attr_reader :saved
+
+    def initialize(value = nil)
+      @value = value
+    end
+
+    def load
+      @value && @value.dup
+    end
+
+    def save(value)
+      @saved = value.dup
+      @value = value.dup
+    end
+
+    def delete
+      @value = nil
+    end
+  end
+
+  class FakeManager
+    attr_reader :refreshes, :logins
+
+    def initialize(store, now)
+      @store = store
+      @now = now
+      @refreshes = 0
+      @logins = 0
+    end
+
+    def login
+      @logins += 1
+      @store.save("access_token" => "logged-in", "refresh_token" => "refresh", "expires_at" => @now + 3600)
+    end
+
+    def refresh(grant)
+      @refreshes += 1
+      grant.merge("access_token" => "fresh", "refresh_token" => "rotated", "expires_at" => @now + 3600)
+    end
+  end
+
+  let(:now) { 1_800_000_000 }
+
+  it "reuses a valid access token" do
+    store = MemoryStore.new("access_token" => "valid", "expires_at" => now + 3600)
+    manager = FakeManager.new(store, now)
+
+    headers = described_class.new(store: store, manager: manager, clock: -> { now }).authorization_headers
+
+    expect(headers).to eq("Authorization" => "Bearer valid")
+    expect(manager.refreshes).to eq(0)
+  end
+
+  it "refreshes within the expiry skew and persists rotation" do
+    store = MemoryStore.new("access_token" => "old", "refresh_token" => "refresh", "expires_at" => now + 30)
+    manager = FakeManager.new(store, now)
+    session = described_class.new(store: store, manager: manager, clock: -> { now })
+
+    expect(session.authorization_headers).to eq("Authorization" => "Bearer fresh")
+    expect(store.saved.fetch("refresh_token")).to eq("rotated")
+    expect(manager.refreshes).to eq(1)
+  end
+
+  it "forces one refresh after transport invalidation" do
+    store = MemoryStore.new("access_token" => "valid", "refresh_token" => "refresh", "expires_at" => now + 3600)
+    manager = FakeManager.new(store, now)
+    session = described_class.new(store: store, manager: manager, clock: -> { now })
+
+    session.invalidate!
+
+    expect(session.authorization_headers.fetch("Authorization")).to eq("Bearer fresh")
+    expect(manager.refreshes).to eq(1)
+  end
+
+  it "requires explicit login when no grant exists" do
+    store = MemoryStore.new
+    manager = FakeManager.new(store, now)
+
+    expect do
+      described_class.new(store: store, manager: manager, clock: -> { now }).authorization_headers
+    end.to raise_error(described_class::NotConnectedError, /mcp login/)
+  end
+
+  it "delegates login and logout" do
+    store = MemoryStore.new
+    manager = FakeManager.new(store, now)
+    session = described_class.new(store: store, manager: manager, clock: -> { now })
+
+    session.login
+    expect(session).to be_connected
+    session.logout
+    expect(session).not_to be_connected
+  end
+
+  it "does not expose tokens from inspect" do
+    store = MemoryStore.new("access_token" => "do-not-leak", "expires_at" => now + 3600)
+    session = described_class.new(store: store, manager: FakeManager.new(store, now), clock: -> { now })
+
+    expect(session.inspect).not_to include("do-not-leak")
+  end
+end


### PR DESCRIPTION
## Summary

- add generic OAuth 2.1-style authorization for remote Streamable HTTP MCP servers, including protected-resource discovery, authorization-server discovery, dynamic client registration, PKCE S256, refresh tokens, and loopback callbacks
- store grants outside `mcp.json` with owner-only permissions, atomic writes, serialized access, and collision-safe server paths
- add `clacky mcp capabilities|login|status|logout` lifecycle commands so extensions can detect and use native OAuth
- inject bearer authorization into the existing HTTP transport and retry exactly once after a 401
- document remote OAuth configuration and security behavior

## Security

- OAuth MCP endpoints, resources, and metadata endpoints must use HTTPS
- authorization metadata issuer must match the advertised authorization server
- callback state is validated and PKCE S256 is mandatory
- token response bodies and stored token values are excluded from diagnostics
- credentials are stored under `~/.clacky/mcp/oauth/` with mode 0600

## Verification

- `BUNDLE_LOCKFILE=Gemfile.lock.ruby-3.3 mise exec ruby@3.4.9 -- bundle exec rspec` — 3101 examples, 0 failures (before conflict-free rebase)
- focused post-rebase MCP/CLI suite — 56 examples, 0 failures
- RubyGem build succeeded and contains all new MCP OAuth files
- live interoperability check against ChatCut: OAuth completed and both native HTTP transport and a compatibility stdio bridge discovered 53 tools
