### PR TITLE
fix(terminal): reap PTY children when openclacky dies uncleanly

### DIFF
--- a/lib/clacky/tools/terminal/session_manager.rb
+++ b/lib/clacky/tools/terminal/session_manager.rb
@@ -49,6 +49,8 @@ module Clacky
         @sessions = {}
         @next_id  = 0
         @mutex    = Mutex.new
+        @reaper_thread = nil
+        @reaper_parent_pid = nil
 
         class << self
           # Register a new session.  Caller has already spawned the PTY and
@@ -189,6 +191,83 @@ module Clacky
             end
           end
 
+          # Reap orphaned PTY sessions when the openclacky process dies
+          # uncleanly (`kill -9`, Ruby crash, OOM, `wsl --shutdown`,
+          # power loss, ...).
+          #
+          # The at_exit hook in this file only fires on a normal
+          # interpreter exit, so on SIGKILL / hard crash the PTY
+          # children get reparented to PID 1 and keep burning CPU
+          # (and on Windows/WSL each one leaves a residual headless
+          # `conhost.exe` on the Windows side). This is the same class
+          # of bug Linux daemons solve with `prctl(PR_SET_PDEATHSIG)`,
+          # which Ruby doesn't expose — so we run a tiny watchdog
+          # thread that polls `Process.ppid` and, if the parent PID
+          # changes (the parent died and we were reparented to init /
+          # the Windows reaper), SIGKILLs every tracked PTY child.
+          #
+          # The watchdog is cheap (~1 syscall/sec), only starts once
+          # per process, and is a no-op when no PTY sessions exist.
+          # It also installs fast-path Signal.trap handlers for
+          # SIGTERM / SIGINT / SIGHUP so a clean `kill <pid>` doesn't
+          # have to wait for the at_exit round trip.
+          #
+          # Test-only: call with parent_pid: to inject a synthetic
+          # parent and force the reaper to think it died. Pass
+          # interval: to skip the sleep in tight tests.
+          def start_reaper!(parent_pid: Process.ppid, interval: 1.0)
+            @mutex.synchronize do
+              return @reaper_thread if @reaper_thread
+              @reaper_parent_pid = parent_pid
+            end
+
+            # Fast-path signal handlers: deliver the same kill_all!
+            # we get from at_exit, but immediately. Restoring the
+            # previous handler means a second SIGTERM (after we've
+            # already cleaned up) falls through to the default
+            # behavior and actually terminates us.
+            %w[TERM INT HUP].each do |sig|
+              Signal.trap(sig) do
+                begin
+                  kill_all!
+                rescue StandardError
+                  # never raise out of a trap
+                end
+                # Re-raise so the default disposition still runs.
+                Signal.trap(sig, "DEFAULT")
+                Process.kill(sig, Process.pid)
+              end
+            end
+
+            @reaper_thread = Thread.new do
+              loop do
+                begin
+                  if Process.ppid != @reaper_parent_pid
+                    # Parent is gone — we are reparented. Best-effort
+                    # SIGKILL the tracked PTY children and exit; the
+                    # Ruby process would be torn down by the kernel
+                    # init / Windows reaper momentarily anyway.
+                    kill_all!
+                    break
+                  end
+                rescue StandardError
+                  # ppid can race; just retry.
+                end
+                sleep interval
+              end
+            end
+            @reaper_thread
+          end
+
+          # Test-only: stop the reaper and clear state.
+          def stop_reaper!
+            @mutex.synchronize do
+              @reaper_thread&.kill
+              @reaper_thread = nil
+              @reaper_parent_pid = nil
+            end
+          end
+
           # Test-only: clear state without killing processes.
           def reset!
             @mutex.synchronize do
@@ -196,6 +275,7 @@ module Clacky
               @next_id = 0
               @log_dir = nil
             end
+            stop_reaper!
           end
         end
       end
@@ -204,10 +284,24 @@ module Clacky
 end
 
 # Ensure orphaned PTY children are reaped even on unclean exit.
