### PR TITLE
Fix Feishu WebSocket TLS SNI

### DIFF
--- a/lib/clacky/server/channel/adapters/feishu/ws_client.rb
+++ b/lib/clacky/server/channel/adapters/feishu/ws_client.rb
@@ -71,6 +71,12 @@ module Clacky
               ssl_context = OpenSSL::SSL::SSLContext.new
               ssl_context.set_params(verify_mode: OpenSSL::SSL::VERIFY_PEER)
               ssl = OpenSSL::SSL::SSLSocket.new(tcp, ssl_context)
+              # Feishu/Lark WebSocket endpoints are served behind CDN edges that
+              # require SNI to select the correct certificate/backend. Some
+              # Ruby/OpenSSL combinations do not infer the hostname for manually
+              # created SSLSocket instances, which can make the peer abort the TLS
+              # handshake with `tlsv1 alert internal error`.
+              ssl.hostname = uri.host if ssl.respond_to?(:hostname=)
               ssl.sync_close = true
               ssl.connect
               ssl


### PR DESCRIPTION
## Summary
- Set `SSLSocket#hostname` before connecting to Feishu/Lark WebSocket endpoints
- This ensures SNI is sent when connecting to CDN-backed `wss://` endpoints
- Prevents TLS handshake failures such as `tlsv1 alert internal error` on some Ruby/OpenSSL environments

## Background
Feishu returns the WebSocket endpoint dynamically from `/callback/ws/endpoint`. The returned host may resolve to CDN edge nodes that require SNI to select the correct certificate/backend. When the socket is created manually with `OpenSSL::SSL::SSLSocket.new`, some Ruby/OpenSSL combinations do not infer the hostname automatically.

## Usage scenario
This issue was encountered when using openclacky's built-in Feishu channel module and chatting with the agent through the Lark client. After each agent update/restart, the Feishu WebSocket channel attempted to reconnect and failed during the TLS handshake.

Observed error:

```text
[feishu-ws] Connection error: SSL_connect returned=1 errno=0 peeraddr=23.211.124.195:443 state=error: tlsv1 alert internal error (SSL alert number 80)
```

Environment where this was reproduced:

- WSL / Windows
- Ruby 4.0.6
- OpenSSL 3.0.2
- openclacky 1.5.7

## Validation
```bash
ruby -c lib/clacky/server/channel/adapters/feishu/ws_client.rb
# Syntax OK
```