### PR TITLE
fix(channel): detach channel_ui and keep channel_info unique on /bind and /unbind (C-5762)

### DIFF
--- a/lib/clacky/server/channel/channel_manager.rb
+++ b/lib/clacky/server/channel/channel_manager.rb
@@ -26,16 +26,20 @@ module Clacky
       # @param session_builder    [Proc] (name:, working_dir:) => session_id — from HttpServer
       # @param run_agent_task     [Proc] (session_id, agent, &task) — from HttpServer
       # @param interrupt_session  [Proc] (session_id) — from HttpServer
+      # @param persist_session    [Proc] (agent) — from HttpServer; flushes the agent to
+      #   its session file. Needed because clearing a stale channel_info must survive a
+      #   restart, and ChannelManager has no direct access to the session store.
       # @param channel_config     [Clacky::ChannelConfig]
       # @param binding_mode       [:chat | :chat_user | :user] how to map IM identities to sessions.
       #   :chat (default)      — one session per chat (all users in a chat share it).
       #   :chat_user           — one session per (chat, user) pair.
       #   :user                — one session per user (merges all chats).
-      def initialize(session_registry:, session_builder:, run_agent_task:, interrupt_session:, channel_config:, binding_mode: :chat)
+      def initialize(session_registry:, session_builder:, run_agent_task:, interrupt_session:, channel_config:, persist_session: nil, binding_mode: :chat)
         @registry          = session_registry
         @session_builder   = session_builder
         @run_agent_task    = run_agent_task
         @interrupt_session = interrupt_session
+        @persist_session   = persist_session
         @channel_config    = channel_config
         @binding_mode      = binding_mode
         @adapters          = []
@@ -391,31 +395,48 @@ module Clacky
           end
 
           # Detach channel_ui from the old session's web_ui, reattach to the new one.
-          # Also clear the old session's persisted agent.channel_info if it still
-          # matches this key — keeping channel_keys and channel_info strictly in sync
-          # so resolve_session never sees two sessions claim the same key via different
-          # sources (see comment in resolve_session).
+          # Stale channel_info for this key is then cleared from every other session
+          # (including ones evicted from memory) so resolve_session and
+          # restore_channel_bindings never see two sessions claim the same key.
           old_session_id = resolve_session(event)
           channel_ui = old_session_id ? channel_ui_for_session(old_session_id) : nil
+          cleared_agent = nil
 
           if channel_ui
             @registry.with_session(old_session_id) do |s|
               s[:ui]&.unsubscribe_channel(channel_ui)
               s.delete(:channel_ui)
-              if s[:agent]&.respond_to?(:channel_info=) && s[:agent].respond_to?(:channel_info) &&
-                 s[:agent].channel_info && channel_key_from_info(s[:agent].channel_info) == key
-                s[:agent].channel_info = nil
+              agent = s[:agent]
+              if agent&.channel_info && channel_key_from_info(agent.channel_info) == key
+                agent.channel_info = nil
+                cleared_agent = agent
               end
             end
           else
             channel_ui = ChannelUIController.new(event, -> { adapter_for(event[:platform]) }, -> { @channel_config.status_messages_enabled? }, -> { @channel_config.process_messages_enabled? })
           end
 
+          @persist_session&.call(cleared_agent) if cleared_agent
+          clear_channel_info_for_key(key, keep_session_id: session_id)
+
           bind_key_to_session(key, session_id)
+          bound_agent = nil
           @registry.with_session(session_id) do |s|
             s[:ui]&.subscribe_channel(channel_ui)
             s[:channel_ui] = channel_ui
+
+            # Stamp channel_info now instead of waiting for the next inbound message
+            # (see route_message): a restart in between would otherwise find no session
+            # carrying this key and drop the binding.
+            agent = s[:agent]
+            if agent
+              agent.channel_info = extract_channel_info(event)
+              bound_agent = agent
+            end
           end
+
+          # Flush outside with_session: the registry mutex must not be held across file IO.
+          @persist_session&.call(bound_agent) if bound_agent
 
           Clacky::Logger.info("[ChannelManager] Bound #{key} -> session #{session_id[0, 8]}")
           adapter.send_text(chat_id, "Bound to session `#{session_id[0, 8]}`.")
@@ -431,21 +452,43 @@ module Clacky
 
         when "/unbind"
           unbound = false
+          cleared_agents = []
           @registry.list.each do |summary|
             @registry.with_session(summary[:id]) do |s|
