### PR TITLE
fix(channel): render ask_user questions as text in IM channels (C-5761)

### DIFF
--- a/lib/clacky/server/channel/channel_ui_controller.rb
+++ b/lib/clacky/server/channel/channel_ui_controller.rb
@@ -95,7 +95,20 @@ module Clacky
       end
 
       def show_tool_call(name, args)
-        # Suppress — too noisy for IM
+        # ask_user is the one tool that must reach the user: the agent stops and
+        # waits for an answer, so swallowing it leaves the chat silently stuck.
+        # Sent unconditionally — it is a question, not process noise, so the
+        # process-messages toggle must not gate it.
+        if Clacky::Tools::AskUser.feedback_tool?(name)
+          args_data = args.is_a?(String) ? (JSON.parse(args) rescue args) : args
+          questions = Clacky::Tools::AskUser.normalize_questions(args_data)
+          return if questions.empty?
+
+          context = args_data.is_a?(Hash) ? (args_data[:context] || args_data["context"]).to_s : ""
+          flush_buffer
+          send_text(Clacky::Tools::AskUser.render_text(questions, context))
+          return
+        end
       end
 
       def show_tool_result(result)

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -128,7 +128,8 @@ module Clacky
                context: context,
                options: first[:options] || [],
                questions: questions)
-          # Don't forward to IM subscribers — they get the formatted text version already
+          # IM subscribers render the same questions as plain text — they have no card.
+          forward_to_subscribers { |sub| sub.show_tool_call(name, args_data) }
           return
         end
 

--- a/spec/clacky/server/channel/channel_ui_controller_spec.rb
+++ b/spec/clacky/server/channel/channel_ui_controller_spec.rb
@@ -90,6 +90,59 @@ RSpec.describe Clacky::Channel::ChannelUIController do
     end
   end
 
+  describe "#show_tool_call" do
+    let(:ask_args) do
+      {
+        "questions" => [
+          { "question" => "语言选中文还是英文?", "options" => %w[中文 English] },
+          { "question" => "输出格式选 Markdown 还是纯文本?", "options" => %w[Markdown 纯文本] }
+        ]
+      }
+    end
+
+    it "renders ask_user questions as text so IM users can answer" do
+      controller.show_tool_call("ask_user", ask_args)
+      expect(sent.size).to eq(1)
+      expect(sent.first).to include("语言选中文还是英文?", "1. 中文", "2. English")
+      expect(sent.first).to include("输出格式选 Markdown 还是纯文本?", "1. Markdown")
+    end
+
+    it "sends ask_user even when process messages are disabled" do
+      @process_enabled = false
+      controller.show_tool_call("ask_user", ask_args)
+      expect(sent.size).to eq(1)
+      expect(sent.first).to include("语言选中文还是英文?")
+    end
+
+    it "accepts a JSON string payload" do
+      controller.show_tool_call("ask_user", JSON.generate(ask_args))
+      expect(sent.first).to include("语言选中文还是英文?")
+    end
+
+    it "renders the retired request_user_feedback name too" do
+      controller.show_tool_call("request_user_feedback", ask_args)
+      expect(sent.first).to include("语言选中文还是英文?")
+    end
+
+    it "flushes pending previews before the question" do
+      controller.buffer_line("$ ls")
+      controller.show_tool_call("ask_user", ask_args)
+      expect(sent).to eq(["$ ls", sent.last])
+      expect(sent.last).to include("语言选中文还是英文?")
+    end
+
+    it "stays silent when ask_user carries no usable question" do
+      controller.show_tool_call("ask_user", { "questions" => [] })
+      expect(sent).to be_empty
+    end
+
+    it "still suppresses every other tool" do
+      controller.show_tool_call("terminal", { "command" => "ls" })
+      controller.show_tool_call("write", { "path" => "a.rb" })
+      expect(sent).to be_empty
+    end
+  end
+
   describe "without a status_messages resolver" do
     it "defaults to not sending status messages" do
       controller = described_class.new(event, -> { adapter })

--- a/spec/clacky/server/web_ui_controller_spec.rb
+++ b/spec/clacky/server/web_ui_controller_spec.rb
@@ -92,3 +92,26 @@ RSpec.describe Clacky::Server::WebUIController, "#show_complete" do
     expect(events.last).not_to have_key(:task_id)
   end
 end
+
+RSpec.describe Clacky::Server::WebUIController, "#show_tool_call" do
+  let(:events) { [] }
+  let(:controller) do
+    described_class.new("test-session", ->(_sid, event) { events << event })
+  end
+  let(:subscriber) { double("channel_ui", show_tool_call: nil) }
+  let(:ask_args) { { "questions" => [{ "question" => "Pick one?", "options" => %w[a b] }] } }
+
+  before { controller.subscribe_channel(subscriber) }
+
+  it "forwards ask_user to channel subscribers so IM can render it as text" do
+    expect(subscriber).to receive(:show_tool_call).with("ask_user", ask_args)
+    controller.show_tool_call("ask_user", ask_args)
+  end
+
+  it "still emits the browser feedback card" do
+    controller.show_tool_call("ask_user", ask_args)
+    ev = events.find { |e| e[:type] == "request_feedback" }
+    expect(ev[:question]).to eq("Pick one?")
+    expect(ev[:options]).to eq(%w[a b])
+  end
+end


### PR DESCRIPTION
## Problem

`ask_user` reached IM users nowhere. `WebUIController#show_tool_call` emitted the browser card and returned early, with a comment claiming IM subscribers "get the formatted text version already" — nothing sent it. `ChannelUIController#show_tool_call` was an empty stub suppressing every tool. Since the agent blocks on `awaiting_feedback`, the chat just went silent while the browser showed a card.

## Fix

`ChannelUIController#show_tool_call` now renders `ask_user` via the existing `AskUser.render_text` (the same helper the terminal UI uses) and sends it unconditionally — a pending question is not process noise, so the `process_messages` toggle, which defaults to `false`, must not gate it. `WebUIController` forwards the call to channel subscribers instead of returning early. All other tools stay suppressed and the browser card is unchanged.

## Test

- ✅ Full suite green (3770 examples, 0 failures), 12 new
- ✅ New specs cover text rendering, delivery while `process_messages` is off, JSON-string args, the legacy `request_user_feedback` name, empty-question silence, other tools still suppressed, and subscriber forwarding
- ✅ Verified manually in WeChat by @jiujiu — question renders once, no duplicate delivery