### PR TITLE
fix(ext-studio): validate extension version input (C-5727)

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/api/handler.rb
+++ b/lib/clacky/default_extensions/ext-studio/api/handler.rb
@@ -344,6 +344,9 @@ class ExtStudioExt < Clacky::ApiExtension
     ext_id  = require_ext_id!
     version = presence(json_body["version"])
     error!("version required", status: 422) unless version
+    unless Clacky::ExtensionVerifier.valid_version?(version)
+      error!("version must use three numeric segments (for example, 1.0.0)", status: 422)
+    end
 
     result  = Clacky::ExtensionLoader.load_all(force: false)
     container = Array(result.containers).find { |id, _| id == ext_id }&.last

--- a/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
+++ b/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
@@ -627,8 +627,12 @@
     }
   }
 
+  function normalizeVersion(v) {
+    return String(v || "").replace(/[^0-9.]/g, "").split(".").slice(0, 3).join(".");
+  }
+
   function isSemver(v) {
-    return /^\d+\.\d+\.\d+$/.test(v);
+    return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
   }
 
   // Unified publish flow: one modal that walks the creator from a release form
@@ -642,23 +646,14 @@
       const titleNew = isBrand ? t("pub.brand.title.new") : t("pub.title.new");
       const titleUpdate = isBrand ? t("pub.brand.title.update") : t("pub.title.update");
       const introText = isBrand ? t("pub.brand.intro", { name: ext.name }) : t("pub.intro", { name: ext.name });
-      let currentVersion = ext.version || "";
+      let currentVersion = normalizeVersion(ext.version);
       let isUpdate = false;
 
       const verField = el("div", { class: "studio-field" });
       verField.appendChild(el("label", { class: "studio-label", text: t("pub.version.label") }));