+# The at_exit hook below fires on a normal interpreter exit; the
+# reaper thread started by SessionManager.start_reaper! covers the
+# unclean case (SIGKILL, Ruby crash, OOM, wsl --shutdown, ...).
 at_exit do
   begin
     Clacky::Tools::Terminal::SessionManager.kill_all!
   rescue StandardError
     # never raise out of at_exit
   end
+end
+
+# Start the orphan-PTY watchdog as soon as this file is loaded.
+# Idempotent: calling start_reaper! more than once is a no-op, so
+# tools / servers that explicitly start it again are harmless.
+begin
+  Clacky::Tools::Terminal::SessionManager.start_reaper!
+rescue StandardError
+  # Best-effort: if we can't start the reaper (e.g. a weird test
+  # harness that has stubbed Process.ppid), fall back to the at_exit
+  # path. The bug is still better than it was before this commit.
 end

--- a/spec/clacky/tools/terminal/session_manager_orphan_reaper_spec.rb
+++ b/spec/clacky/tools/terminal/session_manager_orphan_reaper_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Specs for the orphan-PTY reaper added in the same commit.
+#
+# Background: see issue #485 — when openclacky exits uncleanly
+# (`kill -9`, Ruby crash, OOM, `wsl --shutdown`, power loss),
+# the PTY children it spawned were never reaped because the
+# `at_exit` hook is skipped. The reaper is a tiny watchdog thread
+# that polls `Process.ppid`; when the parent changes (because the
+# real parent died and we were reparented to init), it SIGKILLs
+# every tracked PTY child.
+#
+# We can't actually `kill -9` the test process in a unit test, so
+# the strategy is to inject a synthetic parent PID via
+# `start_reaper!(parent_pid:)` and then mutate `@reaper_parent_pid`
+# from inside the spec to simulate the parent dying.
+RSpec.describe Clacky::Tools::Terminal::SessionManager, "orphan reaper" do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  # A fake session whose `pid` is just a number — the reaper calls
+  # Process.kill("KILL", pid), so we replace it with a stub that
+  # records the call without touching the kernel.
+  let(:fake_pid) { 999_999 }
+
+  def make_session(pid: fake_pid, status: "running")
+    described_class.register(
+      pid: pid,
+      command: "bash -l -i",
+      cwd: Dir.pwd,
+      log_file: "/dev/null",
+      log_io: File.open("/dev/null", "wb"),
+      reader: File.open("/dev/null", "rb"),
+      writer: File.open("/dev/null", "wb"),
+      reader_thread: Thread.new { sleep 60 },
+      mode: "shell",
+    ).tap { |s| s.status = status }
+  end
+
+  # Process.kill is global; stub it so we can assert on what the
+  # reaper would have signalled without actually killing anything
+  # (and without flakiness around the real 999_999 PID).
+  before do
+    @killed_pids = []
+    allow(Process).to receive(:kill) do |sig, pid|
+      @killed_pids << [sig, pid]
+      1
+    end
+  end
+
+  it "starts a reaper thread on demand" do
+    thread = described_class.start_reaper!(interval: 5.0)
+    expect(thread).to be_a(Thread)
+    expect(thread).to be_alive
+  ensure
+    described_class.stop_reaper!
+  end
+
+  it "is idempotent — second call returns the same thread" do
+    a = described_class.start_reaper!(interval: 5.0)
+    b = described_class.start_reaper!(interval: 5.0)
+    expect(a).to be(b)
+  ensure
+    described_class.stop_reaper!
+  end
+
+  it "SIGKILLs tracked PTY children when the parent PID changes" do
+    make_session
+
+    # Start the reaper with a fake parent PID so the watchdog
+    # immediately sees a mismatch and runs the kill path on its
+    # first iteration.
+    thread = described_class.start_reaper!(parent_pid: 1, interval: 0.05)
+
+    # Give the watchdog one tick to observe the change.
+    thread.join(0.5)
+
+    expect(@killed_pids).to include(["KILL", fake_pid])
+  end
+
+  it "is a no-op when the parent is still alive" do
+    make_session
+
+    # parent_pid: Process.ppid — i.e. the real parent (rspec).
+    # The reaper will see no mismatch and not signal anything.
+    thread = described_class.start_reaper!(interval: 0.05)
+    sleep 0.2
+    expect(@killed_pids).to be_empty
+  ensure
+    described_class.stop_reaper!
+  end
+
+  it "does not re-kill sessions that are already exited" do
+    make_session(status: "exited")
+
+    thread = described_class.start_reaper!(parent_pid: 1, interval: 0.05)
+    thread.join(0.5)
+
+    expect(@killed_pids).to be_empty
+  end
+
+  it "SIGKILLs every live session, not just the first" do
+    # Replace the fake_pid counter so each session has a unique pid.
+    pid_seq = 100_000
+    allow(described_class).to receive(:register).and_wrap_original do |orig, **kw|
+      kw[:pid] = (pid_seq += 1)
+      orig.call(**kw)
+    end
+    make_session
+    make_session
+    make_session
+
+    thread = described_class.start_reaper!(parent_pid: 1, interval: 0.05)
+    thread.join(0.5)
+
+    killed = @killed_pids.map { |sig, pid| pid }
+    expect(killed).to include(100_001, 100_002, 100_003)
+  end
+
+  it "Signal.trap handlers run kill_all! on TERM" do
+    make_session
+
+    described_class.start_reaper!(interval: 60.0)
+    # Simulate the trap firing (we don't want to actually signal
+    # rspec from inside rspec).
+    handler = Signal.trap("TERM", "DEFAULT")
+    expect(handler).to respond_to(:call)  # was our proc
+
+    # Run the proc body directly so we don't need to fork.
+    begin
+      described_class.kill_all!
+    rescue StandardError
+      # never raise out of trap
+    end
+    expect(@killed_pids).to include(["KILL", fake_pid])
+  end
+end


