### PR TITLE
fix(mcp): preserve CRLF pairs split across SSE chunk boundaries

### DIFF
--- a/lib/clacky/mcp/http_transport.rb
+++ b/lib/clacky/mcp/http_transport.rb
@@ -141,21 +141,37 @@ module Clacky
 
       private def consume_sse(res)
         buffer = String.new
+        held_cr = false
         res.read_body do |chunk|
+          chunk = "\r#{chunk}" if held_cr
+          # A trailing CR may be the first half of a CRLF pair split across
+          # chunks; hold it back so the pair still normalizes to one "\n"
+          # instead of two, which would fabricate an event boundary.
+          held_cr = chunk.end_with?("\r")
+          chunk = chunk.chomp("\r") if held_cr
           buffer << chunk.gsub("\r\n", "\n").gsub("\r", "\n")
-          while (idx = buffer.index("\n\n"))
-            event = buffer.slice!(0, idx + 2)
-            data_lines = event.each_line.map(&:chomp).select { |l| l.start_with?("data:") }
-            next if data_lines.empty?
-            payload = data_lines.map { |l| l.sub(/\Adata:\s?/, "") }.join("\n")
-            next if payload.empty?
-            begin
-              msg = JSON.parse(payload)
-            rescue JSON::ParserError
-              next
-            end
-            deliver(msg)
+          drain_events(buffer)
+        end
+        return unless held_cr
+
+        # Stream ended while holding a CR: it was a lone CR terminator.
+        buffer << "\n"
+        drain_events(buffer)
+      end
+
+      private def drain_events(buffer)
+        while (idx = buffer.index("\n\n"))
+          event = buffer.slice!(0, idx + 2)
+          data_lines = event.each_line.map(&:chomp).select { |l| l.start_with?("data:") }
+          next if data_lines.empty?
+          payload = data_lines.map { |l| l.sub(/\Adata:\s?/, "") }.join("\n")
+          next if payload.empty?
+          begin
+            msg = JSON.parse(payload)
+          rescue JSON::ParserError
+            next
           end
+          deliver(msg)
         end
       end
 

--- a/spec/clacky/mcp/http_transport_spec.rb
+++ b/spec/clacky/mcp/http_transport_spec.rb
@@ -72,6 +72,28 @@ RSpec.describe Clacky::Mcp::HttpTransport do
       end
     end
 
+    context "when a CRLF between two data lines is split across chunks" do
+      it "keeps both lines in one event" do
+        # The payload only parses when both data lines land in the same
+        # event: normalizing each chunk in isolation turns "\r" | "\n"
+        # into "\n\n", splitting the event in two and corrupting both halves.
+        line1 = '{"jsonrpc": "2.0",'
+        line2 = ' "id": 1, "result": {"ok": true}}'
+        full  = "data: #{line1}\r\ndata: #{line2}\r\n\r\n"
+        split_at = full.index("\r") + 1
+        chunks = [full[0...split_at], full[split_at..]]
+        expect(consume_chunks(transport, chunks)).to eq([payload])
+      end
+    end
+
+    context "when a \\r\\r separator is split across chunks at end of stream" do
+      it "delivers the message" do
+        full = "data: #{json}\r\r"
+        chunks = [full[0...-1], full[-1..]]
+        expect(consume_chunks(transport, chunks)).to eq([payload])
+      end
+    end
+
     context "when multiple events arrive in one chunk" do
       let(:payload2) { { "jsonrpc" => "2.0", "id" => 2, "result" => { "ok" => false } } }
       let(:json2)    { JSON.generate(payload2) }


### PR DESCRIPTION
## What

Fixes a chunk-boundary edge in the MCP HTTP transport's SSE parser: a CRLF pair split across two `read_body` chunks (`\r` at the end of one chunk, `\n` at the start of the next) is currently normalized into two newlines instead of one, fabricating an SSE event boundary.

Related: #379 — the headline `\r\n\r\n` symptom was fixed by d693b14; this hardens the remaining chunk-split case that the per-chunk normalization cannot see.

## Why

`consume_sse` normalizes line endings one chunk at a time (`chunk.gsub("\r\n", "\n").gsub("\r", "\n")`). Chunking is arbitrary — `Net::HTTP` hands the parser whatever the socket delivers — so a `\r\n` pair can straddle two chunks. The lone trailing `\r` is rewritten to `\n` before its `\n` arrives, and the pair becomes `\n\n`.

When that CRLF sat between two `data:` lines of one event, the event is split in two: both halves fail `JSON.parse`, are silently discarded, and the pending request hangs until the read timeout — the same symptom as #379, but intermittent and dependent on where the socket happened to cut the stream.

The fix holds a chunk-trailing `\r` back until the next chunk (or end of stream) shows whether it is half of a CRLF pair or a lone CR terminator. The event-draining loop moves unchanged into `drain_events` so the end-of-stream flush can reuse it; without that flush, a CR-only stream (`\r\r` separators) whose final CR is held back would drop its last event.

## User-visible impact

None in the common case. MCP HTTP servers that emit CRLF SSE with multi-line `data:` payloads no longer drop messages / time out intermittently. No config, no dependencies, no behavior change for `\n\n` streams.

---

## Self-review

### 1. Architecture

- [x] Smallest possible diff for the need
- [x] No new configuration knobs (or justified below)
- [x] No new dependencies (or justified below)
- [x] Fits the existing design / naming / layering

### 2. Need

- [x] Common need that benefits most users, **or** scope and side effects are explained below
- [x] No unintended impact on other users' workflows or defaults

### 3. Code

- [x] All tests pass
- [x] Coverage does not drop; new code has new tests
- [x] Commit messages and this PR are written in English

### Bonus

- [ ] This PR was authored using OpenClacky itself

---

## Notes for reviewers

- Reproduction is in the first new spec: the stream is cut between the `\r` and `\n` of the CRLF separating two `data:` lines. On current main it delivers `[]` (both fragments fail to parse); with the fix it delivers the one joined message.
- The second new spec (`\r\r` split at end of stream) pins the end-of-stream flush for lone-CR terminators.
- Verified on Ruby 3.3.12 / x86_64-linux with `BUNDLE_LOCKFILE=Gemfile.lock.ruby-3.3` (the CI recipe): full `bundle exec rspec` — 3354 examples, 4 failures, and unmodified `main` fails the **same 4** in the identical environment (`terminal_spec.rb:418/:664`, `scripts_manager_spec.rb:8`, `http_server_file_action_display_path_spec.rb:56` — local-container quirks, so CI is the authority there). Net new failures from this change: zero; `spec/clacky/mcp/http_transport_spec.rb` is 13/13 green. Both changed files also parse under Ruby 2.6.10 (`ruby -c`) per the 2.6-compatibility rule.
- Coverage: every line added by the change is executed by the transport specs (checked against SimpleCov per-file data); the only uncovered line in the changed region is the pre-existing `rescue JSON::ParserError` skip, unchanged from `main`.
