### PR TITLE
feat: add OrcaRouter as a named provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ openclacky
 
 Set your **API Key**, **Model**, and **Base URL** (any OpenAI-compatible provider).
 
-Supported out of the box: **Claude (Anthropic) · GPT (OpenAI) · DeepSeek · Kimi (Moonshot) · MiniMax · OpenRouter** — or any custom endpoint.
+Supported out of the box: **Claude (Anthropic) · GPT (OpenAI) · DeepSeek · Kimi (Moonshot) · MiniMax · OpenRouter · OrcaRouter** — or any custom endpoint.
 
 ## Coding use case
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -189,7 +189,7 @@ $ openclacky
 
 设置你的 **API Key**、**模型**和 **Base URL**（任意 OpenAI 兼容提供商）。
 
-开箱即支持：**Claude (Anthropic) · GPT (OpenAI) · DeepSeek · Kimi (Moonshot) · MiniMax · OpenRouter**，或任意自定义端点。
+开箱即支持：**Claude (Anthropic) · GPT (OpenAI) · DeepSeek · Kimi (Moonshot) · MiniMax · OpenRouter · OrcaRouter**，或任意自定义端点。
 
 ## 代码开发场景
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -194,7 +194,7 @@ $ openclacky
 
 **API Key**、**Model**、**Base URL**（任意の OpenAI 互換プロバイダー）を設定します。
 
-標準でサポート: **Claude (Anthropic) · GPT (OpenAI) · DeepSeek · Kimi (Moonshot) · MiniMax · OpenRouter** — または任意のカスタムエンドポイント。
+標準でサポート: **Claude (Anthropic) · GPT (OpenAI) · DeepSeek · Kimi (Moonshot) · MiniMax · OpenRouter · OrcaRouter** — または任意のカスタムエンドポイント。
 
 ## コーディングのユースケース
 

--- a/lib/clacky/providers.rb
+++ b/lib/clacky/providers.rb
@@ -231,6 +231,59 @@ module Clacky
         "website_url" => "https://openrouter.ai/keys"
       }.freeze,
 