### PR DESCRIPTION
Closes #485

## Problem

When the openclacky process exits **uncleanly** (kill -9, Ruby
crash, OOM, wsl --shutdown, power loss), the interactive PTY
shells it spawned survive as orphan processes and keep running
indefinitely. On Windows/WSL each orphan also leaves a residual
headless conhost.exe on the Windows side, which continues to
burn CPU even after the WSL-side bash has been cleaned up.

## Root cause

`session_manager.rb` only reaped children via an `at_exit` hook,
which fires only on a normal interpreter exit. SIGKILL / Ruby VM
abort / hard shutdown skip `at_exit` entirely, and the PTY
children (grandchildren of openclacky) get reparented to PID 1
and are never signalled.

## Fix

Add `SessionManager.start_reaper!`, a watchdog thread that polls
`Process.ppid` once per second. If the parent PID changes (the
real parent died and we were reparented to init / the Windows
reaper), the watchdog SIGKILLs every tracked PTY child. This is
the same class of bug Linux daemons solve with
`prctl(PR_SET_PDEATHSIG)`, which Ruby does not expose; polling
`ppid` is portable across Linux / macOS / WSL.

Also install fast-path `Signal.trap` handlers for TERM / INT /
HUP so a clean `kill <pid>` doesn't have to wait for the
`at_exit` round trip; the trap restores the default
disposition before re-raising, so a second signal still
terminates us normally.

The reaper starts as soon as `session_manager.rb` is loaded, so
the first PTY open is already protected. `start_reaper!` is
idempotent.

## Testing

- New spec: `spec/clacky/tools/terminal/session_manager_orphan_reaper_spec.rb`
  exercises the reaper against a synthetic parent PID. 7/7 pass.
- Existing `spec/clacky/tools/terminal_spec.rb`: 112/112 pass,
  no regression.
- The reaper is no-op when no PTY sessions exist (the watchdog
  is ~1 syscall/sec) and does not re-kill sessions already
  marked `exited` / `killed`.