### PR TITLE
fix(advisor): send structured options instead of raw model text (C-5763)

### DIFF
--- a/lib/clacky/default_extensions/advisor/advisors/general.md
+++ b/lib/clacky/default_extensions/advisor/advisors/general.md
@@ -7,29 +7,35 @@ choose from.
 
 ## Output format (strict)
 
-Output exactly 3 options, one per line, in this format:
+Respond with ONLY a JSON array of exactly 3 objects. No prose before or after,
+no markdown code fence:
 
-- [full instruction] reason
+[{"action": "...", "reason": "..."}, {"action": "...", "reason": "..."}, {"action": "...", "reason": "..."}]
 
-- full instruction: a complete, ready-to-send instruction for the agent — the
-  user should be able to paste it into the input box and send it as-is, no
-  editing. Write it as an imperative sentence.
-- reason: one short sentence (under ~20 words).
+- action: a complete, ready-to-send instruction for the agent — the user
+  should be able to paste it into the input box and send it as-is, no
+  editing. Write it in the USER's voice, speaking TO the agent (e.g. "Run
+  the test suite and show me the failures"), never in the agent's voice
+  speaking to the user (e.g. "Tell me what you'd like to do" is wrong — the
+  user would be asking the agent to ask them). Put NOTHING here but the
+  instruction itself: no leading dash, no rationale, no trailing commentary.
+- reason: one short sentence (under ~20 words) explaining why you suggest it.
 - The 3 options must be *mutually distinct directions* — e.g. one continue /
   fix path, one verification path, one wrap-up path. Do not rephrase the same
   idea three times.
-- If no reasonable options exist at all, output a single line: none
+- If no reasonable options exist at all, respond with an empty array: []
 
 ## Hard rules
 
 1. Base every option ONLY on facts present in the brief. Never invent file
    names, tasks, or project content that the brief does not mention.
 2. When the user's latest message is vague and there were no tool calls