+      "orcarouter" => {
+        "name" => "OrcaRouter",
+        "base_url" => "https://api.orcarouter.ai/v1",
+        "api" => "openai-completions",
+        "default_model" => "openai/gpt-5.5",
+        # Curated default lineup. OrcaRouter exposes 190+ models from OpenAI,
+        # Anthropic, Google, DeepSeek, Qwen, MiniMax, Zhipu and others behind a
+        # single OpenAI-compatible endpoint. Shipping a small list of the
+        # mainstream Claude + GPT entries gives users a working dropdown out
+        # of the box; users can still type any other OrcaRouter model id
+        # manually (e.g. "orcarouter/auto" for request-level auto-routing).
+        "models" => [
+          "anthropic/claude-sonnet-5",
+          "anthropic/claude-opus-4.8",
+          "anthropic/claude-haiku-4.5",
+          "openai/gpt-5.5",
+          "openai/gpt-5.4",
+          "openai/gpt-5.4-mini",
+          "google/gemini-3.5-flash",
+          "deepseek/deepseek-v4-flash",
+          "z-ai/glm-5.2",
+          "orcarouter/auto"
+        ],
+        # Per-primary lite pairing — Claude family pairs with Haiku, GPT
+        # family pairs with the mini variant. Mirrors the openrouter preset
+        # so subagents on OrcaRouter get a sensible cheap/fast sidekick.
+        "lite_models" => {
+          "anthropic/claude-sonnet-5" => "anthropic/claude-haiku-4.5",
+          "anthropic/claude-opus-4.8" => "anthropic/claude-haiku-4.5",
+          "openai/gpt-5.5"            => "openai/gpt-5.4-mini",
+          "openai/gpt-5.4"            => "openai/gpt-5.4-mini"
+        },
+        # Per-model API type overrides. OrcaRouter proxies Claude through a
+        # native Anthropic /v1/messages endpoint (https://api.orcarouter.ai/v1/messages)
+        # in addition to its OpenAI-compatible /chat/completions endpoint.
+        # Routing "anthropic/*" via the native endpoint preserves cache_control
+        # fidelity, matching what Claude Code CLI does internally (same rationale
+        # as the openrouter preset). Non-Claude models keep the OpenAI shim.
+        "model_api_overrides" => {
+          /\Aanthropic\// => "anthropic-messages"
+        }.freeze,
+        # Most models on OrcaRouter are vision-capable; DeepSeek / GLM-5.2 and
+        # the "orcarouter/auto" router are text-only.
+        "capabilities" => { "vision" => true }.freeze,
+        "model_capabilities" => {
+          "deepseek/deepseek-v4-flash" => { "vision" => false }.freeze,
+          "z-ai/glm-5.2"               => { "vision" => false }.freeze,
+          "orcarouter/auto"            => { "vision" => false }.freeze
+        }.freeze,
+        "default_ocr_model" => "google/gemini-3.5-flash",
+        "website_url" => "https://www.orcarouter.ai"
+      }.freeze,
+
       "deepseekv4" => {
         "name" => "DeepSeek V4",
         # DeepSeek API is compatible with both OpenAI and Anthropic formats.

--- a/spec/clacky/providers_spec.rb
+++ b/spec/clacky/providers_spec.rb
@@ -196,6 +196,58 @@ RSpec.describe Clacky::Providers do
       end
     end
 
+    context "for OrcaRouter provider" do
+      it "resolves default model to openai/gpt-5.5" do
+        expect(described_class.default_model("orcarouter")).to eq("openai/gpt-5.5")
+      end
+
+      it "has correct base_url and api type" do
+        expect(described_class.base_url("orcarouter")).to eq("https://api.orcarouter.ai/v1")
+        expect(described_class.api_type("orcarouter")).to eq("openai-completions")
+      end
+
+      it "includes expected models" do
+        expect(described_class.models("orcarouter")).to include(
+          "openai/gpt-5.5", "openai/gpt-5.4-mini",
+          "anthropic/claude-sonnet-5", "anthropic/claude-haiku-4.5",
+          "google/gemini-3.5-flash", "deepseek/deepseek-v4-flash",
+          "z-ai/glm-5.2", "orcarouter/auto"
+        )
+      end
+
+      it "returns correct lite model mappings" do
+        expect(described_class.lite_model("orcarouter", "anthropic/claude-sonnet-5")).to eq("anthropic/claude-haiku-4.5")
+        expect(described_class.lite_model("orcarouter", "anthropic/claude-opus-4.8")).to eq("anthropic/claude-haiku-4.5")
+        expect(described_class.lite_model("orcarouter", "openai/gpt-5.5")).to eq("openai/gpt-5.4-mini")
+        expect(described_class.lite_model("orcarouter", "openai/gpt-5.4")).to eq("openai/gpt-5.4-mini")
+      end
+
+      it "enforces vision capabilities correctly" do
+        # Vision-capable models
+        expect(described_class.supports?("orcarouter", :vision, model_name: "openai/gpt-5.5")).to be true
+        expect(described_class.supports?("orcarouter", :vision, model_name: "anthropic/claude-sonnet-5")).to be true
+        expect(described_class.supports?("orcarouter", :vision, model_name: "google/gemini-3.5-flash")).to be true
+        # Text-only models
+        expect(described_class.supports?("orcarouter", :vision, model_name: "deepseek/deepseek-v4-flash")).to be false
+        expect(described_class.supports?("orcarouter", :vision, model_name: "z-ai/glm-5.2")).to be false
+        expect(described_class.supports?("orcarouter", :vision, model_name: "orcarouter/auto")).to be false
+      end
+
+      it "resolves provider by base_url" do
+        expect(described_class.find_by_base_url("https://api.orcarouter.ai/v1")).to eq("orcarouter")
+        expect(described_class.find_by_base_url("https://api.orcarouter.ai/v1/chat/completions")).to eq("orcarouter")
+      end
+
+      it "has a website_url for API keys" do
+        preset = described_class::PRESETS["orcarouter"]
+        expect(preset["website_url"]).to eq("https://www.orcarouter.ai")
+      end
+
+      it "has a default_ocr_model" do
+        expect(described_class.default_ocr_model("orcarouter")).to eq("google/gemini-3.5-flash")
+      end
+    end
+
     context "conservative default (unknown or undeclared)" do
       it "returns true for an unknown provider_id" do
         # Custom base_urls map to nil provider_id; assume capability supported
@@ -595,6 +647,25 @@ RSpec.describe Clacky::Providers do
     it "tolerates a nil model_name by returning the provider default" do
       expect(described_class.api_type_for_model("openrouter", nil)).to eq("openai-responses")
     end
+
+    it "routes OrcaRouter anthropic/* models to anthropic-messages" do
+      # OrcaRouter also exposes a native Anthropic /v1/messages endpoint, so
+      # Claude models route there to preserve cache_control fidelity (same
+      # rationale as OpenRouter above).
+      expect(described_class.api_type_for_model("orcarouter", "anthropic/claude-sonnet-5"))
+        .to eq("anthropic-messages")
+      expect(described_class.api_type_for_model("orcarouter", "anthropic/claude-opus-4.8"))
+        .to eq("anthropic-messages")
+    end
+
+    it "keeps non-Claude OrcaRouter models on the OpenAI shim" do
+      expect(described_class.api_type_for_model("orcarouter", "google/gemini-3.5-flash"))
+        .to eq("openai-completions")
+      expect(described_class.api_type_for_model("orcarouter", "openai/gpt-5.5"))
+        .to eq("openai-completions")
+      expect(described_class.api_type_for_model("orcarouter", "deepseek/deepseek-v4-flash"))
+        .to eq("openai-completions")
+    end
   end
 
   describe ".anthropic_format_for_model?" do
@@ -614,6 +685,16 @@ RSpec.describe Clacky::Providers do
 
     it "is false for unknown providers" do
       expect(described_class.anthropic_format_for_model?("ghost-provider", "any-model")).to be false
+    end
+
+    it "is true for OrcaRouter Claude models" do
+      expect(described_class.anthropic_format_for_model?("orcarouter", "anthropic/claude-sonnet-5"))
+        .to be true
+    end
+
+    it "is false for OrcaRouter non-Claude models" do
+      expect(described_class.anthropic_format_for_model?("orcarouter", "openai/gpt-5.5"))
+        .to be false
     end
   end
 


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named model provider, wired in
the same way OpenRouter is: an OpenAI-compatible base URL
(`https://api.orcarouter.ai/v1`), a curated model lineup, lite-model pairing for
subagents, and a `model_api_overrides` entry that routes `anthropic/*` models
through OrcaRouter's native Anthropic `/v1/messages` endpoint so Claude's
`cache_control` semantics survive the round trip.

I'm an engineer on the OrcaRouter team.

## What this changes

- `lib/clacky/providers.rb`: registers the `orcarouter` provider preset
  (base URL, default model, model list, lite pairing, per-model API overrides,
  vision capabilities, OCR default, website URL)
- `spec/clacky/providers_spec.rb`: unit tests for the preset (models, base URL
  resolution, lite models, capabilities, API-type routing, anthropic format)
- `README.md` / `README_CN.md` / `README_JA.md`: adds OrcaRouter to the
  out-of-the-box provider list alongside OpenRouter

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how the OpenRouter preset is wired in this repo, so the model
picker, docs and config reference stay consistent for users. OrcaRouter also
exposes a native Anthropic-format endpoint for Claude models; pinning
`anthropic/*` to it preserves prompt-cache fidelity, matching what the
openrouter preset already does.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Pick the OrcaRouter provider in `/config` and enter the key.
3. Choose a model such as `openai/gpt-5.5`, `anthropic/claude-opus-4.8` or
   `z-ai/glm-5.2`. The full catalog is at https://www.orcarouter.ai/models.

Named routers such as `orcarouter/auto` pick an upstream per request. `auto` is
not the default because its candidate pool can include models without
tool-calling support.

## Verification

- Unit tests: all provider-level assertions for the new preset pass (39/39
  checks, run locally against `Clacky::Providers`). The full RSpec suite is
  exercised in CI (the suite loads a `pty`-dependent module, so the full run is
  not available on Windows).
- Live API against the real gateway:
  - `GET /v1/models` -> 200 (193 models; all preset ids confirmed present)
  - `POST /v1/chat/completions` with `openai/gpt-5.5` -> 200
  - `POST /v1/messages` (Anthropic format, `x-api-key`) with
    `anthropic/claude-sonnet-5` -> 200
- Because the provider is a thin base-URL swap, any pipeline or agent that uses
  it also inherits OrcaRouter's gateway-level, zero-trust security controls for
  AI agents, with no application code changes.
