### PR TITLE
fix(pricing): bill whole Beijing weekends off-peak for DeepSeek V4

### DIFF
--- a/lib/clacky/utils/model_pricing.rb
+++ b/lib/clacky/utils/model_pricing.rb
@@ -160,7 +160,8 @@ module Clacky
       #   - "cache hit input"  = cache_read rate (DeepSeek has no separate cache-write charge)
       #   - No tiered pricing (single rate regardless of context length)
       # Effective 2026-08-16 16:00 UTC DeepSeek switched to peak/off-peak billing
-      # (off-peak = half of peak; peak = 01:00-04:00 & 06:00-10:00 UTC).
+      # (off-peak = half of peak; peak = 01:00-04:00 & 06:00-10:00 UTC on
+      # weekdays; from 2026-08-22 16:00 UTC whole Beijing weekends are off-peak).
       # Each entry carries legacy/peak/off_peak tiers; calculate_cost resolves
       # the active tier from the request time.
       "deepseek-v4-flash" => {
@@ -757,6 +758,18 @@ module Clacky
     # 2026-08-17 00:00 Beijing time (= 2026-08-16 16:00 UTC).
     DEEPSEEK_PEAK_PRICING_START = Time.utc(2026, 8, 16, 16, 0, 0).freeze
 
+    # From 00:00 Beijing time on 2026-08-23 (= 2026-08-22 16:00 UTC) the whole
+    # of Saturday and Sunday bills off-peak, peak hours included. Weekday
+    # windows are unchanged. Gated like the constant above: requests before
+    # this instant were charged at peak inside the windows, and repricing them
+    # now would be wrong in the same direction for every weekend on record.
+    DEEPSEEK_WEEKEND_OFF_PEAK_START = Time.utc(2026, 8, 22, 16, 0, 0).freeze
+
+    # Beijing time, the zone DeepSeek states the weekend rule in. China has run
+    # a fixed UTC+08:00 with no daylight saving since 1991, so a constant
+    # offset is exact and needs no tzdata on the host.
+    DEEPSEEK_BILLING_UTC_OFFSET = 8 * 60 * 60
+
     class << self
       # Calculate cost for the given model and usage
       #
@@ -1052,17 +1065,38 @@ module Clacky
       def resolve_deepseek_tier(pricing, now)
         if now < DEEPSEEK_PEAK_PRICING_START
           pricing[:legacy]
-        elsif deepseek_peak_hour?(now)
+        elsif deepseek_peak_tier?(now)
           pricing[:peak]
         else
           pricing[:off_peak]
         end
       end
 
+      # Whether the peak tier applies: a weekday window, and not a weekend that
+      # the weekend-wide rule already covers.
+      def deepseek_peak_tier?(time)
+        !deepseek_weekend_off_peak?(time) && deepseek_peak_hour?(time)
+      end
+
       # Peak hours: 01:00-04:00 and 06:00-10:00 UTC (all other hours off-peak).
       def deepseek_peak_hour?(time)
         hour = time.utc.hour
         (hour >= 1 && hour < 4) || (hour >= 6 && hour < 10)
+      end
+
+      # Whether the instant falls on a Beijing-time Saturday or Sunday with the
+      # weekend-wide rule in force.
+      #
+      # The weekend is bounded in Beijing time, so it runs 16:00 UTC Friday to
+      # 16:00 UTC Sunday — a different 48 hours from `time.utc.wday`. Both
+      # spellings agree on today's tiers, because the two peak windows sit
+      # entirely outside the 16 hours they disagree over. This one keeps
+      # agreeing if DeepSeek moves a window past 16:00 UTC.
+      def deepseek_weekend_off_peak?(time)
+        return false if time < DEEPSEEK_WEEKEND_OFF_PEAK_START
+
+        beijing_wday = (time.utc + DEEPSEEK_BILLING_UTC_OFFSET).wday
+        beijing_wday.zero? || beijing_wday == 6
       end
     end
   end

--- a/spec/clacky/server/model_prices_spec.rb
+++ b/spec/clacky/server/model_prices_spec.rb
@@ -84,6 +84,44 @@ RSpec.describe Clacky::Server::ModelPrices do
 
         expect(result[:prices]["dsk-deepseek-v4-flash"]).to eq(in: 0.22, out: 0.66, ratio: (0.22 + 0.66) / base_total)
       end
+
+      # 2026-08-22 16:00 UTC is 00:00 Beijing on Sunday 2026-08-23, when the
+      # weekend-wide rule starts. Instants below are UTC; the Beijing day is in
+      # the comment.
+      it "still bills a weekend peak hour at peak before the rule starts" do
+        result = described_class.build("dsk-deepseek-v4-flash", now: Time.utc(2026, 8, 22, 6, 0, 0)) # Sat 14:00 Beijing
+
+        expect(result[:prices]["dsk-deepseek-v4-flash"]).to eq(in: 0.44, out: 1.32, ratio: (0.44 + 1.32) / base_total)
+      end
+
+      it "bills a weekend peak hour off-peak once the rule is in force" do
+        result = described_class.build("dsk-deepseek-v4-flash", now: Time.utc(2026, 8, 23, 1, 0, 0)) # Sun 09:00 Beijing
+
+        expect(result[:prices]["dsk-deepseek-v4-flash"]).to eq(in: 0.22, out: 0.66, ratio: (0.22 + 0.66) / base_total)
+      end
+
+      it "leaves the following weekday at peak" do
+        result = described_class.build("dsk-deepseek-v4-flash", now: Time.utc(2026, 8, 24, 1, 0, 0)) # Mon 09:00 Beijing
+
+        expect(result[:prices]["dsk-deepseek-v4-flash"]).to eq(in: 0.44, out: 1.32, ratio: (0.44 + 1.32) / base_total)
+      end
+    end
+  end
+
+  # The weekend is bounded in Beijing time, so it runs 16:00 UTC Friday to
+  # 16:00 UTC Sunday. All four instants below are off-peak by the hour either
+  # way, so the tier tests above cannot tell them apart — pinning the predicate
+  # is what keeps the edges right if DeepSeek moves a window past 16:00 UTC.
+  describe "Clacky::Utils::ModelPricing.deepseek_weekend_off_peak?" do
+    {
+      Time.utc(2026, 8, 28, 15, 0, 0) => false, # Fri 23:00 Beijing
+      Time.utc(2026, 8, 28, 16, 0, 0) => true,  # Sat 00:00 Beijing
+      Time.utc(2026, 8, 30, 15, 0, 0) => true,  # Sun 23:00 Beijing
+      Time.utc(2026, 8, 30, 16, 0, 0) => false, # Mon 00:00 Beijing
+    }.each do |at, weekend|
+      it "returns #{weekend} at #{at.utc.strftime('%Y-%m-%dT%H:%MZ')}" do
+        expect(Clacky::Utils::ModelPricing.deepseek_weekend_off_peak?(at)).to eq(weekend)
+      end
     end
   end
 end


### PR DESCRIPTION
`resolve_deepseek_tier` picks the tier from the UTC hour alone. DeepSeek's notice says that from 00:00 Beijing on Sunday 2026-08-23 the whole of Saturday and Sunday bills off-peak, peak hours included — so since yesterday every weekend request landing in `01:00-04:00` or `06:00-10:00` UTC is costed at double what it was charged.

The change adds `DEEPSEEK_WEEKEND_OFF_PEAK_START = Time.utc(2026, 8, 22, 16, 0, 0)` next to the existing `DEEPSEEK_PEAK_PRICING_START` and gates on it the same way, so weekends already on record keep the peak tier they were actually billed at.

The weekend is bounded in **Beijing** time, which is why it reads the weekday off `time.utc + 8 * 60 * 60` rather than `time.utc.wday`. Those two spellings return the same answer for all 168 hours of a week today, because both peak windows sit clear of the 16:00–24:00 UTC seam the calendars disagree over. That is exactly why the four predicate cases in the spec are there: without them, dropping the offset leaves the suite green and the file only starts mispricing the day a window moves.

Specs added: a pre-rule Saturday that must stay at peak, the first Sunday window that changes, the following Monday, and the four 16:00 UTC edges.

Sources: <https://api-docs.deepseek.com/quick_start/pricing>. Vectors for both axes as plain JSON, if useful for a wider check: <https://github.com/xyzs996/deepseek-peak-offpeak-vectors>