### PR TITLE
fix: preserve task ids in compressed history

### DIFF
--- a/lib/clacky/agent/message_compressor_helper.rb
+++ b/lib/clacky/agent/message_compressor_helper.rb
@@ -624,7 +624,7 @@ module Clacky
 
           case role
           when "user"
-            lines << "## User"
+            lines << (msg[:task_id] ? "## User [Task #{msg[:task_id]}]" : "## User")
             lines << ""
             lines << format_message_content(content)
             lines << ""

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -494,30 +494,34 @@ module Clacky
         current_role       = nil
         current_lines      = []
         current_nested_chunk = nil  # chunk reference from a Compressed Summary heading
+        current_task_id    = nil
 
         raw.each_line do |line|
           stripped = line.chomp
           if (m = stripped.match(/\A## Assistant \[Compressed Summary — original conversation at: (.+)\]/))
             # Nested chunk reference — record it, treat as assistant section
-            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk } if current_role
+            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
             current_role         = "assistant"
             current_lines        = []
             current_nested_chunk = File.join(chunk_dir, m[1])
-          elsif stripped.match?(/\A## (User|Assistant)/)
-            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk } if current_role
-            current_role         = stripped.match(/\A## (User|Assistant)/)[1].downcase
+            current_task_id      = nil
+          elsif (m = stripped.match(/\A## (User|Assistant)(?: \[Task ([1-9]\d*)\])?\z/))
+            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
+            current_role         = m[1].downcase
             current_lines        = []
             current_nested_chunk = nil
+            current_task_id      = m[2]&.to_i
           elsif stripped.match?(/\A### Tool Result:/)
-            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk } if current_role
+            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
             current_role         = "tool"
             current_lines        = []
             current_nested_chunk = nil
+            current_task_id      = nil
           else
             current_lines << line
           end
         end
-        sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk } if current_role
+        sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
 
         # Remove front-matter / header noise sections (nil role or non-user/assistant/tool)
         sections.select! { |s| %w[user assistant tool].include?(s[:role]) }
@@ -548,14 +552,16 @@ module Clacky
             round_index += 1
             # Synthetic timestamp: spread rounds backwards from archived_at
             synthetic_ts = base_time - (sections.size - round_index) * 1.0
+            user_msg = {
+              role: "user",
+              content: text,
+              created_at: synthetic_ts,
+              ext_events: sec_ext_events,
+              _from_chunk: true
+            }
+            user_msg[:task_id] = sec[:task_id] if sec[:task_id]
             current_round = {
-              user_msg: {
-                role: "user",
-                content: text,
-                created_at: synthetic_ts,
-                ext_events: sec_ext_events,
-                _from_chunk: true
-              },
+              user_msg: user_msg,
               events: [],
               # editable: false — this message was archived into a chunk MD and no
               # longer exists in the active in-memory @history, so it cannot be

--- a/spec/clacky/agent/message_compressor_chunk_spec.rb
+++ b/spec/clacky/agent/message_compressor_chunk_spec.rb
@@ -119,6 +119,14 @@ RSpec.describe "Compression chunk MD archiving" do
       expect(content).to include("Compression reduces token usage.")
     end
 
+    it "preserves the user message task_id in the section heading" do
+      original_messages = [system_msg, user_msg.merge(task_id: 6), assistant_msg]
+      path = agent.send(:save_compressed_chunk, original_messages, [],
+                        chunk_index: 1, compression_level: 1)
+
+      expect(File.read(path)).to include("## User [Task 6]")
+    end
+
     it "includes front matter with session metadata" do
       original_messages = [system_msg, user_msg, assistant_msg]
       path = agent.send(:save_compressed_chunk, original_messages, [],

--- a/spec/clacky/agent/session_replay_chunk_spec.rb
+++ b/spec/clacky/agent/session_replay_chunk_spec.rb
@@ -94,8 +94,19 @@ RSpec.describe "replay_history chunk MD expansion" do
 
       expect(rounds.size).to eq(1)
       expect(rounds.first[:user_msg][:content]).to include("Hello from chunk")
+      expect(rounds.first[:user_msg]).not_to have_key(:task_id)
       expect(rounds.first[:events].first[:content]).to include("Hi there")
       expect(rounds.first[:events].first[:role]).to eq("assistant")
+    end
+
+    it "restores task_id from a task-annotated user heading" do
+      path = File.join(sessions_dir, "chunk-1.md")
+      content = chunk_md(user_content: "Mapped question", assistant_content: "Mapped answer")
+      File.write(path, content.sub("## User", "## User [Task 6]"))
+
+      rounds = build_agent([]).send(:parse_chunk_md_to_rounds, path)
+
+      expect(rounds.first[:user_msg][:task_id]).to eq(6)
     end
 
     it "assigns synthetic created_at timestamps based on archived_at" do


### PR DESCRIPTION
## Background

User messages keep task_id while they remain in session history, and Time Machine task state is persisted independently. During compression, however, the chunk Markdown writer emitted only the user role and content. The chunk parser therefore reconstructed the message without task_id, losing the Message to Task mapping after replay even though the Task and snapshot still existed.

## Changes

- Write task-linked user sections as `## User [Task N]` when archiving compressed history.
- Parse both the annotated heading and the legacy `## User` heading.
- Restore task_id on replayed user messages only when the chunk carries it.
- Add focused coverage for writer preservation, parser restoration, and legacy compatibility.

Existing chunks without a task annotation remain readable; this change does not infer or backfill mappings that were never serialized.

## Test plan

- Full suite: 3732 examples, 0 failures.