### PR TITLE
fix(web): inherit the project working dir in the new-session prefill

### DIFF
--- a/lib/clacky/web/features/new-session/view.js
+++ b/lib/clacky/web/features/new-session/view.js
@@ -222,6 +222,18 @@ const NewSessionView = (() => {
 
   async function _prefillDefaultDir() {
     if (NewSessionStore.state.advanced.workingDir) return;  // already set
+    // When a project is selected (possibly restored from localStorage by
+    // loadAgents), prefer its working directory over the global default so
+    // the new session lands in the project's folder — same behavior as
+    // picking the project explicitly from the context bar popover.
+    const project = typeof Projects !== "undefined" && Projects.find
+      ? Projects.find(NewSessionStore.state.advanced.projectId)
+      : null;
+    if (project && project.working_dir) {
+      NewSessionStore.updateAdvanced({ workingDir: project.working_dir });
+      _renderContextBar();
+      return;
+    }
     const home = await NewSessionStore.loadDefaultDirectory();
     if (home) {
       NewSessionStore.updateAdvanced({ workingDir: home });
@@ -857,14 +869,19 @@ const NewSessionView = (() => {
     const sendBtn = $("new-session-send");
     if (sendBtn) sendBtn.addEventListener("click", _submit);
 
-    // Context bar: load models + default dir eagerly, then render chips
+    // Context bar: load models eagerly, then render chips. The working-dir
+    // prefill happens in onPanelShow() instead, so it runs after loadAgents()
+    // restores the remembered project from localStorage.
     _populateModels().then(() => _renderContextBar());
-    _prefillDefaultDir().then(() => _renderContextBar());
   }
 
   async function onPanelShow() {
     _bindOnce();
     await NewSessionStore.loadAgents();
+    // Must run after loadAgents(): that call restores the remembered
+    // projectId from localStorage, which decides whether the working dir is
+    // prefilled from the project or from the global default.
+    await _prefillDefaultDir();
     _renderContextBar();
     _updateSendButton();
     const input = $("new-session-input");

--- a/spec/clacky/server/http_server_create_session_project_dir_spec.rb
+++ b/spec/clacky/server/http_server_create_session_project_dir_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "clacky/server/http_server"
+require "clacky/agent_config"
+require_relative "../../support/http_server_spec_helpers"
+
+# Regression spec for issue #467: sessions created while a project is
+# selected must land in the project's working directory, not silently fall
+# back to the global default. The New Session panel used to prefill its
+# "working directory" field with the global default even when a project was
+# remembered from localStorage, so the client always sent a working_dir and
+# the backend's project-dir inheritance (which only triggers when
+# working_dir is absent) never ran. These specs lock down the backend half
+# of that contract.
+RSpec.describe Clacky::Server::HttpServer, "POST /api/sessions with a project" do
+  include HttpServerSpecHelpers
+
+  let(:tmproot)     { Dir.mktmpdir("clacky_proj_dir_spec") }
+  let(:config_file) { File.join(tmproot, "config.yml") }
+
+  let(:agent_config) do
+    cfg = Clacky::AgentConfig.new(models: [
+      {
+        "model"            => "test-model",
+        "api_key"          => "sk-testkey1234567890abcd",
+        "base_url"         => "https://api.example.com",
+        "anthropic_format" => true,
+        "type"             => "default"
+      }
+    ])
+    stub_const("Clacky::AgentConfig::CONFIG_FILE", config_file)
+    cfg
+  end
+
+  after { FileUtils.rm_rf(tmproot) }
+
+  def create_project(server, working_dir:)
+    server.instance_variable_get(:@project_manager)
+          .create(name: "proj", working_dir: working_dir)
+  end
+
+  def create_session(server, body)
+    res = fake_res
+    dispatch(server, fake_req(method: "POST", path: "/api/sessions", body: body), res)
+    [res.status, parsed_body(res)]
+  end
+
+  it "inherits the project's working_dir when the client sends none" do
+    with_server(agent_config: agent_config) do |server|
+      project_dir = File.join(tmproot, "proj_ws")
+      project = create_project(server, working_dir: project_dir)
+
+      status, body = create_session(server, { name: "s1", project_id: project[:id] })
+
+      expect(status).to eq(201)
+      expect(body["session"]["working_dir"]).to eq(project_dir)
+    end
+  end
+
+  it "keeps an explicit working_dir over the project's" do
+    with_server(agent_config: agent_config) do |server|
+      explicit_dir = File.join(tmproot, "explicit")
+      project = create_project(server, working_dir: File.join(tmproot, "proj_ws"))
+
+      status, body = create_session(server,
+        { name: "s2", project_id: project[:id], working_dir: explicit_dir })
+
+      expect(status).to eq(201)
+      expect(body["session"]["working_dir"]).to eq(explicit_dir)
+    end
+  end
+
+  it "falls back to the default working dir when the project has none" do
+    with_server(agent_config: agent_config) do |server|
+      custom_default = File.join(tmproot, "default_ws")
+      FileUtils.mkdir_p(custom_default)
+      allow(server).to receive(:default_working_dir).and_return(custom_default)
+      project = create_project(server, working_dir: nil)
+
+      status, body = create_session(server, { name: "s3", project_id: project[:id] })
+
+      expect(status).to eq(201)
+      expect(body["session"]["working_dir"]).to eq(custom_default)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Write this PR description in English. -->

## What

When the New Session panel restores the last-used project from localStorage, it now prefills the working-directory field with that project's working directory instead of the global default. Also adds request-level specs locking the backend's project-directory inheritance contract.

## Why

Fixes #467.

The panel restores `projectId` from localStorage on load, but `_prefillDefaultDir()` unconditionally set the working-directory field to the global default directory. `POST /api/sessions` therefore always received a non-empty `working_dir`, so the backend's project-directory inheritance (which only applies when `working_dir` is absent) never ran — sessions created from the panel while a project was selected silently landed in the default workspace instead of the project's folder.

Reproduced on 1.5.6: with a remembered project that has a working directory, repeated clicks on New Session produced sessions that were correctly associated with the project but pointed at the default workspace.

## User-visible impact

With a project that has a working directory selected, the New Session panel now prefills that directory — the same behavior as picking the project explicitly from the context-bar popover. Projects without a directory keep falling back to the global default. No new configuration, no breaking changes.

---

## Self-review

### 1. Architecture

- [x] Smallest possible diff for the need (two hunks in `view.js` + one new spec file)
- [x] No new configuration knobs
- [x] No new dependencies
- [x] Fits the existing design — mirrors the `proj.working_dir || defaultDir` fallback already used by the project popover in the same file

### 2. Need

- [x] Bug fix for a common path: every user creating sessions while a project is selected
- [x] No unintended impact on other users' workflows or defaults

### 3. Code

- [x] All tests pass (see reviewer notes for environment-dependent exceptions)
- [x] Coverage does not drop; new backend contract has new tests. The frontend change is plain browser JS; the repo has no JS test infrastructure (no `package.json`), and introducing one would violate the no-new-dependencies guideline.
- [x] Commit messages and this PR are written in English

### Bonus

- [x] This PR was authored using OpenClacky itself — the bug was found through the Web UI, and the investigation, fix, and tests were all produced by an agent session running inside OpenClacky.

---

## Notes for reviewers

- **Why `_prefillDefaultDir()` moved from `_bindOnce()` to `onPanelShow()`:** `loadAgents()` restores the remembered `projectId` from localStorage; running the prefill before that resolves makes the project lookup lose the race. It now runs after `await loadAgents()`. The existing `if (workingDir) return` guard keeps repeated panel shows idempotent.
- **Project list availability:** `Projects.setAll()` is populated by the first `session_list` WebSocket event at startup — the same guarantee the project popover already relies on. If `Projects` is unavailable, the code falls back to the previous default-directory behavior.
- **Rejected alternative:** a backend heuristic treating `working_dir == default_working_dir` as "unspecified" would misfire for users who deliberately choose the default directory while a project is selected. The frontend is the only layer that knows whether the field was prefilled or explicitly typed.
- **Local test status:** full suite = 3165 examples, 8 failures on my machine — all reproduced identically on a clean `main` checkout (skill-loader specs scan the real `~/.clacky/skills` directory, which contains duplicate/backup skills on this box; live MCP-server specs time out in this sandbox). Targeted run of the related server + web syntax specs: 94 examples, 0 failures, including the 3 new ones.
- **Manual verification:** create a project with a working directory → reload the page (project restored from localStorage) → open New Session → the directory field shows the project's directory → the created session lands there.