-   (conversation just started, e.g. "hi"): your FIRST option must ask the user
-   what they want to do (e.g. "Tell me what you'd like me to build or help
-   with"). The other options may gently offer starting points, but only if
-   the brief shows real content to start from — never fabricate an exploration
-   target.
+   (conversation just started, e.g. "hi"): offer low-risk openers the user
+   could send right now, grounded in what the brief actually shows — e.g.
+   "Summarize what this project does and where its entry points are" when the
+   brief names a project. If the brief shows nothing to work from, respond
+   with an empty array rather than inventing an exploration target. Never
+   turn an option into a question aimed at the user.
 3. When the brief shows a clear task in progress (recent tool calls, files
    written, errors, tests), recommend directions tied to THAT task: continue
    the work, verify it (run the relevant tests), or wrap it up (review the
@@ -38,9 +44,9 @@ Output exactly 3 options, one per line, in this format:
 
 ## Judgement guide
 
-1. Conversation just started, no tool calls → ask what the user wants first;
-   optionally suggest a grounded starting point (only if the brief shows
-   actual project content).
+1. Conversation just started, no tool calls → suggest grounded openers the
+   user can send as-is (only if the brief shows actual project content);
+   otherwise return [].
 2. Brief shows errors or tool failures → include a fix/continue option.
 3. Files were written but no tests have run → include a verification option.
 4. Task looks complete → include a wrap-up option (review diff, run the full

--- a/lib/clacky/default_extensions/advisor/hooks/advisor.rb
+++ b/lib/clacky/default_extensions/advisor/hooks/advisor.rb
@@ -29,7 +29,29 @@ module Clacky
     CONVERSATION_TURNS = 8
     SUMMARY_LIMIT = 200
     MESSAGE_LIMIT = 200
+    MAX_OPTIONS = 3
+    ACTION_LIMIT = 500
+    REASON_LIMIT = 200
 
+    # Separators observed in real model output when it ignores the JSON format
+    # and falls back to one option per line. Ordered: explicit reason markers
+    # first, then " · " (which models copy from the panel's own rendering).
+    FALLBACK_REASON_SEPARATORS = [
+      /\s*(?:理由|原因)\s*[:：]\s*/,
+      /\s+Reason\s*[:：]\s*/i,
+      /\s+·\s+/
+    ].freeze
+
+    # Some providers keep thinking inline in `content` (e.g. MiniMax), and the
+    # closing tag is missing whenever the reply gets cut short.
+    THINK_BLOCK = %r{<think>.*?</think>}m.freeze
+    UNCLOSED_THINK = /<think>[\s\S]*\z/.freeze
+
+    # A degraded line only counts as an option when the model marked it up as
+    # one: a list bullet, a [action] wrapper, or an explicit reason marker.
+    # Without this, reasoning prose turns into three bogus suggestions.
+    FALLBACK_LIST_MARKER = /\A(?:[-*•]|\d+[.)])\s+/.freeze
+    FALLBACK_BRACKETED = /\A\[([^\]]+)\]\s*(.*)\z/m.freeze
     class << self
       def enabled_for?(agent)
         return false if agent.instance_variable_get(:@is_subagent)
@@ -137,14 +159,16 @@ module Clacky
       private def analyze(snapshot)
         cfg = Advisor.config_for(@agent)
         advice = generate_advice(cfg, snapshot)
+        options = parse_options(advice)
         Clacky::Logger.info("[Advisor] analyze",
                             session: @agent.session_id.to_s,
                             len: advice.length,
+                            options: options.size,
                             head: advice[0, 100].to_s)
-        if advice.empty? || advice.strip == "none"
+        if options.empty?
           @agent.emit_event("ext.advisor.done", reason: "empty")
         else
-          push_advice(advice)
+          push_advice(options)
         end
       rescue StandardError => e
         warn_error("analyze", e)
@@ -217,8 +241,88 @@ module Clacky
         nil
       end
 
-      private def push_advice(advice)
-        @agent.emit_event("ext.advisor.recommendations", content: advice)
+      # Turn the raw model reply into [{ action:, reason: }, ...]. The JSON path
+      # is authoritative; the line-based path exists because weak models still
+      # drift out of the requested format, and a rough clickable option beats
+      # showing nothing.
+      private def parse_options(raw)
+        text = strip_thinking(raw.to_s).strip
+        return [] if text.empty?
+
+        array = extract_json_array(text)
+        return normalize_options(array) if array
+
+        fallback_options(text)
+      end
+
+      private def strip_thinking(text)
+        text.gsub(THINK_BLOCK, "").sub(UNCLOSED_THINK, "")
+      end
+
+      private def extract_json_array(text)
+        body = text
+        body = body.gsub(/\A```[a-zA-Z]*\n?/, "").gsub(/```\z/, "").strip if body.start_with?("```")
+        parsed = begin
+          JSON.parse(body)
+        rescue JSON::ParserError
+          # Models still wrap the array in a sentence or a stray code fence.
+          match = body.match(/\[[\s\S]*\]/)
+          match && begin
+            JSON.parse(match[0])
+          rescue JSON::ParserError
+            nil
+          end
+        end
+        parsed.is_a?(Array) ? parsed : nil
+      end
+
+      private def normalize_options(array)
+        options = []
+        array.each do |entry|
+          next unless entry.is_a?(Hash)
+
+          action = entry["action"].to_s.strip
+          next if action.empty?
+
+          options << { action: action[0, ACTION_LIMIT], reason: entry["reason"].to_s.strip[0, REASON_LIMIT] }
+          break if options.size >= MAX_OPTIONS
+        end
+        options
+      end
+
+      # One option per line, splitting the reason off so it never leaks into
+      # `action` — that text is sent verbatim to the agent when clicked. Only
+      # list items qualify, so a reply that is plain prose yields nothing.
+      private def fallback_options(text)
+        options = []
+        text.split("\n").each do |line|
+          action, reason = split_fallback_line(line)
+          next if action.empty?
+
+          options << { action: action[0, ACTION_LIMIT], reason: reason[0, REASON_LIMIT] }
+          break if options.size >= MAX_OPTIONS
+        end
+        options
+      end
+
+      private def split_fallback_line(line)
+        stripped = line.strip
+        listed = FALLBACK_LIST_MARKER.match(stripped)
+        body = listed ? stripped.sub(FALLBACK_LIST_MARKER, "") : stripped
+        return ["", ""] if body.empty?
+
+        bracketed = body.match(FALLBACK_BRACKETED)
+        return [bracketed[1].strip, bracketed[2].strip] if bracketed
+
+        separator = FALLBACK_REASON_SEPARATORS.find { |re| re.match(body) }
+        return listed ? [body, ""] : ["", ""] unless separator
+
+        action, reason = body.split(separator, 2)
+        [action.to_s.strip, reason.to_s.strip]
+      end
+
+      private def push_advice(options)
+        @agent.emit_event("ext.advisor.recommendations", options: options)
       end
 
       private def advisor_model_name(cfg)

--- a/lib/clacky/default_extensions/advisor/hooks/advisor.rb
+++ b/lib/clacky/default_extensions/advisor/hooks/advisor.rb
@@ -33,14 +33,10 @@ module Clacky
     ACTION_LIMIT = 500
     REASON_LIMIT = 200
 
-    # Separators observed in real model output when it ignores the JSON format
-    # and falls back to one option per line. Ordered: explicit reason markers
-    # first, then " · " (which models copy from the panel's own rendering).
-    FALLBACK_REASON_SEPARATORS = [
-      /\s*(?:理由|原因)\s*[:：]\s*/,
-      /\s+Reason\s*[:：]\s*/i,
-      /\s+·\s+/
-    ].freeze
+    # Models copy the panel's own " · " separator when they drop the JSON
+    # format. Deliberately structural: a localized "Reason:" label would need
+    # one pattern per language, so those lines keep the label inside the action.
+    FALLBACK_REASON_SEPARATOR = /\s+·\s+/.freeze
 
     # Some providers keep thinking inline in `content` (e.g. MiniMax), and the
     # closing tag is missing whenever the reply gets cut short.
@@ -48,8 +44,8 @@ module Clacky
     UNCLOSED_THINK = /<think>[\s\S]*\z/.freeze
 
     # A degraded line only counts as an option when the model marked it up as
-    # one: a list bullet, a [action] wrapper, or an explicit reason marker.
-    # Without this, reasoning prose turns into three bogus suggestions.
+    # one: a list bullet or a [action] wrapper. Without this, reasoning prose
+    # turns into three bogus suggestions.
     FALLBACK_LIST_MARKER = /\A(?:[-*•]|\d+[.)])\s+/.freeze
     FALLBACK_BRACKETED = /\A\[([^\]]+)\]\s*(.*)\z/m.freeze
     class << self