-      const verInput = el("input", { class: "studio-input", type: "text", value: currentVersion, placeholder: "1.0.0" });
-      verInput.addEventListener("input", () => {
-        currentVersion = verInput.value.trim();
-        const valid = isSemver(currentVersion);
-        verInput.classList.toggle("studio-input-error", !!currentVersion && !valid);
-        publishBtn.disabled = !valid;
-        publishBtn.textContent = valid ? t("pub.btn.publish", { ver: currentVersion }) : t("pub.btn.publish", { ver: currentVersion || "?" });
-        if (currentVersion && !valid) {
-          setProgress(t("err.invalid_version"), true);
-        } else {
-          status.style.display = "none";
-        }
+      const verInput = el("input", {
+        class: "studio-input", type: "text", value: currentVersion,
+        placeholder: "1.0.0", inputmode: "decimal", autocomplete: "off", spellcheck: "false",
       });
       verField.appendChild(verInput);
 
@@ -694,7 +689,8 @@
 
       const publishBtn = modal.footer.querySelector(".btn-primary");
       const cancelBtn = modal.footer.querySelector(".btn-secondary");
-      if (!currentVersion) publishBtn.disabled = true;
+      verInput.addEventListener("input", () => syncVersionState({ normalize: true }));
+      syncVersionState();
 
       Promise.resolve(prevVersionOrPromise).then((prevVersion) => {
         if (done || !prevVersion) return;
@@ -702,10 +698,8 @@
         const titleEl = modal.overlay.querySelector(".modal-title");
         if (titleEl) titleEl.textContent = titleUpdate;
         if (prevVersion !== currentVersion) {
-          currentVersion = prevVersion;
-          verInput.value = currentVersion;
-          publishBtn.disabled = false;
-          publishBtn.textContent = t("pub.btn.publish", { ver: currentVersion });
+          verInput.value = normalizeVersion(prevVersion);
+          syncVersionState();
         }
       });
 
@@ -715,9 +709,34 @@
         status.className = "studio-modal-status" + (isError ? " studio-modal-status-error" : "");
       }
 
+      function syncVersionState({ normalize = false, updateFeedback = true } = {}) {
+        if (normalize) {
+          const raw = verInput.value;
+          const cursor = verInput.selectionStart;
+          const normalized = normalizeVersion(raw);
+          if (normalized !== raw) {
+            verInput.value = normalized;
+            if (cursor != null) {
+              const normalizedCursor = normalizeVersion(raw.slice(0, cursor)).length;
+              verInput.setSelectionRange(normalizedCursor, normalizedCursor);
+            }
+          }
+        }
+
+        currentVersion = verInput.value.trim();
+        const valid = isSemver(currentVersion);
+        publishBtn.disabled = !valid;
+        publishBtn.textContent = t("pub.btn.publish", { ver: valid ? currentVersion : (currentVersion || "?") });
+
+        if (updateFeedback) {
+          verInput.classList.toggle("studio-input-error", !!currentVersion && !valid);
+          if (currentVersion && !valid) setProgress(t("err.invalid_version"), true);
+          else status.style.display = "none";
+        }
+      }
+
       function resetButtons() {
-        publishBtn.disabled = !currentVersion;
-        publishBtn.textContent = currentVersion ? t("pub.btn.publish", { ver: currentVersion }) : t("pub.btn.publish", { ver: "?" });
+        syncVersionState({ updateFeedback: false });
         cancelBtn.disabled = false;
         notes.disabled = false;
         verInput.disabled = false;

--- a/lib/clacky/extension/verifier.rb
+++ b/lib/clacky/extension/verifier.rb
@@ -29,6 +29,7 @@ module Clacky
     TOOL_KEYS    = %w[id file].freeze
 
     ATTACH_TOKEN_RE = /\A(\*|[\w\-]+)\z/.freeze
+    VERSION_RE      = /\A[0-9]+\.[0-9]+\.[0-9]+\z/.freeze
 
     class << self
       # Run all checks against a fully-loaded ExtensionLoader::Result. Returns
@@ -41,6 +42,10 @@ module Clacky
         issues.concat(manifest_schema_issues(result))
         issues.concat(reference_issues(result))
         issues
+      end
+
+      def valid_version?(version)
+        version.to_s.match?(VERSION_RE)
       end
 
       private def loader_errors_as_issues(result)
@@ -75,6 +80,14 @@ module Clacky
               message: "unknown top-level key #{unknown.inspect} in ext.yml",
               file: File.join(dir, "ext.yml"),
               hint: "Allowed: #{KNOWN_TOP_KEYS.join(', ')}"
+            )
+          end
+
+          if manifest.key?("version") && !valid_version?(manifest["version"])
+            issues << Issue.new(
+              ext: ext_id, unit: nil, level: :error, code: "schema.invalid_version",
+              message: "version must contain exactly three numeric segments (for example, 1.0.0)",
+              file: File.join(dir, "ext.yml"), hint: "Use the format x.x.x with digits only."
             )
           end
 

--- a/spec/clacky/default_extensions_ext_studio_spec.rb
+++ b/spec/clacky/default_extensions_ext_studio_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "ExtStudioExt API handler" do
+  let(:ext_dir) { Dir.mktmpdir }
+  let(:manifest_path) { File.join(ext_dir, "ext.yml") }
+  let(:loader_result) { double("loader result", containers: { "demo" => { dir: ext_dir } }) }
+  let(:handler_class) do
+    Clacky::ApiExtension.reset_registry!
+    handler_path = File.expand_path("../../lib/clacky/default_extensions/ext-studio/api/handler.rb", __dir__)
+    load(handler_path, true)
+    Clacky::ApiExtension.pending_subclasses.last
+  end
+  let(:route) do
+    handler_class.routes.find do |candidate|
+      candidate.method == :post && candidate.pattern == "/set_version"
+    end
+  end
+
+  before do
+    File.write(manifest_path, "id: demo\nversion: 1.0.0\ncontributes: {}\n")
+    allow(Clacky::ExtensionLoader).to receive(:load_all).and_return(loader_result)
+  end
+
+  after do
+    FileUtils.remove_entry(ext_dir) if Dir.exist?(ext_dir)
+    Clacky::ApiExtension.reset_registry!
+  end
+
+  def invoke_set_version(version)
+    req = double("request", body: JSON.generate(ext_id: "demo", version: version))
+    instance = handler_class.new(req: req, res: nil, route: route, params: {}, http_server: nil)
+    instance.invoke
+  end
+
+  it "writes a valid three-segment numeric version" do
+    expect { invoke_set_version("10.2.35") }.to raise_error(Clacky::ApiExtension::Halt) do |halt|
+      expect(halt.status).to eq(200)
+      expect(JSON.parse(halt.payload)).to include("version" => "10.2.35")
+    end
+
+    expect(File.read(manifest_path)).to include("version: 10.2.35")
+  end
+
+  it "rejects an invalid version without changing ext.yml" do
+    original = File.read(manifest_path)
+
+    ["测试test", "1.0", "1..0", "1.0.0.1"].each do |version|
+      expect { invoke_set_version(version) }.to raise_error(Clacky::ApiExtension::Halt) do |halt|
+        expect(halt.status).to eq(422)
+        expect(JSON.parse(halt.payload)["error"]).to match(/1\.0\.0/)
+      end
+    end
+
+    expect(File.read(manifest_path)).to eq(original)
+  end
+end

--- a/spec/clacky/extension_packager_spec.rb
+++ b/spec/clacky/extension_packager_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe Clacky::ExtensionPackager do
         .to raise_error(described_class::Error, /verify found errors/)
     end
 
+    it "blocks packing when the manifest version is invalid" do
+      dir = scaffold("bad-version")
+      yml = File.join(dir, "ext.yml")
+      File.write(yml, File.read(yml).sub(/^version:.*$/, "version: 测试test"))
+
+      expect { described_class.pack("bad-version", source_dir: local, out_dir: out) }
+        .to raise_error(described_class::Error, /schema.invalid_version/)
+    end
+
     it "refuses to pack a container whose produced zip exceeds the size limit" do
       scaffold("demo")
       stub_const("Clacky::ExtensionPackager::MAX_ZIP_SIZE", 1)

--- a/spec/clacky/extension_verifier_spec.rb
+++ b/spec/clacky/extension_verifier_spec.rb
@@ -58,6 +58,49 @@ RSpec.describe Clacky::ExtensionVerifier do
     expect(issues.map(&:code)).not_to include("schema.unknown_key")
   end
 
+  it "accepts a three-segment numeric version" do
+    manifest = <<~YAML
+      id: valid-version
+      version: 10.2.35
+      origin: self
+      contributes: {}
+    YAML
+    make_ext(local, "valid-version", manifest)
+
+    issues = described_class.verify(reload_layers)
+
+    expect(issues.map(&:code)).not_to include("schema.invalid_version")
+  end
+
+  it "flags a version that is not three numeric segments" do
+    manifest = <<~YAML
+      id: invalid-version
+      version: test.1.0
+      origin: self
+      contributes: {}
+    YAML
+    make_ext(local, "invalid-version", manifest)
+
+    issues = described_class.verify(reload_layers)
+    issue = issues.find { |candidate| candidate.code == "schema.invalid_version" }
+
+    expect(issue).not_to be_nil
+    expect(issue.level).to eq(:error)
+  end
+
+  it "keeps the version field optional during local development" do
+    manifest = <<~YAML
+      id: no-version
+      origin: self
+      contributes: {}
+    YAML
+    make_ext(local, "no-version", manifest)
+
+    issues = described_class.verify(reload_layers)
+
+    expect(issues.map(&:code)).not_to include("schema.invalid_version")
+  end
+
   it "flags unknown contributes type" do
     manifest = <<~YAML
       id: bad-contrib


### PR DESCRIPTION
## Problem

The extension publish dialog accepted Chinese characters, letters, and versions with more than three segments. Validation was also limited to the UI, allowing invalid versions to be written through the API or packaged from a manually edited `ext.yml`.

## Fix

- Restrict version input to digits and dots with at most three segments.
- Centralize publish button and validation state updates.
- Validate versions in `/set_version` before modifying `ext.yml`.
- Report invalid manifest versions as `schema.invalid_version`, preventing them from being packaged.
- Keep the version field optional during local development.

## Test

✅ Extension and API regression suite: 107 examples, 0 failures  
✅ JavaScript and Ruby syntax checks passed  
✅ Covered valid versions, Chinese and alphabetic input, missing segments, empty segments, and extra segments  
✅ Verified rejected API requests do not modify `ext.yml`