### PR TITLE
fix(web): render free-text input for ask_user questions without options (C-5758)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -931,7 +931,7 @@ const Sessions = (() => {
                 `${answered ? " disabled" : ""}>${escapeHtml(opt)}${rec}</button>`;
       });
       html += `</div>`;
-      if (q.allow_free_text && q.options.length > 0) {
+      if (q.allow_free_text) {
         html += `<input type="text" class="feedback-free-text" data-question-index="${qi}"` +
                 ` placeholder="${escapeHtml(I18n.t("chat.feedback_other"))}"${answered ? " disabled" : ""}>`;
       }


### PR DESCRIPTION
## Problem

In a multi-question `ask_user` card, a question with no `options` rendered no input field at all. The user had to answer via the main composer, which cleared every already-selected option back to "not selected".

The backend already marks these questions as free-form (`ask_user.rb:126` forces `allow_free_text: true` when `options` is empty), and `_feedbackAnswerFor` has always queried for `.feedback-free-text` for every question index — that lookup just never matched, so the question counted as unanswered forever and the C-5760 guard blocked submission.

## Fix

`sessions.js:934` — drop the `q.options.length > 0` half of the condition so the free-text input follows the backend's `allow_free_text` flag:

```diff
-if (q.allow_free_text && q.options.length > 0) {
+if (q.allow_free_text) {
```

No new i18n string: the existing `chat.feedback_other` placeholder is reused. `_feedbackNeedsCard` is intentionally left alone — a request where *no* question has options still renders as a plain assistant bubble, as designed.

## Test

- ✅ Full suite: 3761 examples, 0 failures
- ✅ `node --check lib/clacky/web/sessions.js`
- ✅ 13 assertions against the real `_buildFeedbackCard` / `_feedbackIsInstant`: the issue's shape (2 questions with options + 1 without) gains exactly one input on the third question; questions with options are untouched; a plain single-choice question stays instant-submit with no input and no submit button; an answered card renders the input disabled on history replay
- ⚠️ Not verified in a real browser (no dev server available). The input now appears in a context that previously had none, so spacing may need a look — `.feedback-options` keeps its `margin-bottom: 0.625rem` even when it renders empty, leaving ~10px between the question and the input.
