### PR TITLE
fix: advisor dismiss button permanently suppresses suggestions until refresh (C-5765)

### DIFF
--- a/lib/clacky/default_extensions/advisor/panels/advisor/view.js
+++ b/lib/clacky/default_extensions/advisor/panels/advisor/view.js
@@ -1,9 +1,9 @@
 // ── Advisor recommendations bar + settings toggle ─────────────────────
 //
 // session.composer slot: recommendation card above the input box. The ✕
-// button dismisses the card for the rest of this page lifetime — purely
-// local, no server call, so a page refresh brings recommendations back.
-// The ⏻ button turns the advisor off globally (persisted to advisor.yml);
+// button dismisses the card for the rest of the current round only - the
+// next round's pending event resets the flag, so recommendations return
+// without a page refresh.// The ⏻ button turns the advisor off globally (persisted to advisor.yml);
 // a toast reminds the user it can be re-enabled in Settings. Clicking an
 // option fills the input box so the user can review (or edit) before
 // sending. Nothing is executed automatically.
@@ -180,24 +180,24 @@
   }
 
   // Module-level state, shared by the card and the settings switch.
-  // dismissed: the user hit ✕ — hide the card for this page lifetime and
-  // ignore incoming events until a refresh (or the settings switch turns
-  // the advisor back on).
-  const state = { mode: "hidden", options: [], fallback: "", errorMessage: "", dismissed: false };
+  // off: the advisor is globally disabled (⏻ button or settings switch) -
+  // ignore incoming events for the rest of this page lifetime.
+  // roundDismissed: the user hit ✕ this round - hide the card and ignore
+  // events until the next round's pending event resets the flag.
+  const state = { mode: "hidden", options: [], fallback: "", errorMessage: "", off: false, roundDismissed: false };
 
   function dismiss() {
-    state.dismissed = true;
+    state.roundDismissed = true;
     state.mode = "hidden";
     redraw();
   }
-
   // Global off: POST the disable endpoint (persisted in advisor.yml) and
   // hide the card; the toast tells the user where to re-enable.
   function turnOff() {
     fetch("/api/ext/advisor/disable", { method: "POST" })
       .then((r) => { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
       .then((d) => {
-        state.dismissed = true;
+        state.off = true;
         state.mode = "hidden";
         redraw();
         if (window.Clacky && Clacky.Modal && Clacky.Modal.toast) {
@@ -227,7 +227,7 @@
   // Build the current card from `state`. Returns null when hidden — the host
   // treats a null result as "render nothing", which clears the slot.
   function renderContent() {
-    if (state.dismissed || state.mode === "hidden") return null;
+    if (state.off || state.mode === "hidden") return null;
 
     const slot = document.createElement("div");
     slot.className = "advisor-card";
@@ -307,7 +307,7 @@
     }
     // The card pushes the message stream up; scroll to the bottom so the
     // last message stays visible instead of being hidden under it.
-    if (!state.dismissed && state.mode !== "hidden") {
+    if (!state.off && state.mode !== "hidden") {
       requestAnimationFrame(() => {
         const m = document.getElementById("messages");
         if (m) m.scrollTop = m.scrollHeight;
@@ -316,12 +316,13 @@
   }
 
   Clacky.ext.subscribe("ext.advisor.pending", () => {
-    if (state.dismissed) return;
+    if (state.off) return;
+    state.roundDismissed = false;
     state.mode = "pending";
     redraw();
   });
   Clacky.ext.subscribe("ext.advisor.recommendations", (payload) => {
-    if (state.dismissed) return;
+    if (state.off || state.roundDismissed) return;
     const content = (payload && (payload.content || payload.advice)) || "";
     const opts = parseOptions(content);
     state.mode = "options";
@@ -330,7 +331,7 @@
     redraw();
   });
   Clacky.ext.subscribe("ext.advisor.done", (payload) => {
-    if (state.dismissed) return;
+    if (state.off || state.roundDismissed) return;
     const reason = payload && payload.reason;
     if (reason === "error" || reason === "empty") {
       state.mode = "error";
@@ -419,7 +420,8 @@
         .then((d) => {
           checkbox.checked = !!d.enabled;
           // Reflect the change on the open composer card immediately.
-          state.dismissed = !d.enabled;
+          state.off = !d.enabled;
+          if (state.off) state.mode = "hidden";
           redraw();
         })
         .catch((err) => {


### PR DESCRIPTION
## Problem

Clicking "Dismiss this round" (✕) on the advisor suggestion card permanently suppressed all future suggestions - even after continuing the conversation, no new cards appeared. Only a full WebUI refresh restored the feature.

Root cause: `view.js` used a single `state.dismissed` flag for both "dismissed this round" (✕ button) and "advisor turned off" (⏻ button / settings switch). Once set, every `ext.advisor.*` event subscriber early-returned for the rest of the page lifetime.

## Fix

Split the conflated flag into two in `lib/clacky/default_extensions/advisor/panels/advisor/view.js`:

- `state.off` — advisor globally disabled (⏻ / settings switch); keeps suppressing for the page lifetime, unchanged behavior.
- `state.roundDismissed` — ✕ clicked this round; reset by the next round's `ext.advisor.pending` event (emitted exactly once per run by the backend's `finish_run`), so the next round's suggestions render normally without a refresh.
- `recommendations` / `done` subscribers now check both flags, so a late result from a dismissed round still cannot pop the card back in.
- The settings toggle now sets `off` and clears the card mode when disabling, preventing a stale card from reappearing after re-enabling.

Backend untouched; no new events, no i18n changes.

## Test

- `bundle exec rspec spec/clacky/default_extensions_advisor_spec.rb` — 25 examples, 0 failures
- `node --check` on the modified view.js
- Full suite before handoff
- Manual WebUI verification: ✕ → next message → card reappears with new suggestions; ✕ during generation → late result stays hidden; ⏻ and settings toggle behavior unchanged