### PR TITLE
fix(client): raise undefined `Clacky::Error` causes NameError, masking upstream errors

### DIFF
--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -415,7 +415,7 @@ module Clacky
         if defined?(Clacky::Logger)
           Clacky::Logger.warn("[parse_simple_openai_response] no content. status=#{response.status} body=#{snippet}")
         end
-        raise Clacky::Error,
+        raise RetryableError,
           "Upstream OpenAI-compatible response missing choices[0].message.content. " \
           "Body snippet: #{snippet}"
       end


### PR DESCRIPTION
## Bug

`client.rb` line 418 raises `Clacky::Error`, but **`Clacky::Error` is never defined** anywhere in the codebase.

`lib/clacky.rb` (lines 169–203) defines these error classes:

```ruby
module Clacky
  class AgentInterrupted < Exception; end
  class AgentError < StandardError; end
  class BadRequestError < AgentError; end
  class InsufficientCreditError < AgentError; end
  class RetryableError < StandardError; end
  class UpstreamTruncatedError < RetryableError; end
  class ToolCallError < AgentError; end
  class BrowserNotReachableError < AgentError; end
end
```

There is **no `Clacky::Error` base class** — the other root error classes (`AgentError`, `RetryableError`) inherit directly from `StandardError`, bypassing any `Error` intermediate.

## Impact

When the upstream OpenAI-compatible API returns HTTP 200 but the response body is missing `choices[0].message.content`, `parse_simple_openai_response` hits this line and throws:

```
NameError: uninitialized constant Clacky::Error
```

This `NameError` **masks the real error** (malformed upstream response) and breaks the caller's error-handling path, since no `rescue` clause catches `NameError`.

## Fix

Replace `Clacky::Error` with `RetryableError`. Rationale:

1. **Semantic match** — an upstream response missing `content` is a transient anomaly that may succeed on retry.
2. **Consistency** — the rest of `client.rb` handles similar upstream malformations with `RetryableError` / `UpstreamTruncatedError` (e.g. lines 266, 325, 403).
3. **Enables retry** — `RetryableError` flows through the existing retry logic, whereas a raw `StandardError` would not.

This is a one-line change.

## Not a reserved placeholder

`Clacky::Error` is not a reserved/placeholder constant:
- It appears **exactly once** in the entire codebase (this line only).
- No `autoload`, no `clacky/error.rb`, no gemspec reference.
- No other class inherits from it.
- The line is on a live runtime error path, not a TODO/stub.