### PR TITLE
fix(web): route ask_user free-text Enter through the unanswered-question guard (C-5760)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -1016,6 +1016,16 @@ const Sessions = (() => {
       if (free) free.focus();
     };
 
+    // Enter and the submit button must agree: a stepped card never sends a
+    // partial answer, it jumps back to the first unanswered question instead.
+    const trySubmit = () => {
+      if (stepped) {
+        const blank = list.findIndex((_, i) => _feedbackAnswerFor(card, list, i).length === 0);
+        if (blank !== -1) { showStep(blank); return; }
+      }
+      _submitFeedbackCard(card, list);
+    };
+
     card.querySelectorAll(".feedback-option-btn").forEach(btn => {
       btn.onclick = () => {
         const qi = Number(btn.dataset.questionIndex);
@@ -1060,7 +1070,7 @@ const Sessions = (() => {
         input.onkeydown = (e) => {
           if (e.key !== "Enter" || ime.isComposing(e)) return;
           e.preventDefault();
-          if (step === list.length - 1) _submitFeedbackCard(card, list);
+          if (step === list.length - 1) trySubmit();
           else showStep(step + 1);
         };
       });
@@ -1069,16 +1079,7 @@ const Sessions = (() => {
     }
 
     const submit = card.querySelector(".feedback-submit-btn");
-    if (submit) {
-      submit.onclick = () => {
-        if (stepped) {
-          // Don't silently drop a question the user skipped past — take them back to it.
-          const blank = list.findIndex((_, i) => _feedbackAnswerFor(card, list, i).length === 0);
-          if (blank !== -1) { showStep(blank); return; }
-        }
-        _submitFeedbackCard(card, list);
-      };
-    }
+    if (submit) submit.onclick = trySubmit;
   }
 
   // Render a mention chip (file/directory/session) as a bubble badge.


### PR DESCRIPTION
## Problem

A stepped `ask_user` card guarded against partial submission only on the submit button path. Pressing Enter in a free-text field on the last step called `_submitFeedbackCard` directly, skipping that guard, so a user who stepped past an unanswered question could send a partial answer. `_submitFeedbackCard` drops empty answers silently, so the skipped question never appeared in the reply.

## Fix

Extracted the guard into a single `trySubmit` closure in `_wireFeedbackCard` and pointed both paths at it, so there is one definition of "ready to send" instead of two that can drift. Submit button behaviour is unchanged; non-stepped cards still submit directly.

## Test

- ✅ Full suite green (3758 examples, 0 failures)
- ⚠️ Browser-only interaction, not verified on a real page — please confirm Enter on the last step with an earlier question unanswered jumps back to it instead of sending
