### PR TITLE
fix(arguments_parser): guard nil tool.parameters in format_tool_definition

### DIFF
--- a/lib/clacky/utils/arguments_parser.rb
+++ b/lib/clacky/utils/arguments_parser.rb
@@ -161,11 +161,14 @@ module Clacky
         lines << "  Name: #{tool.name}"
         lines << "  Description: #{tool.description}"
 
-        if tool.parameters[:properties]
+        params = tool.parameters
+        properties = params && params[:properties]
+        if properties
           lines << "  Parameters:"
-          tool.parameters[:properties].each do |param, spec|
-            required_mark = tool.parameters[:required]&.include?(param.to_s) ? " (required)" : ""
-            lines << "    - #{param}#{required_mark}: #{spec[:description]}"
+          properties.each do |param, spec|
+            required_mark = params[:required]&.include?(param.to_s) ? " (required)" : ""
+            desc = spec.is_a?(Hash) ? spec[:description] : spec.to_s
+            lines << "    - #{param}#{required_mark}: #{desc}"
           end
         end
 


### PR DESCRIPTION
## Inconsistency

`format_tool_definition` accesses `tool.parameters[:properties]` directly, while its sibling methods in the **same file** both use safe navigation:

```ruby
# validate_required_params (line 94–95) ✅ safe
required   = tool.parameters&.dig(:required) || []
properties = tool.parameters&.dig(:properties) || {}

# build_error_message (line 121) ✅ safe
required_params = tool.parameters&.dig(:required) || []

# format_tool_definition (line 164) ❌ no guard
if tool.parameters[:properties]
  tool.parameters[:properties].each do |param, spec|
    required_mark = tool.parameters[:required]&.include?(param.to_s)
    lines << "    - #{param}#{required_mark}: #{spec[:description]}"
  end
end
```

## Risk

`tool_parameters` is an `attr_accessor` on `Tools::Base` (defaults to `nil`). If a tool is ever registered without setting it, `format_tool_definition` raises `NoMethodError: undefined method '[]' for nil`.

This is especially harmful because `format_tool_definition` is called from `raise_helpful_error` (line 113) — **the error-handling path itself** — so the original error would be masked by a secondary crash.

Currently all 12 registered built-in tools set `tool_parameters`, so this is a defensive/consistency fix, not an active bug.

## Fix

Extract `tool.parameters` into a local variable and guard against nil, consistent with the rest of the file:

```ruby
params = tool.parameters
properties = params && params[:properties]
if properties
  lines << "  Parameters:"
  properties.each do |param, spec|
    required_mark = params[:required]&.include?(param.to_s) ? " (required)" : ""
    desc = spec.is_a?(Hash) ? spec[:description] : spec.to_s
    lines << "    - #{param}#{required_mark}: #{desc}"
  end
end
```

Also guards `spec[:description]` against non-Hash spec values (e.g. OpenAI-style JSON schema where a property value could be a string).