### PR TITLE
fix(agent): stop reporting awaiting_feedback for question-mark endings (C-5757)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -726,6 +726,11 @@ module Clacky
 
         # Track if ask_user was called
         awaiting_user_feedback = false
+        # Heuristic sibling of the above: the reply merely ended with a question
+        # mark. Kept separate because it must never reach build_result — the
+        # session status it feeds shows a "waiting" badge to the user, and a
+        # rhetorical closing question is not a request for input.
+        turn_unfinished = false
         # Track if task was interrupted by user (denied tool execution)
         task_interrupted = false
 
@@ -849,7 +854,7 @@ module Clacky
             # If the assistant ended its turn with a question, treat this as
             # an in-flight conversation (agent is awaiting the user's reply)
             # and skip skill evolution — the task isn't truly complete yet.
-            awaiting_user_feedback = true if ends_with_question
+            turn_unfinished = true if ends_with_question
 
             break
           end
@@ -908,7 +913,7 @@ module Clacky
         # Run skill evolution hooks after main loop completes
         # Skip if task was interrupted by user (denied tool) or awaiting user feedback
         # Only for main agent (not subagents) to avoid recursive evolution
-        unless @is_subagent || task_interrupted || awaiting_user_feedback
+        unless @is_subagent || task_interrupted || awaiting_user_feedback || turn_unfinished
           run_skill_evolution_hooks
         end
 
@@ -919,7 +924,7 @@ module Clacky
         # and only then [OK] Task Complete is printed. No cleanup dance,
         # no cross-method progress handle holding.
         # Skip on interrupt / feedback / subagent (self-guarded inside too).
-        unless @is_subagent || task_interrupted || awaiting_user_feedback
+        unless @is_subagent || task_interrupted || awaiting_user_feedback || turn_unfinished
           run_memory_update_subagent
         end
 

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -1827,5 +1827,19 @@ RSpec.describe Clacky::Agent do
         agent.run("fix the bug")
       end
     end
+
+    it "still reaches both hooks on a plain ending" do
+      Dir.mktmpdir do |tmpdir|
+        agent = build_agent(tmpdir, :confirm_all)
+
+        allow(client).to receive(:send_messages_with_tools)
+          .and_return(mock_api_response(content: "All done."))
+
+        expect(agent).to receive(:run_skill_evolution_hooks)
+        expect(agent).to receive(:run_memory_update_subagent)
+
+        agent.run("fix the bug")
+      end
+    end
   end
 end

--- a/spec/clacky/agent_spec.rb
+++ b/spec/clacky/agent_spec.rb
@@ -1787,5 +1787,45 @@ RSpec.describe Clacky::Agent do
         expect(result[:awaiting_user_feedback]).to be false
       end
     end
+
+    it "is false when the reply merely ends with a question mark" do
+      Dir.mktmpdir do |tmpdir|
+        agent = build_agent(tmpdir, :confirm_all)
+
+        allow(client).to receive(:send_messages_with_tools)
+          .and_return(mock_api_response(content: "Fixed it. Want me to run the tests?"))
+
+        result = agent.run("fix the bug")
+
+        expect(result[:awaiting_user_feedback]).to be false
+      end
+    end
+
+    it "is false when the reply ends with a full-width question mark" do
+      Dir.mktmpdir do |tmpdir|
+        agent = build_agent(tmpdir, :confirm_all)
+
+        allow(client).to receive(:send_messages_with_tools)
+          .and_return(mock_api_response(content: "\u4FEE\u597D\u4E86\uFF0C\u8FD8\u9700\u8981\u6211\u505A\u4EC0\u4E48\u5417\uFF1F"))
+
+        result = agent.run("fix the bug")
+
+        expect(result[:awaiting_user_feedback]).to be false
+      end
+    end
+
+    it "still skips skill evolution and memory update on a question-mark ending" do
+      Dir.mktmpdir do |tmpdir|
+        agent = build_agent(tmpdir, :confirm_all)
+
+        allow(client).to receive(:send_messages_with_tools)
+          .and_return(mock_api_response(content: "Done. Anything else?"))
+
+        expect(agent).not_to receive(:run_skill_evolution_hooks)
+        expect(agent).not_to receive(:run_memory_update_subagent)
+
+        agent.run("fix the bug")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

When the agent finished a turn with a reply ending in `?` / `？` (a closing plan, a polite sign-off, a rhetorical question), the session was marked `awaiting_feedback` and the sidebar showed a "waiting" badge that never cleared — even though the agent needed nothing from the user.

Two independently reasonable changes collided:

- `7d02d7f2` (Jun 7) set `awaiting_user_feedback` on a question-mark ending to skip skill evolution / memory update. At that time the flag was loop-local — `build_result` did not carry it, so it never left the agent.
- `303025bd` (Aug 21) added the sidebar awaiting state and reused that same flag via `build_result`, unknowingly promoting a punctuation heuristic into the session status broadcast to the frontend.

## Fix

Split the two signals in `agent.rb` — one variable was carrying two meanings:

- `turn_unfinished` — the question-mark heuristic, feeding only the skill evolution and memory update guards (`7d02d7f2`'s intent, unchanged)
- `awaiting_user_feedback` — set only when `ask_user` actually ran, and the only one reaching `build_result`

`http_server.rb` and the frontend are untouched: fixing the source makes every consumer correct. `show_complete` now receives the strict flag, so a >5-iteration turn ending in `?` prints its completion summary in the terminal UIs like any other finished turn.

## Test

- ✅ Full suite: 3774 examples, 0 failures
- ✅ 4 new specs in `agent_spec.rb`: `?` and `？` endings leave `result[:awaiting_user_feedback]` false, hooks are still skipped on a question-mark ending, and hooks still run on a plain ending
- ✅ Web UI checked by hand: no stale "waiting" badge on a question-mark ending