### PR TITLE
fix(web): guard ask_user free-text Enter against IME composition (C-5759)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1054,9 +1054,11 @@ const Sessions = (() => {
         dot.onclick = () => showStep(Number(dot.dataset.step));
       });
 
+      // IME.track so confirming a composition candidate is not read as Enter.
       card.querySelectorAll(".feedback-free-text").forEach(input => {
+        const ime = IME.track(input);
         input.onkeydown = (e) => {
-          if (e.key !== "Enter") return;
+          if (e.key !== "Enter" || ime.isComposing(e)) return;
           e.preventDefault();
           if (step === list.length - 1) _submitFeedbackCard(card, list);
           else showStep(step + 1);


### PR DESCRIPTION
## Problem

The free-text input on an `ask_user` card submitted on any `Enter` keydown, with no check for an in-flight IME composition. Confirming a Chinese candidate with Enter was therefore read as "send": the raw pinyin was submitted and the composition never completed. Reproduced on macOS with a 3-question card — the answer went out as `项目名叫什么? mayapp`.

## Fix

Wrapped the handler in `IME.track` (`lib/clacky/web/utils.js`), the same guard already used by the session search box and the message edit box. It covers all three browser signals: `isComposing` on Chrome/Firefox/Edge, `keyCode === 229` on older engines, and a recent `compositionend` timestamp for Safari, which fires it ~5ms *before* keydown so `isComposing` is already false.

Enter now returns early while a composition is active and behaves as before once it ends.

## Test

- ✅ Simulated all three browser signals plus the non-IME paths (plain Enter submits, stepped Enter advances, Enter well after `compositionend` still submits, non-Enter keys untouched)
- ✅ `bundle exec rspec` — 3742 examples, 0 failures
- ⚠️ Real IME candidate selection needs a manual check; composition event sequences come from the OS input method and can't be driven from a test harness