### PR TITLE
Add icons to project action menu

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -14144,7 +14144,9 @@ body.setup-mode[data-theme="dark"] {
   box-shadow: 0 8px 24px rgba(0,0,0,.5), 0 2px 6px rgba(0,0,0,.3);
 }
 .project-actions-menu-item {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
   padding: 0.375rem 0.625rem;
   border: none;
@@ -14153,16 +14155,42 @@ body.setup-mode[data-theme="dark"] {
   cursor: pointer;
   color: var(--color-text-primary);
   font-size: 0.8125rem;
+  line-height: 1.4;
   text-align: left;
   transition: background .12s ease, color .12s ease;
 }
+.project-actions-menu-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 0.875rem;
+  color: var(--color-text-secondary);
+  transition: color .12s ease;
+}
+.project-actions-menu-icon svg {
+  display: block;
+  flex-shrink: 0;
+}
+.project-actions-menu-label {
+  min-width: 0;
+  flex: 1;
+}
 .project-actions-menu-item:hover {
   background: var(--color-bg-hover);
+}
+.project-actions-menu-item:hover .project-actions-menu-icon {
+  color: var(--color-text-primary);
 }
 .project-actions-menu-item.danger {
   color: var(--color-error);
   margin-top: 0.25rem;
   position: relative;
+}
+.project-actions-menu-item.danger .project-actions-menu-icon,
+.project-actions-menu-item.danger:hover .project-actions-menu-icon {
+  color: var(--color-error);
 }
 .project-actions-menu-item.danger::before {
   content: "";
@@ -14496,4 +14524,3 @@ body.setup-mode[data-theme="dark"] {
 .project-picker-done-btn:hover {
   background: var(--color-bg-hover);
 }
-

--- a/lib/clacky/web/projects.js
+++ b/lib/clacky/web/projects.js
@@ -372,7 +372,7 @@ const Projects = (() => {
 
   
 
-  /** Show a small context menu for project actions (edit / delete). */
+  /** Show a small context menu for project actions. */
   function _showProjectMenu(projectId, anchor) {
     // Remove any existing project menu
     document.querySelectorAll(".project-actions-menu").forEach(m => m.remove());
@@ -380,10 +380,23 @@ const Projects = (() => {
     const menu = document.createElement("div");
     menu.className = "project-actions-menu";
 
-    const addItem = (labelKey, defaultLabel, danger, onClick) => {
+    // Lucide Pencil and Trash2 icons, embedded to avoid extra asset requests.
+    const iconEdit = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>`;
+    const iconTrash = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>`;
+
+    const addItem = (labelKey, defaultLabel, iconSvg, danger, onClick) => {
       const item = document.createElement("button");
       item.className = "project-actions-menu-item" + (danger ? " danger" : "");
-      item.textContent = I18n.t(labelKey, defaultLabel);
+
+      const icon = document.createElement("span");
+      icon.className = "project-actions-menu-icon";
+      icon.innerHTML = iconSvg;
+
+      const label = document.createElement("span");
+      label.className = "project-actions-menu-label";
+      label.textContent = I18n.t(labelKey, defaultLabel);
+
+      item.append(icon, label);
       item.addEventListener("click", e => {
         e.stopPropagation();
         menu.remove();
@@ -392,9 +405,9 @@ const Projects = (() => {
       menu.appendChild(item);
     };
 
-    addItem("projects.menu.edit", "Edit Project", false, () => promptEdit(projectId));
-    addItem("projects.menu.deleteSessions", "Delete Sessions", false, () => promptDeleteSessions(projectId));
-    addItem("projects.menu.delete", "Delete",  true,  () => promptDelete(projectId));
+    addItem("projects.menu.edit", "Edit Project", iconEdit, false, () => promptEdit(projectId));
+    addItem("projects.menu.deleteSessions", "Delete Sessions", iconTrash, false, () => promptDeleteSessions(projectId));
+    addItem("projects.menu.delete", "Delete", iconTrash, true, () => promptDelete(projectId));
 
     // Position near anchor
     const rect = anchor.getBoundingClientRect();

--- a/spec/clacky/web/project_actions_menu_spec.rb
+++ b/spec/clacky/web/project_actions_menu_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe "Project actions menu UI" do
+  let(:web_dir) { File.expand_path("../../../lib/clacky/web", __dir__) }
+  let(:projects) { File.read(File.join(web_dir, "projects.js")) }
+  let(:styles) { File.read(File.join(web_dir, "app.css")) }
+
+  it "embeds Lucide Pencil and Trash2 icons for the three actions" do
+    expect(projects).to include(
+      'addItem("projects.menu.edit", "Edit Project", iconEdit, false'
+    )
+    expect(projects).to include(
+      'addItem("projects.menu.deleteSessions", "Delete Sessions", iconTrash, false'
+    )
+    expect(projects).to include(
+      'addItem("projects.menu.delete", "Delete", iconTrash, true'
+    )
+    expect(projects).to include('viewBox="0 0 24 24" width="14" height="14"')
+    expect(projects).to include('stroke="currentColor" stroke-width="2"')
+    expect(projects).to include(
+      'M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174'
+    )
+    expect(projects).to include('<path d="M10 11v6"/><path d="M14 11v6"/>')
+    expect(projects).to include('const iconEdit = `<svg')
+    expect(projects).to include('const iconTrash = `<svg')
+  end
+
+  it "matches the existing 14px menu icon size and themes only deletion as dangerous" do
+    expect(styles).to match(
+      /\.project-actions-menu-icon \{.*?width: 0\.875rem;.*?height: 0\.875rem;/m
+    )
+    expect(styles).not_to include("project-edit.svg")
+    expect(styles).not_to include("project-trash.svg")
+    expect(styles).to include(".project-actions-menu-icon svg")
+    expect(styles).to match(
+      /\.project-actions-menu-item\.danger .*?color: var\(--color-error\);/m
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- embed the official Lucide Pencil and Trash2 SVGs in the project actions menu at the existing 14px menu-icon size
- keep regular actions aligned with theme text colors while reserving the danger color for project deletion
- keep the existing project-action copy unchanged and add focused regression coverage

## Why

The project menu previously used text-only labels. The inline icons align it with the existing session action UI while preserving the current copy and light/dark theme behavior.

## Validation

- `bundle exec rspec spec/clacky/web/project_actions_menu_spec.rb spec/clacky/web/syntax_spec.rb` — 21 examples, 0 failures
- `node --check lib/clacky/web/projects.js`
- `node --check lib/clacky/web/i18n.js`
- manually verified English/Chinese copy, light/dark themes, hover states, and all three menu entry points in the local Web UI
