### PR TITLE
fix(web): support mention menu with Windows IME (C-5768)

### DIFF
--- a/lib/clacky/web/components/mentions.js
+++ b/lib/clacky/web/components/mentions.js
@@ -417,17 +417,19 @@ const MentionAC = (() => {
 
     let node = caret.startContainer;
     let offset = caret.startOffset;
-    if (node.nodeType !== 3) {
-      if (node.nodeType !== 1 || offset === 0) return false;
-      node = node.childNodes[offset - 1];
+    if (node.nodeType !== Node.TEXT_NODE) {
+      if (node.nodeType !== Node.ELEMENT_NODE || offset === 0) return false;
+      const previousChildIndex = offset - 1;
+      node = node.childNodes[previousChildIndex];
       while (node && node.lastChild) node = node.lastChild;
-      if (!node || node.nodeType !== 3) return false;
+      if (!node || node.nodeType !== Node.TEXT_NODE) return false;
       offset = node.nodeValue.length;
     }
-    if (offset === 0 || node.nodeValue[offset - 1] !== "@") return false;
+    const atOffset = offset - 1;
+    if (atOffset < 0 || node.nodeValue[atOffset] !== "@") return false;
 
     const at = document.createRange();
-    at.setStart(node, offset - 1);
+    at.setStart(node, atOffset);
     at.setEnd(node, offset);
     at.deleteContents();
 

--- a/lib/clacky/web/components/mentions.js
+++ b/lib/clacky/web/components/mentions.js
@@ -404,6 +404,47 @@ const MentionAC = (() => {
     el.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
+  // Promote an "@" already committed by the browser into the tracked marker.
+  // Windows IMEs may suppress the printable keydown (or expose it as Process),
+  // so the input/composition events are the only reliable character boundary.
+  function _adoptCommittedAtMarker() {
+    const el = _inputEl();
+    const sel = window.getSelection();
+    if (!el || !sel || !sel.rangeCount || !sel.isCollapsed) return false;
+
+    const caret = sel.getRangeAt(0);
+    if (!el.contains(caret.startContainer)) return false;
+
+    let node = caret.startContainer;
+    let offset = caret.startOffset;
+    if (node.nodeType !== 3) {
+      if (node.nodeType !== 1 || offset === 0) return false;
+      node = node.childNodes[offset - 1];
+      while (node && node.lastChild) node = node.lastChild;
+      if (!node || node.nodeType !== 3) return false;
+      offset = node.nodeValue.length;
+    }
+    if (offset === 0 || node.nodeValue[offset - 1] !== "@") return false;
+
+    const at = document.createRange();
+    at.setStart(node, offset - 1);
+    at.setEnd(node, offset);
+    at.deleteContents();
+
+    const marker = document.createElement("span");
+    marker.className = "mention-at-marker";
+    marker.textContent = "@";
+    at.insertNode(marker);
+
+    const after = document.createRange();
+    after.setStartAfter(marker);
+    after.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(after);
+    _atNode = marker;
+    return true;
+  }
+
   // Cancel path: turn the tracked "@" marker back into plain text so the user
   // keeps the character they typed.
   function _unwrapAtMarker() {
@@ -569,12 +610,25 @@ const MentionAC = (() => {
       }
     });
 
-    // If the user deletes the "@" while the menu is open, close the menu.
-    el.addEventListener("input", () => {
+    // Keydown is not reliable while a Windows IME is active. Once the browser
+    // commits a literal "@", adopt it into the existing marker state machine.
+    // Composing input waits for compositionend so we never rewrite active IME
+    // text; non-composing input can be handled immediately.
+    el.addEventListener("input", (e) => {
+      _cfg = cfg;
+      if (!_visible && !e.isComposing && e.data === "@" && _adoptCommittedAtMarker()) {
+        open("root");
+        return;
+      }
       if (_visible && _atNode && !el.contains(_atNode)) {
         _atNode = null;
         hide();
       }
+    });
+
+    el.addEventListener("compositionend", (e) => {
+      _cfg = cfg;
+      if (!_visible && e.data === "@" && _adoptCommittedAtMarker()) open("root");
     });
 
     // Optional @ button removed — @ is opened via the keyboard only.

--- a/spec/clacky/web/mention_autocomplete_spec.rb
+++ b/spec/clacky/web/mention_autocomplete_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe "Web mention autocomplete" do
     expect(input_handler).to include("!e.isComposing")
     expect(composition_handler).to include('_adoptCommittedAtMarker()')
   end
+
+  it "uses named DOM and caret positions when adopting committed text" do
+    expect(source).to include("node.nodeType !== Node.TEXT_NODE")
+    expect(source).to include("node.nodeType !== Node.ELEMENT_NODE")
+    expect(source).to include("const previousChildIndex = offset - 1")
+    expect(source).to include("const atOffset = offset - 1")
+    expect(source).not_to match(/node\.nodeType !== [13]/)
+  end
 end

--- a/spec/clacky/web/mention_autocomplete_spec.rb
+++ b/spec/clacky/web/mention_autocomplete_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "Web mention autocomplete" do
+  let(:source) do
+    File.read(File.expand_path("../../../lib/clacky/web/components/mentions.js", __dir__))
+  end
+
+  it "falls back to committed input when IME keydown is not usable" do
+    expect(source).to include('function _adoptCommittedAtMarker()')
+    expect(source).to include(
+      'if (!_visible && !e.isComposing && e.data === "@" && _adoptCommittedAtMarker())'
+    )
+    expect(source).to include(
+      'if (!_visible && e.data === "@" && _adoptCommittedAtMarker()) open("root")'
+    )
+  end
+
+  it "waits for compositionend before rewriting active IME text" do
+    input_handler = source[/el\.addEventListener\("input".*?^    \}\);/m]
+    composition_handler = source[/el\.addEventListener\("compositionend".*?^    \}\);/m]
+
+    expect(input_handler).to include("!e.isComposing")
+    expect(composition_handler).to include('_adoptCommittedAtMarker()')
+  end
+end


### PR DESCRIPTION
## Problem

On WSL/Windows, typing `@` while a Chinese IME is active does not open the mention menu. The menu relied exclusively on a non-composing `keydown`, but Windows IMEs may suppress or transform that event.

## Fix

Added a fallback that detects the committed `@` through input and composition events, then promotes it into the existing mention marker state machine. Active IME text is not modified until composition finishes, while the existing keyboard path remains unchanged.

## Test

✅ Added regression coverage for committed IME input and composition handling  
✅ Web syntax and focused tests: 21 examples, 0 failures  
✅ Full RSpec suite: 3805 examples, 0 failures