### PR TITLE
Improve chat navigator with smooth zoom-ring interaction

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2915,45 +2915,91 @@ body {
 .chat-navigator {
   position: absolute;
   right: 0;
-  width: 1.5rem;
+  width: 3rem;
   z-index: 10;
   pointer-events: none;
   display: flex;
   flex-direction: column;
 }
 .chat-nav-track {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 0.25rem;
-  padding: 0.625rem 0.375rem;
-  pointer-events: none;
+  align-items: flex-end;
+  gap: 0.3125rem;
+  padding: 0.75rem 0.3125rem;
+  pointer-events: auto;
+  touch-action: pan-y;
   overflow: hidden;
 }
 .chat-nav-bar {
+  position: relative;
+  z-index: 1;
   height: 0.1875rem;
+  width: 0.875rem;
   flex-shrink: 0;
-  border-radius: 0.125rem;
-  background: var(--color-border-secondary);
+  border-radius: 999px;
+  background: var(--color-border-primary);
   cursor: pointer;
   pointer-events: auto;
-  opacity: 0.45;
-  transition: opacity 0.15s ease, background 0.15s ease, transform 0.12s ease;
+  opacity: var(--chat-nav-opacity, 0.52);
+  transform-origin: right center;
+  transform:
+    scaleX(var(--chat-nav-scale-x, 1))
+    scaleY(var(--chat-nav-scale-y, 1));
+  transition:
+    opacity 0.16s ease,
+    background 0.16s ease,
+    transform 0.18s cubic-bezier(0.22, 0.61, 0.36, 1);
+  will-change: transform, opacity;
+}
+.chat-nav-bar::before {
+  content: "";
+  position: absolute;
+  inset: -0.1875rem -0.25rem;
 }
 .chat-nav-bar:hover {
-  opacity: 0.85;
-  background: var(--color-text-muted);
-  transform: scaleX(1.6);
+  opacity: 0.88;
+  background: var(--color-text-secondary);
 }
 .chat-nav-bar.hovered {
-  opacity: 0.85;
-  background: var(--color-text-muted);
-  transform: scaleX(1.6);
+  opacity: 0.88;
+  background: var(--color-text-secondary);
 }
 .chat-nav-bar.active {
-  opacity: 1;
+  opacity: 0.82;
+  background: color-mix(in srgb, var(--color-accent-primary) 32%, var(--color-border-primary));
+}
+.chat-nav-indicator {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  right: 0.3125rem;
+  width: 0.875rem;
+  height: 0.1875rem;
+  border-radius: 999px;
   background: var(--color-accent-primary);
+  box-shadow: 0 0 0.25rem color-mix(in srgb, var(--color-accent-primary) 24%, transparent);
+  opacity: 0;
+  scale: var(--chat-nav-indicator-scale, 1) 1;
+  transform-origin: right center;
+  pointer-events: none;
+  will-change: transform, scale;
+  transition:
+    opacity 0.16s ease,
+    scale 0.18s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.chat-nav-indicator.is-visible {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-nav-bar,
+  .chat-nav-indicator {
+    transition: none;
+  }
 }
 
 /* ── Hover popup ─────────────────────────────────────────────────────────── */
@@ -14597,4 +14643,3 @@ body.setup-mode[data-theme="dark"] {
 .project-picker-done-btn:hover {
   background: var(--color-bg-hover);
 }
-

--- a/lib/clacky/web/components/chat-navigator.js
+++ b/lib/clacky/web/components/chat-navigator.js
@@ -16,16 +16,20 @@
   const $ = (id) => document.getElementById(id);
 
   const NAV_SELECTOR = ".msg-user-wrap";
+  const MAGNIFY_RADIUS = 64;
+  const MAX_MAGNIFY    = 1.35;
 
-  let nav, track, popup, popupList;
+  let nav, track, indicator, popup, popupList;
   let messages, chatMain;
   let items = [];          // [{ el, bar, popupItem, type, preview }]
   let activeIdx = -1;
   let mo, ro;
   let rebuildTimer = null;
-  let scrollTimer = null;
+  let scrollFrame = null;
+  let showTimer = null;
   let hideTimer = null;
   let hoveredIdx = -1;
+  let indicatorOffsetTop = 0;
 
   // ── Preview text extraction ────────────────────────────────────────────
 
@@ -59,6 +63,8 @@
 
   function _rebuild() {
     if (!messages || !track) return;
+    clearTimeout(showTimer);
+    _resetMagnification();
     const els = Array.from(messages.querySelectorAll(NAV_SELECTOR));
     items = els.map((el) => ({
       el,
@@ -70,8 +76,11 @@
     nav.style.display = scrollable && items.length > 1 ? "" : "none";
     if (!scrollable || items.length <= 1) return;
 
-    // Build bars
-    track.innerHTML = "";
+    // Build bars. The floating indicator moves between these fixed message
+    // landmarks as the chat scrolls, so progress reads continuously instead
+    // of jumping from one active bar to the next.
+    track.innerHTML = '<div class="chat-nav-indicator" aria-hidden="true"></div>';
+    indicator = track.querySelector(".chat-nav-indicator");
     items.forEach((item, i) => {
       const bar = document.createElement("div");
       bar.className = "chat-nav-bar";
@@ -106,46 +115,134 @@
   function _updateActive() {
     if (!items.length) return;
     const threshold = messages.getBoundingClientRect().top + 30;
-    let idx = 0;
+    let idx = Math.max(0, Math.min(activeIdx, items.length - 1));
+
+    const itemTop = (i) => items[i].el.getBoundingClientRect().top;
     for (let i = 0; i < items.length; i++) {
-      if (!items[i].el || !items[i].el.isConnected) {
+      if (!items[i].el || !items[i].el.isConnected || !items[i].bar) {
         _scheduleRebuild();
         return;
       }
-      const top = items[i].el.getBoundingClientRect().top;
-      if (top <= threshold) idx = i;
-      else break;
     }
+
+    // Start at the previous index and only walk as far as this frame moved.
+    // This keeps scroll tracking cheap while still handling large scrollbar
+    // jumps in either direction.
+    while (idx + 1 < items.length && itemTop(idx + 1) <= threshold) idx++;
+    while (idx > 0 && itemTop(idx) > threshold) idx--;
+
     if (idx !== activeIdx) {
       activeIdx = idx;
       items.forEach((item, i) => {
         item.bar.classList.toggle("active", i === idx);
       });
     }
+
+    // Interpolate between the current and next message landmarks. The active
+    // class remains useful for context, while the indicator provides the
+    // smooth, exact motion users expect from a progress control.
+    if (indicator && items[idx].bar) {
+      const currentTop = itemTop(idx);
+      let indicatorTop = items[idx].bar.offsetTop;
+      if (idx + 1 < items.length && items[idx + 1].bar) {
+        const nextTop = itemTop(idx + 1);
+        const distance = nextTop - currentTop;
+        const fraction = distance > 0
+          ? Math.max(0, Math.min(1, (threshold - currentTop) / distance))
+          : 0;
+        const currentBarTop = items[idx].bar.offsetTop;
+        const nextBarTop = items[idx + 1].bar.offsetTop;
+        indicatorTop = currentBarTop + (nextBarTop - currentBarTop) * fraction;
+      }
+      indicatorOffsetTop = indicatorTop;
+      indicator.style.transform = `translate3d(0, ${indicatorTop}px, 0)`;
+      indicator.classList.add("is-visible");
+    }
   }
 
   function _onScroll() {
-    clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(_updateActive, 80);
+    if (scrollFrame !== null) return;
+    scrollFrame = requestAnimationFrame(() => {
+      scrollFrame = null;
+      _updateActive();
+    });
   }
 
   // ── Popup interaction ───────────────────────────────────────────────────
 
+  // Return horizontal stretch on a cosine arc: longest at the pointer, then
+  // progressively shorter with a soft tangent at both edges. This creates the
+  // lens/zoom-ring silhouette without a visible step where magnification ends.
+  function _magnificationAt(distance) {
+    const normalized = Math.min(Math.abs(distance) / MAGNIFY_RADIUS, 1);
+    const influence = (Math.cos(normalized * Math.PI) + 1) / 2;
+    return 1 + MAX_MAGNIFY * influence;
+  }
+
+  function _applyMagnification(clientY) {
+    if (!track || !items.length) return;
+    const trackRect = track.getBoundingClientRect();
+    track.classList.add("is-magnified");
+
+    items.forEach((item) => {
+      if (!item.bar) return;
+      const center = trackRect.top + item.bar.offsetTop + item.bar.offsetHeight / 2;
+      const scaleX = _magnificationAt(clientY - center);
+      const influence = (scaleX - 1) / MAX_MAGNIFY;
+      item.bar.style.setProperty("--chat-nav-scale-x", scaleX.toFixed(3));
+      item.bar.style.setProperty("--chat-nav-scale-y", (1 + influence * 0.12).toFixed(3));
+      item.bar.style.setProperty("--chat-nav-opacity", (0.52 + influence * 0.22).toFixed(3));
+    });
+
+    if (indicator) {
+      const center = trackRect.top + indicatorOffsetTop + indicator.offsetHeight / 2;
+      indicator.style.setProperty(
+        "--chat-nav-indicator-scale",
+        _magnificationAt(clientY - center).toFixed(3)
+      );
+    }
+  }
+
+  function _magnifyAroundIndex(idx) {
+    const bar = items[idx] && items[idx].bar;
+    if (!bar || !track) return;
+    const trackRect = track.getBoundingClientRect();
+    _applyMagnification(trackRect.top + bar.offsetTop + bar.offsetHeight / 2);
+  }
+
+  function _resetMagnification() {
+    if (track) track.classList.remove("is-magnified");
+    items.forEach((item) => {
+      if (!item.bar) return;
+      item.bar.style.removeProperty("--chat-nav-scale-x");
+      item.bar.style.removeProperty("--chat-nav-scale-y");
+      item.bar.style.removeProperty("--chat-nav-opacity");
+    });
+    if (indicator) indicator.style.removeProperty("--chat-nav-indicator-scale");
+  }
+
   function _onBarHover(idx) {
     clearTimeout(hideTimer);
-    _showPopup(idx);
+    clearTimeout(showTimer);
+    _magnifyAroundIndex(idx);
+    if (popup && popup.style.display !== "none") {
+      _showPopup(idx);
+    } else {
+      showTimer = setTimeout(() => _showPopup(idx), 260);
+    }
   }
 
   function _onItemHover(idx) {
     clearTimeout(hideTimer);
     hoveredIdx = idx;
+    _magnifyAroundIndex(idx);
     items.forEach((item, i) => {
       item.bar.classList.toggle("hovered", i === idx);
     });
   }
 
   function _showPopup(idx) {
-    if (!popup || !items.length) return;
+    if (!popup || !items[idx] || !items[idx].bar) return;
     hoveredIdx = idx;
     popup.style.display = "flex";
 
@@ -157,8 +254,8 @@
     // Position popup vertically centered on the hovered bar
     const bar = items[idx].bar;
     const navRect = nav.getBoundingClientRect();
-    const barRect = bar.getBoundingClientRect();
-    const barCenter = barRect.top + barRect.height / 2 - navRect.top;
+    const trackRect = track.getBoundingClientRect();
+    const barCenter = trackRect.top + bar.offsetTop + bar.offsetHeight / 2 - navRect.top;
     popup.style.top = "";
     popup.style.bottom = "";
     const popupHeight = popup.offsetHeight;
@@ -177,6 +274,7 @@
   }
 
   function _hidePopup() {
+    clearTimeout(showTimer);
     clearTimeout(hideTimer);
     hideTimer = setTimeout(() => {
       if (!popup) return;
@@ -197,7 +295,12 @@
     const msgRect = messages.getBoundingClientRect();
     const elRect = el.getBoundingClientRect();
     const offset = elRect.top - msgRect.top;
-    messages.scrollTop += offset - 12;
+    const reduceMotion = window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    messages.scrollTo({
+      top: messages.scrollTop + offset - 12,
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
     _hidePopup();
   }
 
@@ -229,7 +332,15 @@
 
     // Hover open / leave close
     nav.addEventListener("mouseenter", () => clearTimeout(hideTimer));
-    nav.addEventListener("mouseleave", _hidePopup);
+    nav.addEventListener("mouseleave", () => {
+      _resetMagnification();
+      _hidePopup();
+    });
+    track.addEventListener("pointermove", (event) => {
+      if (!event.pointerType || event.pointerType === "mouse" || event.pointerType === "pen") {
+        _applyMagnification(event.clientY);
+      }
+    });
 
     // Observe message children changes (add / remove / clear)
     mo = new MutationObserver(() => _scheduleRebuild());


### PR DESCRIPTION
## What changed

- update the active chat marker on animation frames instead of waiting for an 80 ms scroll debounce
- interpolate the progress indicator between message landmarks and use smooth scrolling for click-to-jump
- add a distance-based zoom-ring hover effect: the nearest tick grows longest and surrounding ticks form a soft cosine arc
- delay the message preview popup briefly so the magnification feedback appears first
- enlarge the invisible hover target while preserving vertical touch scrolling and reduced-motion behavior

## Why

The right-edge navigator felt delayed during continuous scrolling, click navigation jumped abruptly, and the small low-contrast markers were difficult to read. The new interaction stays restrained at rest but becomes clear and tactile on hover, similar to a mobile zoom dial.

## Validation

- `bundle _2.4.22_ exec rspec spec/clacky/web/syntax_spec.rb` — 19 examples, 0 failures
- `node --check lib/clacky/web/components/chat-navigator.js`
- `git diff --check`
- manual browser QA on a 20-marker, 9,018 px chat history: verified frame-by-frame indicator tracking, smooth click navigation, cosine magnification, delayed preview, reset-on-leave, and no console errors
