### PR TITLE
fix(advisor): keep recommendation card state per session (C-5764)

### DIFF
--- a/lib/clacky/default_extensions/advisor/panels/advisor/view.js
+++ b/lib/clacky/default_extensions/advisor/panels/advisor/view.js
@@ -1,12 +1,15 @@
 // ── Advisor recommendations bar + settings toggle ─────────────────────
 //
-// session.composer slot: recommendation card above the input box. The ✕
-// button dismisses the card for the rest of the current round only - the
-// next round's pending event resets the flag, so recommendations return
-// without a page refresh.// The ⏻ button turns the advisor off globally (persisted to advisor.yml);
-// a toast reminds the user it can be re-enabled in Settings. Clicking an
-// option fills the input box so the user can review (or edit) before
-// sending. Nothing is executed automatically.
+// session.composer slot: recommendation card above the input box. Card
+// state is keyed by session id - each session's recommendations live in
+// their own bucket, so switching sessions never leaks one session's card
+// into another (and switching back restores it). The ✕ button dismisses
+// the card for the rest of the current round only - the next round's
+// pending event resets the flag, so recommendations return without a
+// page refresh. The ⏻ button turns the advisor off globally (persisted to
+// advisor.yml); a toast reminds the user it can be re-enabled in Settings.
+// Clicking an option fills the input box so the user can review (or edit)
+// before sending. Nothing is executed automatically.
 //
 // settings.tabs + settings.body: an "Advisor" tab with a master on/off
 // switch, persisted to ~/.clacky/advisor.yml via /api/ext/advisor/*.
@@ -179,16 +182,37 @@
     });
   }
 
-  // Module-level state, shared by the card and the settings switch.
-  // off: the advisor is globally disabled (⏻ button or settings switch) -
-  // ignore incoming events for the rest of this page lifetime.
-  // roundDismissed: the user hit ✕ this round - hide the card and ignore
-  // events until the next round's pending event resets the flag.
-  const state = { mode: "hidden", options: [], fallback: "", errorMessage: "", off: false, roundDismissed: false };
+  // Module-level state for the global advisor switch. advisor.yml is a
+  // global config, so `off` applies to every session for the rest of this
+  // page lifetime (⏻ button or settings switch).
+  const state = { off: false };
+
+  // Per-session card state, keyed by sessionId. The bus mirrors every ext.*
+  // event regardless of the active session, so each session's card state must
+  // live in its own bucket: session A's recommendations stay in A while you
+  // view B, and come back when you return to A. roundDismissed: the user hit ✕
+  // this round - hide the card and ignore events until the next round's
+  // pending event resets the flag.
+  //
+  // The host's per-session `create(ctx)` runtime can't hold this - it is only
+  // allocated during a render pass, and background sessions receive events
+  // while they have no render context.
+  const sessionStates = new Map();
+
+  function stateFor(sessionId) {
+    let s = sessionStates.get(sessionId);
+    if (!s) {
+      s = { mode: "hidden", options: [], fallback: "", errorMessage: "", roundDismissed: false };
+      sessionStates.set(sessionId, s);
+    }
+    return s;
+  }
 
   function dismiss() {
-    state.roundDismissed = true;
-    state.mode = "hidden";
+    const s = sessionStates.get(Clacky.ext.context.sessionId);
+    if (!s) return;
+    s.roundDismissed = true;
+    s.mode = "hidden";
     redraw();
   }
   // Global off: POST the disable endpoint (persisted in advisor.yml) and
