### PR TITLE
Fix possible fix(deps): faraday 2.8.1 → ~> 1.10.6, >= 2.14.3 (CVE-2026-54297) in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       base64 (>= 0.1.0)
       chunky_png (~> 1.4)
       diffy (~> 3.4)
-      faraday (>= 2.0, < 2.9)
+      faraday (>= 2.14.3)
       faraday-multipart (~> 1.0)
       logger (>= 1.4)
       pastel (~> 0.8)
@@ -37,7 +37,7 @@ GEM
     diffy (3.4.4)
     docile (1.4.1)
     erb (6.0.4)
-    faraday (2.8.1)
+    faraday (2.14.3)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)


### PR DESCRIPTION
This changes `Gemfile.lock` to address something a scan flagged. It is around line 40.

Faraday's default NestedParamsEncoder does not limit recursion depth when parsing nested query strings. An attacker can craft a query string that produces an extremely deep Ruby Hash, causing Faraday's dehash routine to recurse without bound. This leads to an uncaught SystemStackError, crashing the application thread and resulting in denial of service. The risk is high because the vulnerability is easy to trigger with a malicious query string and affects any application that uses Faraday's nested query parsing. The fix is to upgrade Faraday to a version that enforces a maximum nesting depth (fixed in faraday >=2.14.3 or >=1.10.6).

Update faraday to 2.14.3 and relax its version constraint, addressing the reported CVE.

For reference: rule `CVE-2026-54297`. Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