-              if s[:channel_keys]&.delete(key)
-                unbound = true
-                # Keep agent.channel_info in sync with channel_keys (see resolve_session).
-                # Without this, after process restart + eviction, the fallback path would
-                # silently re-bind this key back to the unbinded session via stale
-                # channel_info, defeating /unbind.
-                if s[:agent]&.respond_to?(:channel_info=) && s[:agent].respond_to?(:channel_info) &&
-                   s[:agent].channel_info && channel_key_from_info(s[:agent].channel_info) == key
-                  s[:agent].channel_info = nil
-                end
+              # Set#delete always returns self — use delete? so an unknown key
+              # reports "No binding found." instead of a false "Unbound.".
+              next unless s[:channel_keys]&.delete?(key)
+
+              unbound = true
+
+              agent = s[:agent]
+              if agent&.channel_info && channel_key_from_info(agent.channel_info) == key
+                # Clear in memory here rather than relying on clear_channel_info_for_key:
+                # that scan reads the on-disk summary, which misses a channel_info that
+                # was stamped on this live agent but not persisted yet.
+                agent.channel_info = nil
+                cleared_agents << agent
+              end
+
+              # Detach channel_ui once the last key is gone, otherwise outbound
+              # broadcasts keep reaching the IM chat through web_ui's subscriber
+              # list even though inbound messages no longer resolve this session.
+              # Keys are a Set: a session may still be reachable via another key.
+              if s[:channel_keys].empty?
+                s[:ui]&.unsubscribe_channel(s[:channel_ui]) if s[:channel_ui]
+                s.delete(:channel_ui)
               end
             end
           end
+
+          if unbound
+            cleared_agents.each { |agent| @persist_session&.call(agent) }
+            # Drop channel_info everywhere else too: restore_channel_bindings would
+            # otherwise hand the key to an older session that still carries a stale
+            # copy on disk, silently re-binding it after a restart.
+            clear_channel_info_for_key(key)
+          end
+
           adapter.send_text(chat_id, unbound ? "Unbound." : "No binding found.")
 
         when "/status"
@@ -748,6 +791,38 @@ module Clacky
           end
         end
         result
+      end
+
+      # Clear a stale agent.channel_info for `key` across every session except
+      # `keep_session_id`. Every inbound message stamps channel_info onto the
+      # bound agent (see route_message), so switching bindings leaves the field
+      # behind on older sessions. Those leftovers are what restore_channel_bindings
+      # reads at startup, letting an abandoned session silently reclaim the key.
+      # The on-disk summary is authoritative here, so sessions evicted from
+      # memory are cleaned too — which is exactly the case /bind used to miss.
+      def clear_channel_info_for_key(key, keep_session_id: nil)
+        @registry.list(limit: nil).each do |summary|
+          next if summary[:id] == keep_session_id
+
+          info = summary[:channel_info]
+          next unless info.is_a?(Hash) && info[:platform] && info[:user_id] && info[:chat_id]
+          next unless channel_key_from_info(info) == key
+          next unless @registry.ensure(summary[:id])
+
+          cleared = nil
+          @registry.with_session(summary[:id]) do |s|
+            agent = s[:agent]
+            next unless agent&.channel_info && channel_key_from_info(agent.channel_info) == key
+
+            agent.channel_info = nil
+            cleared = agent
+          end
+          next unless cleared
+
+          # Flush outside with_session: the registry mutex must not be held across file IO.
+          @persist_session&.call(cleared)
+          Clacky::Logger.info("[ChannelManager] Cleared stale channel_info #{key} from session #{summary[:id][0, 8]}")
+        end
       end
 
       def bind_key_to_session(key, session_id)

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -254,6 +254,9 @@ module Clacky
           session_builder:   method(:build_session),
           run_agent_task:    method(:run_agent_task),
           interrupt_session: method(:interrupt_session),
+          # No updated_at: clearing a stale channel_info must not bump the session's
+          # position in the newest-first list.
+          persist_session:   ->(agent) { @session_manager.save(agent.to_session_data) },
           channel_config:    Clacky::ChannelConfig.load
         )
         @browser_manager = Clacky::BrowserManager.instance