@@ -198,7 +222,6 @@
       .then((r) => { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
       .then((d) => {
         state.off = true;
-        state.mode = "hidden";
         redraw();
         if (window.Clacky && Clacky.Modal && Clacky.Modal.toast) {
           Clacky.Modal.toast(t("advisor.offHint", "已关闭工作建议，可在设置页重新打开"), {
@@ -224,10 +247,15 @@
       });
   }
 
-  // Build the current card from `state`. Returns null when hidden — the host
-  // treats a null result as "render nothing", which clears the slot.
-  function renderContent() {
-    if (state.off || state.mode === "hidden") return null;
+  // Build the current card for the render context's session. Returns null
+  // when hidden - the host treats a null result as "render nothing", which
+  // clears the slot.
+  function renderContent(ctx) {
+    if (!ctx || !ctx.sessionId || state.off) return null;
+    // Read-only lookup: a session with no advisor event yet has no bucket and
+    // renders nothing, so rendering never allocates state.
+    const s = sessionStates.get(ctx.sessionId);
+    if (!s || s.mode === "hidden") return null;
 
     const slot = document.createElement("div");
     slot.className = "advisor-card";
@@ -264,7 +292,7 @@
     head.appendChild(actions);
     slot.appendChild(head);
 
-    if (state.mode === "pending") {
+    if (s.mode === "pending") {
       const row = document.createElement("div");
       row.className = "advisor-pending";
 
@@ -277,20 +305,20 @@
       return slot;
     }
 
-    if (state.mode === "error") {
+    if (s.mode === "error") {
       const row = document.createElement("div");
       row.className = "advisor-error";
-      row.textContent = state.errorMessage;
+      row.textContent = s.errorMessage;
       slot.appendChild(row);
       return slot;
     }
 
-    if (state.options.length > 0) {
-      renderOptions(slot, state.options);
+    if (s.options.length > 0) {
+      renderOptions(slot, s.options);
     } else {
       const text = document.createElement("div");
       text.className = "advisor-card-text";
-      text.textContent = state.fallback;
+      text.textContent = s.fallback;
       slot.appendChild(text);
     }
     return slot;
@@ -307,7 +335,9 @@
     }
     // The card pushes the message stream up; scroll to the bottom so the
     // last message stays visible instead of being hidden under it.
-    if (!state.off && state.mode !== "hidden") {
+    const active = Clacky.ext.context.sessionId;
+    const s = active ? sessionStates.get(active) : null;
+    if (!state.off && s && s.mode !== "hidden") {
       requestAnimationFrame(() => {
         const m = document.getElementById("messages");
         if (m) m.scrollTop = m.scrollHeight;
@@ -315,36 +345,44 @@
     }
   }
 
-  Clacky.ext.subscribe("ext.advisor.pending", () => {
-    if (state.off) return;
-    state.roundDismissed = false;
-    state.mode = "pending";
-    redraw();
+  Clacky.ext.subscribe("ext.advisor.pending", (payload) => {
+    const sid = payload && payload.sessionId;
+    if (!sid || state.off) return;
+    const s = stateFor(sid);
+    s.roundDismissed = false;
+    s.mode = "pending";
+    if (sid === Clacky.ext.context.sessionId) redraw();
   });
   Clacky.ext.subscribe("ext.advisor.recommendations", (payload) => {
-    if (state.off || state.roundDismissed) return;
+    const sid = payload && payload.sessionId;
+    if (!sid || state.off) return;
+    const s = stateFor(sid);
+    if (s.roundDismissed) return;
     const content = (payload && (payload.content || payload.advice)) || "";
     const opts = parseOptions(content);
-    state.mode = "options";
-    state.options = opts;
-    state.fallback = opts.length > 0 ? "" : content;
-    redraw();
+    s.mode = "options";
+    s.options = opts;
+    s.fallback = opts.length > 0 ? "" : content;
+    if (sid === Clacky.ext.context.sessionId) redraw();
   });
   Clacky.ext.subscribe("ext.advisor.done", (payload) => {
-    if (state.off || state.roundDismissed) return;
+    const sid = payload && payload.sessionId;
+    if (!sid || state.off) return;
+    const s = stateFor(sid);
+    if (s.roundDismissed) return;
     const reason = payload && payload.reason;
     if (reason === "error" || reason === "empty") {
-      state.mode = "error";
-      state.errorMessage = (reason === "error" && payload && payload.message)
+      s.mode = "error";
+      s.errorMessage = (reason === "error" && payload && payload.message)
         ? t("advisor.error", "建议生成失败") + "：" + payload.message
         : t("advisor.empty", "未能生成建议，请稍后重试");
     } else {
-      state.mode = "hidden";
+      s.mode = "hidden";
     }
-    redraw();
+    if (sid === Clacky.ext.context.sessionId) redraw();
   });
 
-  Clacky.ext.ui.mount("session.composer", () => renderContent(), { order: 200 });
+  Clacky.ext.ui.mount("session.composer", (container, ctx) => renderContent(ctx), { order: 200 });
 
   // ── Settings tab: master on/off switch ─────────────────────────────────
 
@@ -421,7 +459,6 @@
           checkbox.checked = !!d.enabled;
           // Reflect the change on the open composer card immediately.
           state.off = !d.enabled;
-          if (state.off) state.mode = "hidden";
           redraw();
         })
         .catch((err) => {


### PR DESCRIPTION
## Problem

Advisor card state lived in a single module-level object, while the ext bus mirrors every `ext.advisor.*` event regardless of the active session. Session A's recommendations stayed visible — and clickable — after switching to another session.

## Fix

Key card state by session id in a `Map`, keeping the global `off` flag at module level (advisor.yml is global config). Subscriptions route each payload to its own bucket and only redraw when the event belongs to the active session; the renderer reads the bucket for its render context and returns null when absent, so a session with no advisor events renders nothing.

The host's per-session `create(ctx)` runtime cannot hold this state: it is only allocated during a render pass, and background sessions receive events while they have no render context.

## Test

- `bundle exec rspec` — 3732 examples, 1 pre-existing failure unrelated to this change (`enabled_for?` reads the real `~/.clacky/advisor.yml` instead of the mocked config; reproduced on a clean HEAD).
- Manual cross-session matrix: A receives a card → switching to B shows none → events for A while viewing B stay hidden → returning to A restores it → ✕ hides it for the round → same-round events stay hidden → next round's pending event restores it.