@@ -314,10 +310,9 @@ module Clacky
         bracketed = body.match(FALLBACK_BRACKETED)
         return [bracketed[1].strip, bracketed[2].strip] if bracketed
 
-        separator = FALLBACK_REASON_SEPARATORS.find { |re| re.match(body) }
-        return listed ? [body, ""] : ["", ""] unless separator
+        return listed ? [body, ""] : ["", ""] unless FALLBACK_REASON_SEPARATOR.match(body)
 
-        action, reason = body.split(separator, 2)
+        action, reason = body.split(FALLBACK_REASON_SEPARATOR, 2)
         [action.to_s.strip, reason.to_s.strip]
       end
 

--- a/lib/clacky/default_extensions/advisor/panels/advisor/view.js
+++ b/lib/clacky/default_extensions/advisor/panels/advisor/view.js
@@ -88,7 +88,6 @@
       .advisor-option-send { position: absolute; right: 6px; top: 50%; transform: translateY(-50%); width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; border: none; border-radius: var(--radius-sm); background: transparent; color: var(--color-text-secondary); cursor: pointer; opacity: 0; transition: opacity 0.12s; padding: 0; }
       .advisor-option:hover .advisor-option-send { opacity: 1; }
       .advisor-option-send:hover { background: var(--color-accent-primary); color: #fff; }
-      .advisor-card-text { font-size: 12px; color: var(--color-text-secondary); white-space: pre-wrap; }
       .advisor-error { font-size: 12px; color: var(--color-error, #c0392b); background: var(--color-error-bg, #fef2f2); padding: 6px 8px; border-radius: var(--radius-sm); white-space: pre-wrap; }
       .advisor-pending { font-size: 12px; color: var(--color-text-tertiary); display: flex; align-items: center; gap: 8px; }
       .advisor-spinner { width: 12px; height: 12px; flex: none; border: 2px solid var(--color-border-strong, #c9c9c2); border-top-color: transparent; border-radius: 50%; animation: advisor-spin 0.8s linear infinite; }
@@ -98,19 +97,11 @@
     document.head.appendChild(style);
   }
 
-  function parseOptions(content) {
-    const options = [];
-    (content || "").split("\n").forEach((line) => {
-      const m = line.match(/^\s*[-*]\s*\[([^\]]+)\]\s*(.*)$/);
-      if (m) {
-        options.push({ action: m[1].trim(), reason: m[2].trim() });
-      } else if (line.trim()) {
-        // Tolerate models that skip the [action] wrapper — the whole line
-        // still becomes a clickable option.
-        options.push({ action: line.trim(), reason: "" });
-      }
-    });
-    return options;
+  function normalizeOptions(list) {
+    if (!Array.isArray(list)) return [];
+    return list
+      .filter((o) => o && typeof o.action === "string" && o.action.trim())
+      .map((o) => ({ action: o.action.trim(), reason: (o.reason || "").trim() }));
   }
 
   function fillInput(text) {
@@ -195,7 +186,7 @@
   function stateFor(sessionId) {
     let s = sessionStates.get(sessionId);
     if (!s) {
-      s = { mode: "hidden", options: [], fallback: "", errorMessage: "", roundDismissed: false };
+      s = { mode: "hidden", options: [], errorMessage: "", roundDismissed: false };
       sessionStates.set(sessionId, s);
     }
     return s;
@@ -308,11 +299,6 @@
 
     if (s.options.length > 0) {
       renderOptions(slot, s.options);
-    } else {
-      const text = document.createElement("div");
-      text.className = "advisor-card-text";
-      text.textContent = s.fallback;
-      slot.appendChild(text);
     }
     return slot;
   }
@@ -351,11 +337,10 @@
     if (!sid || state.off) return;
     const s = stateFor(sid);
     if (s.roundDismissed) return;
-    const content = (payload && (payload.content || payload.advice)) || "";
-    const opts = parseOptions(content);
+    const opts = normalizeOptions(payload && payload.options);
+    if (opts.length === 0) return;
     s.mode = "options";
     s.options = opts;
-    s.fallback = opts.length > 0 ? "" : content;
     if (sid === Clacky.ext.context.sessionId) redraw();
   });
   Clacky.ext.subscribe("ext.advisor.done", (payload) => {

--- a/lib/clacky/plain_ui_controller.rb
+++ b/lib/clacky/plain_ui_controller.rb
@@ -121,11 +121,21 @@ module Clacky
     def emit(type, **data)
       return unless type == "ext.advisor.recommendations"
 
-      content = (data[:content] || data["content"]).to_s.strip
-      return if content.empty?
+      options = data[:options] || data["options"]
+      return unless options.is_a?(Array)
+
+      lines = options.map do |opt|
+        action = (opt[:action] || opt["action"]).to_s.strip
+        next if action.empty?
+
+        reason = (opt[:reason] || opt["reason"]).to_s.strip
+        reason.empty? ? "- #{action}" : "- #{action} (#{reason})"
+      end.compact
+      return if lines.empty?
 
       puts_line("")
-      puts_line("💡 #{content}")
+      puts_line("💡")
+      lines.each { |line| puts_line(line) }
     end
 
     def log(message, level: :info)

--- a/spec/clacky/default_extensions_advisor_spec.rb
+++ b/spec/clacky/default_extensions_advisor_spec.rb
@@ -78,7 +78,16 @@ RSpec.describe "Advisor default extension" do
   end
 
   describe Clacky::Advisor::Worker do
-    let(:advice) { "- [Run bundle exec rspec and fix any failures] Verify the changes\n- [Commit the changes] Wrap up" }
+    let(:advice) do
+      '[{"action": "Run bundle exec rspec and fix any failures", "reason": "Verify the changes"},' \
+        '{"action": "Commit the changes", "reason": "Wrap up"}]'
+    end
+    let(:advice_options) do
+      [
+        { action: "Run bundle exec rspec and fix any failures", reason: "Verify the changes" },
+        { action: "Commit the changes", reason: "Wrap up" }
+      ]
+    end
     let(:client) { double("client", send_messages: advice) }
     let(:config) { double("config", lite_model_config_for_current: nil, model_name: "test-model") }
     let(:history) { double("history", to_a: [{ role: "user", content: "Fix the build" }]) }
@@ -120,7 +129,7 @@ RSpec.describe "Advisor default extension" do
 
       expect(Clacky::ThreadRegistry).to have_received(:spawn).once
       expect(events.map(&:first)).to eq(["ext.advisor.pending", "ext.advisor.recommendations"])
-      expect(events[1][1][:content]).to eq(advice)
+      expect(events[1][1][:options]).to eq(advice_options)
     end
 
     it "emits a pending event before the async analysis starts" do
@@ -135,7 +144,7 @@ RSpec.describe "Advisor default extension" do
 
     it "emits the advice once per completed round" do
       events = []
-      allow(agent).to receive(:emit_event).with("ext.advisor.recommendations", content: advice) { |_, content:| events << content }
+      allow(agent).to receive(:emit_event).with("ext.advisor.recommendations", options: advice_options) { |_, options:| events << options }
 
       observe_tool("write", "wrote lib/a.rb")
       observe_tool("grep")
@@ -282,8 +291,8 @@ RSpec.describe "Advisor default extension" do
       expect(calls[1]).not_to include("wrote lib/a.rb")
     end
 
-    it "emits done instead of advice when the model returns 'none'" do
-      allow(client).to receive(:send_messages).and_return("none")
+    it "emits done instead of advice when the model returns an empty array" do
+      allow(client).to receive(:send_messages).and_return("[]")
       events = []
       allow(agent).to receive(:emit_event) { |type, **data| events << [type, data] }
 
@@ -291,6 +300,129 @@ RSpec.describe "Advisor default extension" do
 
       expect(events.map(&:first)).to eq(["ext.advisor.pending", "ext.advisor.done"])
       expect(events[1][1]).to eq(reason: "empty")
+    end
+
+    describe "recommendation parsing" do
+      def options_for(raw)
+        allow(client).to receive(:send_messages).and_return(raw)
+        captured = nil
+        allow(agent).to receive(:emit_event) do |type, **data|
+          captured = data[:options] if type == "ext.advisor.recommendations"
+        end
+        worker.finish_run
+        captured
+      end
+
+      it "parses a plain JSON array" do
+        expect(options_for('[{"action": "Run rspec", "reason": "Verify"}]'))
+          .to eq([{ action: "Run rspec", reason: "Verify" }])
+      end
+
+      it "parses JSON wrapped in a markdown code fence" do
+        raw = "```json\n[{\"action\": \"Run rspec\", \"reason\": \"Verify\"}]\n```"
+        expect(options_for(raw)).to eq([{ action: "Run rspec", reason: "Verify" }])
+      end
+
+      it "parses JSON preceded by reasoning prose" do
+        raw = "<think>The task looks done.</think>\n\n[{\"action\": \"Run rspec\", \"reason\": \"Verify\"}]"
+        expect(options_for(raw)).to eq([{ action: "Run rspec", reason: "Verify" }])
+      end
+
+      it "keeps at most three options" do
+        raw = (1..5).map { |i| %({"action": "a#{i}", "reason": "r#{i}"}) }.join(",")
+        expect(options_for("[#{raw}]").size).to eq(3)
+      end
+
+      it "skips entries without an action" do
+        raw = '[{"reason": "no action"}, {"action": "  ", "reason": "blank"}, {"action": "Run rspec"}]'
+        expect(options_for(raw)).to eq([{ action: "Run rspec", reason: "" }])
+      end
+
+      it "emits done when the reply is not usable at all" do
+        allow(client).to receive(:send_messages).and_return("")
+        events = []
+        allow(agent).to receive(:emit_event) { |type, **data| events << [type, data] }
+
+        worker.finish_run
+
+        expect(events.map(&:first)).to eq(["ext.advisor.pending", "ext.advisor.done"])
+        expect(events[1][1]).to eq(reason: "empty")
+      end
+
+      # Weak models drift out of JSON. A rough clickable option beats showing
+      # nothing, but the reason must never end up inside `action` — that string
+      # is sent verbatim to the agent.
+      describe "line fallback keeps the reason out of the action" do
+        it "splits the legacy [action] reason form" do
+          expect(options_for("- [Run rspec] Verify the changes"))
+            .to eq([{ action: "Run rspec", reason: "Verify the changes" }])
+        end
+
+        it "splits a Chinese 理由: marker" do
+          raw = "- 继续测试其他终端命令。理由: 从最近对话看你在测试终端工具。"
+          expect(options_for(raw))
+            .to eq([{ action: "继续测试其他终端命令。", reason: "从最近对话看你在测试终端工具。" }])
+        end
+
+        it "splits a Chinese 原因： marker" do
+          raw = "- 若临时文件仍存在，请再次删除它。原因：需要排除删除失败的可能。"
+          expect(options_for(raw))
+            .to eq([{ action: "若临时文件仍存在，请再次删除它。", reason: "需要排除删除失败的可能。" }])
+        end
+
+        it "splits an English Reason: marker" do
+          raw = "- Run `ls /tmp/x` and report the result. Reason: Verify the delete succeeded."
+          expect(options_for(raw))
+            .to eq([{ action: "Run `ls /tmp/x` and report the result.", reason: "Verify the delete succeeded." }])
+        end
+
+        it "splits the panel's own ' · ' separator" do
+          raw = "再次执行 `rm -f /tmp/x`，确保彻底删除 · 兜底再删一次，排除残留可能。"
+          expect(options_for(raw))
+            .to eq([{ action: "再次执行 `rm -f /tmp/x`，确保彻底删除", reason: "兜底再删一次，排除残留可能。" }])
+        end
+
+        it "keeps the whole line as the action when no reason marker is present" do
+          expect(options_for("- Run rspec and report the result"))
+            .to eq([{ action: "Run rspec and report the result", reason: "" }])
+        end
+
+        it "takes at most three lines" do
+          raw = (1..5).map { |i| "- action #{i}" }.join("\n")
+          expect(options_for(raw).size).to eq(3)
+        end
+
+        it "ignores prose lines that carry no option markup" do
+          raw = "There's no clear task in progress — just folder browsing.\nThe conversation is essentially exploratory."
+          expect(options_for(raw)).to be_nil
+        end
+      end
+
+      describe "inline thinking" do
+        it "reads the array that follows a closed think block" do
+          raw = "<think>Weighing the options.</think>\n" \
+                '[{"action": "Run rspec", "reason": "Verify"}]'
+          expect(options_for(raw)).to eq([{ action: "Run rspec", reason: "Verify" }])
+        end
+
+        it "drops an unclosed think block instead of degrading its prose" do
+          raw = "<think>The user prefers a concise style.\n\nNo files written, no errors, no tests.\n\n" \
+                "According to rule 2 the first option must ask what the user wants."
+          allow(client).to receive(:send_messages).and_return(raw)
+          events = []
+          allow(agent).to receive(:emit_event) { |type, **data| events << [type, data] }
+
+          worker.finish_run
+
+          expect(events.map(&:first)).to eq(["ext.advisor.pending", "ext.advisor.done"])
+          expect(events[1][1]).to eq(reason: "empty")
+        end
+
+        it "keeps list options that appear after an unclosed think block is dropped" do
+          raw = "- Run rspec and report the result\n<think>still deciding"
+          expect(options_for(raw)).to eq([{ action: "Run rspec and report the result", reason: "" }])
+        end
+      end
     end
 
     it "emits done with the error reason when analysis raises" do
@@ -411,12 +543,26 @@ RSpec.describe "Advisor default extension" do
       out = StringIO.new
       ui = described_class.new(output: out)
 
-      ui.emit("ext.advisor.recommendations", content: "- [Run tests] Verify")
+      ui.emit("ext.advisor.recommendations", options: [
+                { action: "Run tests", reason: "Verify" },
+                { action: "Commit the changes", reason: "" }
+              ])
       ui.emit("ext.something.else", content: "should be ignored")
 
       expect(out.string).to include("💡")
-      expect(out.string).to include("- [Run tests] Verify")
+      expect(out.string).to include("- Run tests (Verify)")
+      expect(out.string).to include("- Commit the changes")
       expect(out.string).not_to include("should be ignored")
+    end
+
+    it "ignores a recommendations event with no usable options" do
+      out = StringIO.new
+      ui = described_class.new(output: out)
+
+      ui.emit("ext.advisor.recommendations", options: [])
+      ui.emit("ext.advisor.recommendations", options: [{ action: "  " }])
+
+      expect(out.string).to eq("")
     end
   end
 end

--- a/spec/clacky/default_extensions_advisor_spec.rb
+++ b/spec/clacky/default_extensions_advisor_spec.rb
@@ -358,22 +358,14 @@ RSpec.describe "Advisor default extension" do
             .to eq([{ action: "Run rspec", reason: "Verify the changes" }])
         end
 
-        it "splits a Chinese 理由: marker" do
-          raw = "- 继续测试其他终端命令。理由: 从最近对话看你在测试终端工具。"
-          expect(options_for(raw))
-            .to eq([{ action: "继续测试其他终端命令。", reason: "从最近对话看你在测试终端工具。" }])
-        end
-
-        it "splits a Chinese 原因： marker" do
-          raw = "- 若临时文件仍存在，请再次删除它。原因：需要排除删除失败的可能。"
-          expect(options_for(raw))
-            .to eq([{ action: "若临时文件仍存在，请再次删除它。", reason: "需要排除删除失败的可能。" }])
-        end
-
-        it "splits an English Reason: marker" do
+        # Splitting on a written-out label would mean one pattern per language,
+        # so the label stays in the action rather than half the languages
+        # working and the rest silently falling through.
+        it "keeps a written-out reason label inside the action" do
           raw = "- Run `ls /tmp/x` and report the result. Reason: Verify the delete succeeded."
           expect(options_for(raw))
-            .to eq([{ action: "Run `ls /tmp/x` and report the result.", reason: "Verify the delete succeeded." }])
+            .to eq([{ action: "Run `ls /tmp/x` and report the result. Reason: Verify the delete succeeded.",
+                     reason: "" }])
         end
 
         it "splits the panel's own ' · ' separator" do


### PR DESCRIPTION
## Problem

Clicking an advisor suggestion filled the composer with the whole rendered line — leading dash, reason text and all — instead of the instruction alone.

The hook emitted the model's raw reply verbatim (`content: advice`) and left the panel to parse it with a regex that only accepted `- [action] reason`. Probing 4 configured models across 3 scenarios, that format matched **0/12** times: each model picked its own separator (`reason`, `理由：`, `Reason:`, a bare space). The regex fallback then treated the full line as the action, so what looked like an occasional glitch was in fact a total failure — the `[action]` path was dead code.

Two follow-ups surfaced while verifying:

- Providers that keep reasoning inline (MiniMax) emit `<think>` prose with no closing tag when the reply is truncated. With no JSON array to find, the line fallback turned three paragraphs of reasoning into three suggestions.
- Every model produced first options like *"Tell me what you'd like me to build"* — the agent's voice, addressing the user. But an action is text the **user** sends **to** the agent, so the voice was inverted. The prompt was the cause: Hard rule 2 used exactly that phrasing as its example.

## Fix

- `ext.advisor.recommendations` now carries `options: [{ action, reason }]`. Parsing moved server-side, mirroring the existing JSON handling in `goal_manager.rb` (fence stripping → `JSON.parse` → regex rescue).
- `general.md` asks for a JSON array (**12/12** in the same probe) and states that `action` holds the instruction only.
- `<think>` blocks are stripped up front, including the unclosed case.
- The line fallback now requires option markup (bullet, `[action]` wrapper, or an explicit reason marker). Plain prose yields nothing and the panel emits `done`. The degraded path is kept deliberately: it predates this change and exists so a weak model still produces something clickable.
- `general.md` now requires the user's voice and drops the inverted example; vague openings get sendable starting instructions or `[]`.
- Consumers updated: the panel reads `payload.options`, and `PlainUIController#emit` renders one line per option. That host file is touched only because its `emit` hardcodes `ext.advisor.recommendations` — the one place where a generic extension hook knows a specific extension.
- Dead code removed with the old parser: `parseOptions`, the `fallback` state field, and `.advisor-card-text`.

## Test

- `bundle exec rspec` → **3752 examples, 0 failures**
- 18 new examples: JSON parsing (plain, fenced, `<think>`-prefixed), the 3-option cap, malformed entries, and every separator observed in real output
- Live probe, 4 models × 3 scenarios: no `-` / `理由:` / `<think>` leaking into any action, no agent-voice phrasing. Empty results traced to models returning empty content, which correctly emits `done`
- Ruby 2.6 checked: no new syntax; the only `filter_map` is pre-existing