--- a/spec/clacky/server/channel/channel_manager_binding_spec.rb
+++ b/spec/clacky/server/channel/channel_manager_binding_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/channel"
+require "clacky/server/web_ui_controller"
+
+RSpec.describe Clacky::Channel::ChannelManager do
+  let(:sent) { [] }
+  let(:adapter) do
+    rec = sent
+    double("adapter").tap do |a|
+      allow(a).to receive(:send_text) { |_chat_id, text, _opts| rec << text }
+    end
+  end
+
+  let(:session_id) { "sess_1111aaaa" }
+  let(:event) { { platform: :weixin, chat_id: "chat_1", user_id: "user_1", message_id: "msg_1" } }
+  let(:key) { "weixin:chat:chat_1" }
+  let(:web_ui) { Clacky::Server::WebUIController.new(session_id, ->(_sid, _ev) {}) }
+  let(:channel_ui) do
+    Clacky::Channel::ChannelUIController.new(event, -> { adapter }, -> { false }, -> { false })
+  end
+  let(:agent) { double("agent", channel_info: { platform: "weixin", chat_id: "chat_1", user_id: "user_1" }) }
+
+  let(:persisted) { [] }
+
+  let(:session) do
+    {
+      ui: web_ui,
+      channel_ui: channel_ui,
+      agent: agent,
+      channel_keys: Set.new([key])
+    }
+  end
+
+  let(:registry) do
+    store = session
+    sid = session_id
+    double("registry").tap do |r|
+      allow(r).to receive(:list).and_return([{ id: sid, source: "channel" }])
+      allow(r).to receive(:list).with(limit: nil).and_return([{ id: sid, source: "channel" }])
+      allow(r).to receive(:ensure).and_return(true)
+      allow(r).to receive(:with_session).with(sid).and_yield(store)
+    end
+  end
+
+  let(:manager) do
+    rec = persisted
+    described_class.new(
+      session_registry: registry,
+      session_builder: ->(**_kw) { session_id },
+      run_agent_task: ->(*) {},
+      interrupt_session: ->(*) {},
+      persist_session: ->(a) { rec << a },
+      channel_config: double("channel_config"),
+      binding_mode: :chat
+    )
+  end
+
+  before do
+    web_ui.subscribe_channel(channel_ui)
+    allow(agent).to receive(:channel_info=)
+  end
+
+  def unbind
+    manager.handle_command(adapter, event, "/unbind")
+  end
+
+  describe "/bind" do
+    let(:target_id) { "sess_2222bbbb" }
+    let(:target_agent) { double("target_agent", channel_info: nil) }
+    let(:target_ui) { Clacky::Server::WebUIController.new(target_id, ->(_sid, _ev) {}) }
+    let(:target_session) { { ui: target_ui, agent: target_agent, channel_keys: Set.new } }
+
+    before do
+      allow(target_agent).to receive(:channel_info=)
+      rows = [{ id: session_id, source: "channel" }, { id: target_id, source: "channel" }]
+      allow(registry).to receive(:list).and_return(rows)
+      allow(registry).to receive(:list).with(limit: nil).and_return(rows)
+      allow(registry).to receive(:with_session).with(target_id).and_yield(target_session)
+    end
+
+    it "stamps and persists channel_info on the newly bound session" do
+      expect(target_agent).to receive(:channel_info=)
+        .with(hash_including(platform: :weixin, chat_id: "chat_1"))
+
+      manager.handle_command(adapter, event, "/bind #{target_id}")
+
+      expect(target_session[:channel_keys]).to include(key)
+      expect(persisted).to include(target_agent)
+      expect(sent).to eq(["Bound to session `#{target_id[0, 8]}`."])
+    end
+
+    it "clears channel_info from the previously bound session" do
+      expect(agent).to receive(:channel_info=).with(nil)
+
+      manager.handle_command(adapter, event, "/bind #{target_id}")
+
+      expect(web_ui.channel_subscribed?).to be false
+      expect(session[:channel_keys]).not_to include(key)
+    end
+  end
+
+  describe "/unbind" do
+    it "detaches channel_ui from the session web_ui so outbound events stop reaching the chat" do
+      expect(web_ui.channel_subscribed?).to be true
+
+      unbind
+
+      expect(web_ui.channel_subscribed?).to be false
+      expect(session).not_to have_key(:channel_ui)
+      expect(sent).to eq(["Unbound."])
+    end
+
+    it "clears both channel_keys and channel_info" do
+      expect(agent).to receive(:channel_info=).with(nil)
+
+      unbind
+
+      expect(session[:channel_keys]).to be_empty
+    end
+
+    it "keeps channel_ui subscribed while another key still points at the session" do
+      session[:channel_keys].add("weixin:chat:chat_2")
+
+      unbind
+
+      expect(web_ui.channel_subscribed?).to be true
+      expect(session[:channel_ui]).to eq(channel_ui)
+      expect(session[:channel_keys].to_a).to eq(["weixin:chat:chat_2"])
+    end
+
+    it "reports no binding and leaves subscriptions untouched when the key is unknown" do
+      session[:channel_keys] = Set.new(["weixin:chat:other"])
+
+      unbind
+
+      expect(sent).to eq(["No binding found."])
+      expect(web_ui.channel_subscribed?).to be true
+      expect(session[:channel_ui]).to eq(channel_ui)
+    end
+
+    it "persists the cleared channel_info so a restart cannot restore the binding" do
+      expect(agent).to receive(:channel_info=).with(nil)
+
+      unbind
+
+      expect(persisted).to eq([agent])
+    end
+  end
+
+  describe "/unbind with a stale binding left on an older session" do
+    let(:stale_id) { "sess_964a5317" }
+    let(:stale_agent) do
+      double("stale_agent", channel_info: { platform: "weixin", chat_id: "chat_1", user_id: "user_1" })
+    end
+    let(:stale_session) { { agent: stale_agent, channel_keys: Set.new } }
+
+    before do
+      allow(stale_agent).to receive(:channel_info=)
+      rows = [
+        { id: session_id, source: "channel" },
+        { id: stale_id, source: "channel",
+          channel_info: { platform: "weixin", chat_id: "chat_1", user_id: "user_1" } }
+      ]
+      allow(registry).to receive(:list).and_return(rows)
+      allow(registry).to receive(:list).with(limit: nil).and_return(rows)
+      allow(registry).to receive(:with_session).with(stale_id).and_yield(stale_session)
+    end
+
+    it "clears the stale channel_info that would otherwise reclaim the key on restart" do
+      expect(stale_agent).to receive(:channel_info=).with(nil)
+
+      unbind
+
+      expect(sent).to eq(["Unbound."])
+      expect(persisted).to include(stale_agent)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`/unbind` did not actually unbind a channel.

