### PR TITLE
fix(message_format): expand stop_reason mapping (3 → 8 cases)

### DIFF
--- a/lib/clacky/message_format/anthropic.rb
+++ b/lib/clacky/message_format/anthropic.rb
@@ -191,6 +191,10 @@ module Clacky
         #              empty-response detector, which exempts "length")
         #   content_filter — model declined (refusal)
         #   other    — context compaction (compaction)
+        # Note: `compaction` is a real stop_reason but only emitted under the
+        # `compact-2026-01-12` beta header (server-side context compaction),
+        # so it is not yet in the stable SDK's StopReason literal list.
+        # See: https://platform.claude.com/docs/en/build-with-claude/compaction
         # Unmapped values fall through unchanged.
         finish_reason = case data["stop_reason"]
                         when "end_turn", "pause_turn", "stop_sequence" then "stop"

--- a/lib/clacky/message_format/anthropic.rb
+++ b/lib/clacky/message_format/anthropic.rb
@@ -181,10 +181,23 @@ module Clacky
           { id: tc["id"], type: "function", name: tc["name"], arguments: args }
         end
 
+        # Map Anthropic stop_reason → OpenAI-style finish_reason so downstream
+        # (llm_caller empty-response detector, agent loop, CostTracker) stays
+        # provider-agnostic. Each cluster shares the same semantic class:
+        #   stop     — natural end of turn (end_turn / pause_turn / stop_sequence)
+        #   length   — token or context-window limit hit (max_tokens /
+        #              model_context_window_exceeded; mapping the latter to
+        #              "length" also prevents a futile retry in llm_caller's
+        #              empty-response detector, which exempts "length")
+        #   content_filter — model declined (refusal)
+        #   other    — context compaction (compaction)
+        # Unmapped values fall through unchanged.
         finish_reason = case data["stop_reason"]
-                        when "end_turn"   then "stop"
+                        when "end_turn", "pause_turn", "stop_sequence" then "stop"
                         when "tool_use"   then "tool_calls"
-                        when "max_tokens" then "length"
+                        when "max_tokens", "model_context_window_exceeded" then "length"
+                        when "refusal"    then "content_filter"
+                        when "compaction" then "other"
                         else data["stop_reason"]
                         end
 

--- a/lib/clacky/message_format/bedrock.rb
+++ b/lib/clacky/message_format/bedrock.rb
@@ -118,11 +118,14 @@ module Clacky
           { id: tc["toolUseId"], type: "function", name: tc["name"], arguments: args }
         end
 
-        # Map Bedrock stopReason → canonical finish_reason
+        # Map Bedrock stopReason → canonical finish_reason (same clusters as
+        # the Anthropic direct adapter — see lib/clacky/message_format/anthropic.rb).
         finish_reason = case data["stopReason"]
-                        when "end_turn"   then "stop"
+                        when "end_turn", "pause_turn", "stop_sequence" then "stop"
                         when "tool_use"   then "tool_calls"
-                        when "max_tokens" then "length"
+                        when "max_tokens", "model_context_window_exceeded" then "length"
+                        when "refusal"    then "content_filter"
+                        when "compaction" then "other"
                         else data["stopReason"]
                         end
 

--- a/lib/clacky/message_format/bedrock.rb
+++ b/lib/clacky/message_format/bedrock.rb
@@ -125,6 +125,8 @@ module Clacky
                         when "tool_use"   then "tool_calls"
                         when "max_tokens", "model_context_window_exceeded" then "length"
                         when "refusal"    then "content_filter"
+                        # `compaction` is a beta stop_reason (compact-2026-01-12);
+                        # see anthropic.rb for the full note.
                         when "compaction" then "other"
                         else data["stopReason"]
                         end

--- a/spec/clacky/message_format_anthropic_spec.rb
+++ b/spec/clacky/message_format_anthropic_spec.rb
@@ -169,4 +169,36 @@ RSpec.describe Clacky::MessageFormat::Anthropic do
       expect(use_block[:id]).to match(/\A[a-zA-Z0-9_-]+\z/)
     end
   end
+
+  describe ".parse_response finish_reason mapping" do
+    let(:base_response) do
+      {
+        "content" => [{ "type" => "text", "text" => "hello" }],
+        "usage" => { "input_tokens" => 10, "output_tokens" => 5 }
+      }
+    end
+
+    def parse_with(stop_reason)
+      described_class.parse_response(base_response.merge("stop_reason" => stop_reason))
+    end
+
+    {
+      "end_turn" => "stop",
+      "pause_turn" => "stop",
+      "stop_sequence" => "stop",
+      "tool_use" => "tool_calls",
+      "max_tokens" => "length",
+      "model_context_window_exceeded" => "length",
+      "refusal" => "content_filter",
+      "compaction" => "other"
+    }.each do |stop_reason, expected|
+      it "maps #{stop_reason} → #{expected}" do
+        expect(parse_with(stop_reason)[:finish_reason]).to eq(expected)
+      end
+    end
+
+    it "passes through unmapped stop_reason values unchanged" do
+      expect(parse_with("some_unknown_reason")[:finish_reason]).to eq("some_unknown_reason")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The Anthropic and Bedrock adapters only mapped **3** `stop_reason` values to the canonical `finish_reason`; everything else fell through unchanged (`else data["stop_reason"]`). As the providers expose more stop reasons, unmapped values leak straight through to downstream logic (`llm_caller` empty-response detector, agent loop, CostTracker), which only understands the canonical OpenAI-style set.

This PR expands the mapping to **8 cases**, grouped by semantic class, so downstream behavior stays provider-agnostic and correct.

## Mapping table

| finish_reason | Anthropic / Bedrock stop_reason | Status |
|---|---|---|
| `stop` | `end_turn` · **`pause_turn`** · **`stop_sequence`** | `end_turn` was mapped; 2 added |
| `tool_calls` | `tool_use` | unchanged |
| `length` | `max_tokens` · **`model_context_window_exceeded`** | `max_tokens` was mapped; 1 added |
| `content_filter` | **`refusal`** | newly covered |
| `other` | **`compaction`** | newly covered |
| *(passthrough)* | any unknown value | unchanged |

## Why the new cases matter

- **`model_context_window_exceeded` → `length`**: the `llm_caller` empty-response detector **exempts `length`** but retries everything else. Without this mapping the detector treated context overflow as retryable, firing a **guaranteed-to-fail retry** (context is still over the window). Mapping it to `length` makes the detector give up immediately.
- **`refusal` → `content_filter`**: a model refusal was previously an unrecognized finish reason, which downstream code could misinterpret as an error/anomaly. It now maps to the standard content-filter bucket.
- **`pause_turn` / `stop_sequence` → `stop`**, **`compaction` → `other`**: normalize provider-specific natural-stop / compaction signals into the canonical clusters.

Both adapters (`anthropic.rb`, `bedrock.rb`) receive the **same** cluster mapping so behavior is consistent across providers.

## Testing

- `spec/clacky/message_format_anthropic_spec.rb`: 9 new examples — one per mapped value (8) + 1 asserting unknown values pass through unchanged.
- Full `message_format_anthropic_spec.rb`: **21 examples, 0 failures**.

## Scope

3 files, +53 / −5. Touches only `message_format/anthropic.rb`, `message_format/bedrock.rb`, and the matching spec. No changes to persistence, agent loop, or client plumbing — independent of #463.