### PR TITLE
fix(persistence): harden session save against interruption (#445)

### DIFF
--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -7113,16 +7113,30 @@ module Clacky
         # never made it into session.json (history vanishes on replay).
         @registry.shutdown_all_idle_timers
 
+        # Phase 1: raise AgentInterrupted on every live agent thread.
+        live = []
         @registry.each_live_agent do |id, agent, thread|
           next unless thread&.alive?
+          live << [id, agent, thread]
           begin
             thread.raise(Clacky::AgentInterrupted, "Worker shutting down")
             Clacky::Logger.info("[shutdown] interrupted session=#{id}")
           rescue => e
             Clacky::Logger.error("[shutdown] interrupt failed for session=#{id}: #{e.message}")
           end
-          thread.join(AGENT_INTERRUPT_JOIN_SECONDS)
+        end
+
+        # Phase 2: join all threads in parallel so total wait is a single
+        # timeout, not N × timeout. Without this, many live agents turn
+        # shutdown into a multi-second stall that often exceeds the Master
+        # deadline and triggers a SIGKILL before saves can run.
+        live.map { |_, _, t| Thread.new { t.join(AGENT_INTERRUPT_JOIN_SECONDS) } }.each(&:join)
+
+        # Phase 3: serial save — to_session_data is not thread-safe.
+        live.each do |id, agent, _|
           @session_manager.save(agent.to_session_data(status: :interrupted, updated_at: Time.now))
+        rescue => e
+          Clacky::Logger.error("[shutdown] save failed for session=#{id}: #{e.message}")
         end
       end
 

--- a/lib/clacky/server/server_master.rb
+++ b/lib/clacky/server/server_master.rb
@@ -173,7 +173,7 @@ module Clacky
         # also get a chance to shut down cleanly (triggering interrupt_all_agents).
         begin
           Process.kill("TERM", -old_pid)
-          deadline = Time.now + 5
+          deadline = Time.now + 10
           loop do
             pid, = Process.waitpid2(old_pid, Process::WNOHANG)
             break if pid
@@ -199,8 +199,8 @@ module Clacky
             # TERM the entire worker process group so grandchildren (node MCP, etc.)
             # are also signalled and can clean up before we force-kill.
             Process.kill("TERM", -@worker_pid)
-            # Wait up to 2s for worker graceful exit, then KILL the whole group
-            deadline = Time.now + 3
+            # Wait up to 10s for worker graceful exit (interrupt_all_agents + save), then KILL
+            deadline = Time.now + 10
             loop do
               pid, = Process.waitpid2(@worker_pid, Process::WNOHANG)
               break if pid

--- a/lib/clacky/session_manager.rb
+++ b/lib/clacky/session_manager.rb
@@ -29,8 +29,12 @@ module Clacky
       filename = generate_filename(session_data[:session_id], session_data[:created_at])
       filepath = File.join(@sessions_dir, filename)
 
-      File.write(filepath, JSON.pretty_generate(session_data))
-      FileUtils.chmod(0o600, filepath)
+      # Atomic write: write to a temp file then rename, so a SIGKILL mid-write
+      # cannot leave a truncated / corrupt session.json on disk.
+      tmp = "#{filepath}.tmp"
+      File.write(tmp, JSON.pretty_generate(session_data))
+      FileUtils.chmod(0o600, tmp)
+      File.rename(tmp, filepath)
 
       @last_saved_path = filepath
 
@@ -160,8 +164,10 @@ module Clacky
       base = chunk_base_name(session_id, created_at)
       chunk_path = File.join(@sessions_dir, "#{base}-chunk-#{chunk_index}.md")
 
-      File.write(chunk_path, md_content)
-      FileUtils.chmod(0o600, chunk_path)
+      tmp = "#{chunk_path}.tmp"
+      File.write(tmp, md_content)
+      FileUtils.chmod(0o600, tmp)
+      File.rename(tmp, chunk_path)
 
       chunk_path
     end

--- a/spec/clacky/server/http_server_spec.rb
+++ b/spec/clacky/server/http_server_spec.rb
@@ -1196,12 +1196,13 @@ RSpec.describe Clacky::Server::HttpServer do
       stuck_thread.join
     end
 
-    it "waits serially — total wall time reflects N × per-thread timeout" do
+    it "waits in parallel — total wall time reflects a single timeout, not N × timeout" do
       server   = build_server
       registry = server.instance_variable_get(:@registry)
       sm       = server.instance_variable_get(:@session_manager)
 
-      # Three unresponsive threads, each burning the full join window.
+      # Three unresponsive threads. With parallel joins the total wait is a
+      # single AGENT_INTERRUPT_JOIN_SECONDS window, not 3 ×.
       stuck_threads = []
       3.times do |i|
         sid   = "stuck-#{i}"
@@ -1218,9 +1219,9 @@ RSpec.describe Clacky::Server::HttpServer do
       server.send(:interrupt_all_agents)
       elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
 
-      # Serial: 3 × 0.2s. Parallel would finish in ~0.2s, so >0.4s proves the
-      # waits stack up.
-      expect(elapsed).to be > 0.4
+      # Parallel: ~0.2s. Serial would be 3 × 0.2s = 0.6s, so <0.4s proves the
+      # joins overlap.
+      expect(elapsed).to be < 0.4
 
       stuck_threads.each(&:kill)
       stuck_threads.each(&:join)

--- a/spec/clacky/session_manager_atomic_write_spec.rb
+++ b/spec/clacky/session_manager_atomic_write_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "json"
+
+RSpec.describe Clacky::SessionManager, "#save (atomic write)" do
+  let(:temp_dir) { Dir.mktmpdir("clacky_sm_atomic_spec") }
+  let(:trash_dir) { File.join(temp_dir, "sessions-trash") }
+  subject(:manager) { described_class.new(sessions_dir: temp_dir) }
+
+  before do
+    allow(Clacky::TrashDirectory).to receive(:sessions_trash_dir).and_return(trash_dir)
+  end
+
+  after { FileUtils.rm_rf(temp_dir) if Dir.exist?(temp_dir) }
+
+  def session_data(id: "test-1")
+    {
+      session_id: id,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      messages: [{ role: "user", content: "hello" }]
+    }
+  end
+
+  it "writes a valid JSON file (no truncation)" do
+    path = manager.save(session_data)
+    parsed = JSON.parse(File.read(path), symbolize_names: true)
+    expect(parsed[:session_id]).to eq("test-1")
+    expect(parsed[:messages].first[:content]).to eq("hello")
+  end
+
+  it "does not leave a .tmp file behind" do
+    path = manager.save(session_data)
+    expect(File.exist?("#{path}.tmp")).to be(false)
+  end
+
+  it "produces a file with 0600 permissions" do
+    path = manager.save(session_data)
+    stat = File.stat(path)
+    expect(stat.mode & 0o777).to eq(0o600)
+  end
+
+  it "overwrites an existing file atomically (old content fully replaced)" do
+    manager.save(session_data(id: "test-1"))
+    path = manager.save(session_data(id: "test-1")) # second save
+
+    # File should exist and be valid — no corruption from the rename-overwrite.
+    parsed = JSON.parse(File.read(path), symbolize_names: true)
+    expect(parsed[:session_id]).to eq("test-1")
+  end
+end
+
+RSpec.describe Clacky::SessionManager, "#write_chunk (atomic write)" do
+  let(:temp_dir) { Dir.mktmpdir("clacky_sm_chunk_atomic_spec") }
+  let(:trash_dir) { File.join(temp_dir, "sessions-trash") }
+  subject(:manager) { described_class.new(sessions_dir: temp_dir) }
+
+  before do
+    allow(Clacky::TrashDirectory).to receive(:sessions_trash_dir).and_return(trash_dir)
+  end
+
+  after { FileUtils.rm_rf(temp_dir) if Dir.exist?(temp_dir) }
+
+  it "writes valid chunk content" do
+    path = manager.write_chunk("sess-1", "2026-01-01T00:00:00Z", 0, "# Chunk 0\nhello")
+    expect(File.read(path)).to eq("# Chunk 0\nhello")
+  end
+
+  it "does not leave a .tmp file behind" do
+    path = manager.write_chunk("sess-1", "2026-01-01T00:00:00Z", 0, "data")
+    expect(File.exist?("#{path}.tmp")).to be(false)
+  end
+end


### PR DESCRIPTION
## What

Fixes three independent root causes that lose session content on restart/shutdown — the **stop-gap fix** from the root-cause analysis in #445.

Authored using openclacky itself. 🐕

## Why

| Root cause | What happens | Impact |
|---|---|---|
| **Non-atomic file write** | `File.write` + `chmod` is not atomic — a SIGKILL between them (or mid-write) leaves a truncated / zero-byte `session.json` | Session is unrecoverable; all history lost |
| **Master deadline too short** | Shutdown grace was 2-3s, but `interrupt_all_agents` + `save` for N live agents can take longer → SIGKILL fires before saves complete | In-flight sessions not persisted |
| **Serial interrupt joins** | Each agent thread joined sequentially (N × timeout) | Total wait easily exceeds Master deadline |

## Changes

### `session_manager.rb` — atomic write
`save()` and `write_chunk()` now write to a `.tmp` file then `File.rename`. On POSIX, `rename` is atomic — a crash at any point leaves either the old file or the new file, never a half-written one.

### `server_master.rb` — longer grace period
Both the hot-restart and shutdown deadlines raised from 2-5s → **10s**, giving `interrupt_all_agents` + `save` enough room to finish.

### `http_server.rb` — parallel interrupt joins
`interrupt_all_agents` restructured into three phases:
1. **Raise** `AgentInterrupted` on every live thread
2. **Join** all threads in parallel → total wait is a single timeout, not N × timeout
3. **Save** each session serially (`to_session_data` is not thread-safe), with a per-session `rescue` so one failure doesn't skip the rest

## Tests

- **New**: `session_manager_atomic_write_spec.rb` — 6 specs covering valid JSON output, no `.tmp` residue, 0600 permissions, and overwrite safety for both `save` and `write_chunk`.
- **Updated**: the existing `interrupt_all_agents` spec now asserts **parallel** wait (`elapsed < 0.4s` for 3 threads) instead of serial wait (`elapsed > 0.4s`).
- All 9 specs pass; the 11 existing session_manager / server_master specs still pass — **zero regressions**.

## Design notes

- No new dependencies, no new config knobs, no new abstractions.
- `File.rename` is used directly (Ruby stdlib) — same pattern the codebase already uses elsewhere for atomic file replacement.
- The 10s deadline is a tunable, not a hard guarantee. It's enough for the common case (a handful of live agents); the SIGKILL at expiry remains as the final safety net.
- WAL and streaming checkpoint (the deeper fixes from #446) are intentionally **out of scope** here — this PR addresses only the three causes that are cheap to fix.

Closes #445.