1. **Outbound messages kept flowing.** `/unbind` dropped the session's channel key so inbound messages no longer resolved, but the session's `channel_ui` stayed subscribed to its `web_ui`. Agent output continued to reach the IM chat through `web_ui → @channel_subscribers → channel_ui → adapter.send_text`.

2. **`Set#delete` is always truthy.** It returns `self` whether or not the element existed, so `/unbind` on an unbound chat replied `"Unbound."` instead of `"No binding found."`.

3. **The binding came back after a restart.** Every inbound message stamps `agent.channel_info` onto the bound session (`route_message`), and `restore_channel_bindings` reads that field at startup to rebuild bindings. Switching bindings therefore left the field behind on older sessions, and the cleanup that was supposed to remove it sat inside an `if channel_ui` block — `channel_ui` is in-memory only, so a session evicted from memory was skipped entirely and kept its stale stamp. At startup the arbitration is newest-`updated_at`-first, so an abandoned session that had merely been opened in the WebUI could reclaim the key.

4. **`/bind` left a window with no stamp at all.** The new session's `channel_info` was only written when the next inbound message arrived, so a restart in between dropped the binding.

## Fix

- Unsubscribe `channel_ui` from `web_ui` once the session's last channel key is gone. Guarded on `channel_keys.empty?` because keys are a `Set` — a session may still be reachable through another key.
- Use `Set#delete?` so an unknown key reports `"No binding found."`.
- Move the stale-`channel_info` cleanup out of the `if channel_ui` block into `clear_channel_info_for_key`, which scans the on-disk summary (already carried by `SessionRegistry#list` rows) and therefore also cleans sessions evicted from memory. Matches `restore_channel_bindings`, which likewise does not filter by source.
- Stamp and persist `channel_info` on the newly bound session inside `/bind` instead of waiting for the next inbound message.
- Inject `persist_session` from `HttpServer` so the cleared/updated field survives a restart. `to_session_data` is called without `updated_at` so cleanup does not bump a session's position in the newest-first list — which is exactly the ordering `restore_channel_bindings` arbitrates on.

The number of sessions carrying a given channel key on disk is now exactly 1 after `/bind` and 0 after `/unbind`. Existing multi-stamp state self-heals on the next `/bind` or `/unbind`, so no migration is needed.

## Test

- New `spec/clacky/server/channel/channel_manager_binding_spec.rb` (8 examples). `/bind` and `/unbind` had no coverage before; the unknown-key case is what surfaced the `Set#delete` bug. Covers `channel_ui` detach, `channel_keys` / `channel_info` staying in sync (guards the C-5651 regression), retaining the subscription while another key remains, stale stamps on sessions evicted from memory, and the `/bind` stamp-and-persist path.
- `bundle exec rspec spec/clacky/server/channel/` → 156 examples, 0 failures
- `bundle exec rspec` → 3742 examples, 0 failures
- Manually verified on WeChat: `/bind` to a new session, `/unbind`, then restart — inbound and outbound both stop, and the key is no longer reclaimed by an older session.