### PR TITLE
feat(messages): return assistant timestamps in session history

### DIFF
--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -287,8 +287,9 @@ module Clacky
       # @param limit [Integer] Maximum number of rounds (user turns) to replay
       # @param before [Float, nil] Unix timestamp cursor — only replay rounds where the user message
       #   created_at < before. Pass nil to get the most recent rounds.
+      # @param include_message_metadata [Boolean] Include persisted message metadata in UI callbacks
       # @return [Hash] { has_more: Boolean } — whether older rounds exist beyond this page
-      def replay_history(ui, limit: 20, before: nil)
+      def replay_history(ui, limit: 20, before: nil, include_message_metadata: false)
         # Split @history into rounds, each starting at a real user message
         rounds = []
         current_round = nil
@@ -371,7 +372,9 @@ module Clacky
         # still see the last visible state of the chat (e.g. compressed summary + recent work).
         if rounds.empty?
           visible = @history.to_a.reject { |m| m[:role].to_s == "system" || m[:system_injected] }
-          visible.each { |msg| _replay_single_message(msg, ui) }
+          visible.each do |msg|
+            _replay_single_message(msg, ui, include_message_metadata: include_message_metadata)
+          end
           return { has_more: false }
         end
 
@@ -402,7 +405,7 @@ module Clacky
             # — they are internal scaffolding and must not be shown to the user.
             next if ev[:system_injected]
 
-            _replay_single_message(ev, ui)
+            _replay_single_message(ev, ui, include_message_metadata: include_message_metadata)
           end
         end
 
@@ -712,7 +715,7 @@ module Clacky
 
       # Render a single non-user message into the UI.
       # Used by both the normal round-based replay and the compressed-session fallback.
-      def _replay_single_message(msg, ui)
+      def _replay_single_message(msg, ui, include_message_metadata: false)
         return if msg[:system_injected]
 
         case msg[:role].to_s
@@ -733,7 +736,11 @@ module Clacky
             else
               raw_text
             end
-            ui.show_assistant_message(text, files: [])
+            if include_message_metadata
+              ui.show_assistant_message(text, files: [], created_at: msg[:created_at])
+            else
+              ui.show_assistant_message(text, files: [])
+            end
           end
 
           # Tool calls embedded in assistant message

--- a/lib/clacky/message_history.rb
+++ b/lib/clacky/message_history.rb
@@ -45,6 +45,13 @@ module Clacky
       if message[:role] == "user"
         drop_dangling_tool_calls!
       end
+      # Assistant timestamps are part of the persisted message metadata used
+      # by history consumers.  User messages are stamped by Agent#run at
+      # ingress; assistant messages are stamped here at the single write
+      # boundary so synthetic/error paths cannot accidentally omit the field.
+      if message[:role] == "assistant" && !message.key?(:created_at)
+        message = message.merge(created_at: Time.now.to_f)
+      end
       @messages << deep_sanitize_utf8(message)
       self
     end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -67,12 +67,14 @@ module Clacky
         @events << ev
       end
 
-      def show_assistant_message(content, files:)
+      def show_assistant_message(content, files:, created_at: nil)
         return if content.nil? || content.to_s.strip.empty?
 
         # Rewrite local image paths to /api/local-image proxy URLs for browser rendering
         rewritten = Utils::FileProcessor.rewrite_local_image_urls(content.to_s)
-        @events << { type: "assistant_message", session_id: @session_id, content: rewritten }
+        event = { type: "assistant_message", session_id: @session_id, content: rewritten }
+        event[:created_at] = created_at if created_at
+        @events << event
       end
 
       def show_tool_call(name, args)
@@ -6464,7 +6466,8 @@ module Clacky
         # Collect events emitted by replay_history via a lightweight collector UI
         collected = []
         collector = HistoryCollector.new(session_id, collected)
-        result    = agent.replay_history(collector, limit: limit, before: before)
+        result    = agent.replay_history(collector, limit: limit, before: before,
+                                         include_message_metadata: true)
 
         json_response(res, 200, { events: collected, has_more: result[:has_more] })
       end

--- a/spec/clacky/agent/session_replay_chunk_spec.rb
+++ b/spec/clacky/agent/session_replay_chunk_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "replay_history chunk MD expansion" do
       @events << { type: :user, content: content, created_at: created_at, editable: editable }
     end
 
-    def show_assistant_message(content, files:)
-      @events << { type: :assistant, content: content }
+    def show_assistant_message(content, files:, created_at: nil)
+      @events << { type: :assistant, content: content, created_at: created_at }
     end
 
     def show_tool_call(name, args)
@@ -328,6 +328,20 @@ RSpec.describe "replay_history chunk MD expansion" do
   end
 
   describe "replay_history with compressed sessions" do
+    it "passes a persisted assistant timestamp to the message collector" do
+      assistant_created_at = Time.now.to_f
+      messages = [
+        { role: "user", content: "Question", created_at: assistant_created_at - 1 },
+        { role: "assistant", content: "Answer", created_at: assistant_created_at }
+      ]
+
+      collector = TestCollector.new
+      build_agent(messages).replay_history(collector, include_message_metadata: true)
+
+      assistant = collector.events.find { |event| event[:type] == :assistant }
+      expect(assistant[:created_at]).to eq(assistant_created_at)
+    end
+
     it "expands chunk rounds when history contains only a compressed summary" do
       chunk_path = File.join(sessions_dir, "chunk-1.md")
       File.write(chunk_path, chunk_md(

--- a/spec/clacky/message_history_spec.rb
+++ b/spec/clacky/message_history_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Clacky::MessageHistory do
       expect(history.to_a.first).to include(system_injected: true, task_id: 42)
     end
 
+    it "timestamps assistant messages when the caller omits created_at" do
+      before = Time.now.to_f
+      history.append({ role: "assistant", content: "done" })
+      after = Time.now.to_f
+
+      expect(history.to_a.first[:created_at]).to be_between(before, after)
+    end
+
+    it "preserves an explicit assistant created_at" do
+      history.append({ role: "assistant", content: "done", created_at: 1_700_000_000.25 })
+
+      expect(history.to_a.first[:created_at]).to eq(1_700_000_000.25)
+    end
+
     context "when appending a user message after a dangling assistant+tool_calls" do
       it "drops the dangling assistant message automatically" do
         history.append(user_msg)

--- a/spec/clacky/server/history_collector_spec.rb
+++ b/spec/clacky/server/history_collector_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/http_server"
+
+RSpec.describe Clacky::Server::HistoryCollector do
+  it "returns created_at on assistant message events" do
+    events = []
+    collector = described_class.new("session-1", events)
+
+    collector.show_assistant_message(
+      "Done",
+      files: [],
+      created_at: 1_700_000_000.25
+    )
+
+    expect(events).to contain_exactly(
+      type: "assistant_message",
+      session_id: "session-1",
+      content: "Done",
+      created_at: 1_700_000_000.25
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- stamp assistant messages with created_at when they enter MessageHistory
- preserve the timestamp in session persistence
- include created_at on assistant_message events returned by GET /api/sessions/:id/messages
- keep regular UI replay callbacks unchanged unless message metadata is explicitly requested

## Why

User messages already persist and return creation timestamps, while assistant messages did not. Consumers of the messages endpoint could not determine when an agent response was created without guessing from session-level timestamps.

## User-visible impact

New assistant messages now return a Unix-seconds created_at value from the session messages endpoint. Existing sessions are left unchanged because their original assistant creation times cannot be reconstructed accurately.

## Tests

- rspec
- 3690 examples, 0 failures

Built and verified using OpenClacky.