### PR TITLE
fix(session): preserve attachment badges after compression (C-5658)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -568,9 +568,12 @@ module Clacky
       all_disk_files = disk_files + downgraded
 
       # Format user message — text + inline vision images
-      # Store the tmp path alongside the data_url so the history replay can
-      # reconstruct the image if the base64 was stripped (e.g. after compression).
-      user_content = format_user_content(user_input, vision_images.map { |v| { url: v[:url], path: v[:path] } })
+      # Store the tmp path and original name alongside the data_url: the path supports
+      # normal replay, while the name becomes the lightweight badge after compression.
+      user_content = format_user_content(
+        user_input,
+        vision_images.map { |v| { url: v[:url], path: v[:path], name: v[:name] } }
+      )
 
       # Parse disk files — agent's responsibility, not the upload layer.
       # process_path runs the parser script and returns a FileRef with preview_path or parse_error.
@@ -2351,10 +2354,10 @@ module Clacky
 
     # Build user message content for LLM.
     # Returns plain String when no vision images; Array of content parts otherwise.
-    # Build user message content for LLM.
-    # vision_images: Array of String (plain url) OR Hash { url:, path: }
-    # path is stored in the block so history replay can reconstruct the image
-    # from the tmp file when the base64 data_url is no longer available.
+    # vision_images: Array of String (plain url) OR Hash { url:, path:, name: }
+    # path is stored so normal history replay can reconstruct the image; name is
+    # lightweight metadata used for an archived badge after compression. Both
+    # fields are stripped by MessageHistory before the content reaches the API.
     private def format_user_content(text, vision_images)
       vision_images ||= []
 
@@ -2366,6 +2369,7 @@ module Clacky
         if img.is_a?(Hash)
           block = { type: "image_url", image_url: { url: img[:url] } }
           block[:image_path] = img[:path] if img[:path]
+          block[:image_name] = img[:name] if img[:name]
           content << block
         else
           content << { type: "image_url", image_url: { url: img } }

--- a/lib/clacky/agent/message_compressor_helper.rb
+++ b/lib/clacky/agent/message_compressor_helper.rb
@@ -624,10 +624,12 @@ module Clacky
 
           case role
           when "user"
+            display_files = display_files_for_archive(msg)
             lines << (msg[:task_id] ? "## User [Task #{msg[:task_id]}]" : "## User")
             lines << ""
-            lines << format_message_content(content)
+            lines << format_archived_user_content(content, display_files)
             lines << ""
+            append_display_files_line(lines, display_files)
             append_ext_events_line(lines, msg)
           when "assistant"
             # If this message is itself a compressed summary, annotate the header
@@ -674,6 +676,55 @@ module Clacky
           end
         end
         lines
+      end
+
+      # Serialize only the lightweight UI metadata needed to reconstruct file
+      # badges after compression. File paths, previews, sizes, MIME types, and
+      # contents deliberately stay out of the chunk archive.
+      def display_files_for_archive(msg)
+        files = Array(msg[:display_files]).dup
+        Array(msg[:content]).each do |block|
+          next unless block.is_a?(Hash)
+          next unless %w[image image_url].include?((block[:type] || block["type"]).to_s)
+
+          name = block[:image_name] || block["image_name"]
+          if name.nil? || name.to_s.strip.empty?
+            path = block[:image_path] || block["image_path"]
+            name = File.basename(path.to_s).sub(/\A[0-9a-f]{16}_/, "") unless path.to_s.empty?
+          end
+          name = "image" if name.nil? || name.to_s.strip.empty?
+          files << { name: name, type: "image" }
+        end
+
+        files.filter_map do |file|
+          next unless file.is_a?(Hash)
+
+          name = file[:name] || file["name"]
+          next if name.nil? || name.to_s.strip.empty?
+
+          type = file[:type] || file["type"] || "file"
+          type = "file" if type.to_s.strip.empty?
+          { name: name.to_s, type: type.to_s }
+        end.uniq { |file| [file[:name], file[:type]] }
+      end
+
+      # Once an image has a badge in the archive, omit the generic [image_url]
+      # placeholder from the visible replay text. Text blocks remain unchanged.
+      def format_archived_user_content(content, display_files)
+        return format_message_content(content) unless content.is_a?(Array)
+        return format_message_content(content) unless display_files.any? { |file| file[:type] == "image" }
+
+        visible_blocks = content.reject do |block|
+          block.is_a?(Hash) && %w[image image_url].include?((block[:type] || block["type"]).to_s)
+        end
+        format_message_content(visible_blocks)
+      end
+
+      def append_display_files_line(lines, files)
+        return if files.empty?
+
+        lines << "_Display files: #{files.to_json}_"
+        lines << ""
       end
 
       # Serialize persisted extension events into the chunk MD so they survive

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -979,7 +979,9 @@ module Clacky
 
           mime_type = (url || "")[/\Adata:([^;]+);/, 1] || "image/jpeg"
           ext       = mime_type.split("/").last
-          { name: "image_#{idx + 1}.#{ext}", mime_type: mime_type, data_url: url, path: path }
+          name      = block[:image_name] || block["image_name"]
+          name      = "image_#{idx + 1}.#{ext}" if name.nil? || name.to_s.strip.empty?
+          { name: name, mime_type: mime_type, data_url: url, path: path }
         end
       end
 

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -534,6 +534,7 @@ module Clacky
         sections.each do |sec|
           text = sec[:lines].join.strip
           text, sec_ext_events = extract_ext_events_from_text(text)
+          text, sec_display_files = extract_display_files_from_text(text)
 
           # Nested chunk: expand it recursively, prepend before current rounds
           if sec[:nested_chunk]
@@ -546,7 +547,7 @@ module Clacky
             next
           end
 
-          next if text.empty? && sec_ext_events.empty?
+          next if text.empty? && sec_ext_events.empty? && sec_display_files.empty?
 
           if sec[:role] == "user"
             round_index += 1
@@ -560,6 +561,7 @@ module Clacky
               _from_chunk: true
             }
             user_msg[:task_id] = sec[:task_id] if sec[:task_id]
+            user_msg[:display_files] = sec_display_files unless sec_display_files.empty?
             current_round = {
               user_msg: user_msg,
               events: [],
@@ -615,6 +617,35 @@ module Clacky
       rescue => e
         Clacky::Logger.warn("parse_chunk_md_to_rounds failed for #{chunk_path}: #{e.message}")
         []
+      end
+
+
+      # Pull lightweight attachment badge metadata out of a chunk section.
+      # The marker is internal archive data and must not appear in replayed text.
+      # Only name + type are accepted; paths and file contents are never restored.
+      def extract_display_files_from_text(text)
+        return [text, []] unless text.include?("_Display files:")
+
+        files = []
+        kept = text.each_line.reject do |line|
+          match = line.strip.match(/\A_Display files:\s*(\[.*\])_?\z/i)
+          next false unless match
+
+          parsed = JSON.parse(match[1]) rescue []
+          Array(parsed).each do |file|
+            next unless file.is_a?(Hash)
+
+            name = file["name"] || file[:name]
+            next if name.nil? || name.to_s.strip.empty?
+
+            type = file["type"] || file[:type] || "file"
+            type = "file" if type.to_s.strip.empty?
+            files << { name: name.to_s, type: type.to_s }
+          end
+          true
+        end
+
+        [kept.join.strip, files]
       end
 
 

--- a/lib/clacky/message_history.rb
+++ b/lib/clacky/message_history.rb
@@ -15,8 +15,10 @@ module Clacky
       subagent_instructions subagent_result subagent_transcript token_usage
       compressed_summary chunk_path truncated transient
       chunk_index chunk_count ext_events skill_command skill_command_display
-      display_references
+      display_files display_references
     ].freeze
+
+    INTERNAL_CONTENT_BLOCK_FIELDS = %i[image_path image_name].freeze
 
     # Cap on persisted ext_events per message. These are milestone events
     # (progress chatter is transient), so a handful per message is the norm —
@@ -358,7 +360,9 @@ module Clacky
           next nil
         end
 
-        block.key?(:image_path) ? block.reject { |k, _| k == :image_path } : block
+        next block if (block.keys & INTERNAL_CONTENT_BLOCK_FIELDS).empty?
+
+        block.reject { |key, _| INTERNAL_CONTENT_BLOCK_FIELDS.include?(key) }
       end
 
       return msg if cleaned == content

--- a/spec/clacky/agent/attachment_compression_spec.rb
+++ b/spec/clacky/agent/attachment_compression_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe "attachment metadata across compression" do
+  let(:writer) do
+    Class.new do
+      include Clacky::Agent::MessageCompressorHelper
+      public :render_message_sections
+    end.new
+  end
+
+  let(:reader) do
+    Class.new do
+      include Clacky::Agent::SessionSerializer
+      public :extract_display_files_from_text
+    end.new
+  end
+
+  it "archives only attachment name and type" do
+    md = writer.render_message_sections([
+      {
+        role: "user",
+        content: "",
+        display_files: [{
+          name: "data.csv",
+          type: "csv",
+          path: "/tmp/private/data.csv",
+          preview_path: "/tmp/private/preview.md",
+          size_bytes: 12_345,
+          content: "private file contents"
+        }]
+      }
+    ]).join("\n")
+
+    expect(md).to include('_Display files: [{"name":"data.csv","type":"csv"}]_')
+    expect(md).not_to include("/tmp/private")
+    expect(md).not_to include("12345")
+    expect(md).not_to include("private file contents")
+  end
+
+  it "restores lightweight metadata and strips the archive marker from text" do
+    text, files = reader.extract_display_files_from_text(
+      "Please analyze this\n_Display files: [{\"name\":\"report.pdf\",\"type\":\"pdf\"}]_"
+    )
+
+    expect(text).to eq("Please analyze this")
+    expect(files).to eq([{ name: "report.pdf", type: "pdf" }])
+  end
+
+  it "defaults a missing attachment type without restoring extra fields" do
+    _text, files = reader.extract_display_files_from_text(
+      '_Display files: [{"name":"notes.txt","path":"/tmp/notes.txt"}]_'
+    )
+
+    expect(files).to eq([{ name: "notes.txt", type: "file" }])
+  end
+
+  it "archives an inline image as a badge without retaining image data" do
+    md = writer.render_message_sections([
+      {
+        role: "user",
+        content: [{
+          type: "image_url",
+          image_url: { url: "data:image/png;base64,PRIVATE_IMAGE_DATA" },
+          image_path: "/tmp/private/photo.png",
+          image_name: "photo.png"
+        }]
+      }
+    ]).join("\n")
+
+    expect(md).to include('_Display files: [{"name":"photo.png","type":"image"}]_')
+    expect(md).not_to include("PRIVATE_IMAGE_DATA")
+    expect(md).not_to include("/tmp/private")
+    expect(md).not_to include("[image_url]")
+  end
+
+  it "does not mutate the original display metadata while adding image badges" do
+    files = [{ name: "report.pdf", type: "pdf" }]
+    message = {
+      role: "user",
+      content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AA==" }, image_name: "photo.png" }],
+      display_files: files
+    }
+
+    writer.render_message_sections([message])
+
+    expect(files).to eq([{ name: "report.pdf", type: "pdf" }])
+  end
+
+  it "stores the original image name as internal multipart metadata" do
+    content = Clacky::Agent.allocate.send(
+      :format_user_content,
+      "",
+      [{ url: "data:image/png;base64,AA==", path: "/tmp/random_photo.png", name: "photo.png" }]
+    )
+
+    expect(content.first[:image_name]).to eq("photo.png")
+  end
+end

--- a/spec/clacky/agent/session_replay_chunk_spec.rb
+++ b/spec/clacky/agent/session_replay_chunk_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe "replay_history chunk MD expansion" do
     end
 
     def show_user_message(content, task_id: nil, created_at: nil, files: [], editable: true, skill_command: nil, skill_command_display: nil)
-      @events << { type: :user, content: content, task_id: task_id, created_at: created_at, editable: editable }
+      @events << { type: :user, content: content, task_id: task_id, created_at: created_at,
+                   files: files, editable: editable }
     end
 
     def show_assistant_message(content, files:, interim: false, created_at: nil)
@@ -97,6 +98,33 @@ RSpec.describe "replay_history chunk MD expansion" do
       expect(rounds.first[:user_msg]).not_to have_key(:task_id)
       expect(rounds.first[:events].first[:content]).to include("Hi there")
       expect(rounds.first[:events].first[:role]).to eq("assistant")
+    end
+
+    it "keeps an attachment-only user round" do
+      path = File.join(sessions_dir, "chunk-1.md")
+      File.write(path, chunk_md(
+        user_content: '_Display files: [{"name":"data.csv","type":"csv"}]_',
+        assistant_content: "Processed"
+      ))
+
+      rounds = build_agent([]).send(:parse_chunk_md_to_rounds, path)
+
+      expect(rounds.size).to eq(1)
+      expect(rounds.first[:user_msg][:content]).to eq("")
+      expect(rounds.first[:user_msg][:display_files]).to eq([{ name: "data.csv", type: "csv" }])
+    end
+
+    it "removes attachment metadata from replayed user text" do
+      path = File.join(sessions_dir, "chunk-1.md")
+      File.write(path, chunk_md(
+        user_content: "Please analyze this\n\n_Display files: [{\"name\":\"data.csv\",\"type\":\"csv\"}]_",
+        assistant_content: "Processed"
+      ))
+
+      rounds = build_agent([]).send(:parse_chunk_md_to_rounds, path)
+
+      expect(rounds.first[:user_msg][:content]).to eq("Please analyze this")
+      expect(rounds.first[:user_msg][:display_files]).to eq([{ name: "data.csv", type: "csv" }])
     end
 
     it "restores task_id from a task-annotated user heading" do
@@ -363,6 +391,28 @@ RSpec.describe "replay_history chunk MD expansion" do
       expect(contents).to include(a_string_including("Current question"))
       expect(user_events.find { |event| event[:content] == "Current question" }[:task_id]).to eq(6)
       expect(result[:has_more]).to be false
+    end
+
+    it "replays an attachment-only message as a file badge" do
+      chunk_path = File.join(sessions_dir, "chunk-1.md")
+      File.write(chunk_path, chunk_md(
+        user_content: '_Display files: [{"name":"data.csv","type":"csv"}]_',
+        assistant_content: "Processed"
+      ))
+
+      messages = [
+        { role: "system", content: "You are helpful." },
+        { role: "assistant", content: "Summary...", compressed_summary: true, chunk_path: chunk_path }
+      ]
+
+      collector = TestCollector.new
+      build_agent(messages).replay_history(collector)
+
+      user_event = collector.events.find { |event| event[:type] == :user }
+      expect(user_event[:content]).to eq("")
+      expect(user_event[:files]).to contain_exactly(include(name: "data.csv", type: "csv",
+                                                            path: nil, preview_path: nil))
+      expect(user_event[:editable]).to be false
     end
 
     it "respects before cursor for chunk rounds" do

--- a/spec/clacky/agent/session_replay_image_only_spec.rb
+++ b/spec/clacky/agent/session_replay_image_only_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe "replay_history image-only user message" do
     {
       type: "image_url",
       image_url: { url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC" },
-      image_path: "/tmp/img_001.png"
+      image_path: "/tmp/img_001.png",
+      image_name: "IMG_1234.png"
     }
   end
 
@@ -80,7 +81,22 @@ RSpec.describe "replay_history image-only user message" do
     # … and carry the recovered image so the UI can render it.
     files = collector.user_messages.first[:files]
     expect(files).not_to be_empty
+    expect(files.first[:name]).to eq("IMG_1234.png")
     expect(files.first[:data_url]).to start_with("data:image/png")
+  end
+
+  it "falls back to a generated image name for legacy messages" do
+    legacy_image_block = image_block.dup.tap { |block| block.delete(:image_name) }
+    messages = [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: [legacy_image_block], created_at: Time.now.to_f }
+    ]
+
+    agent = build_agent(messages)
+    collector = ImageCollector.new
+    agent.replay_history(collector)
+
+    expect(collector.user_messages.first[:files].first[:name]).to eq("image_1.png")
   end
 
   it "still renders an image_url message that also has text (control)" do

--- a/spec/clacky/message_history_spec.rb
+++ b/spec/clacky/message_history_spec.rb
@@ -712,4 +712,27 @@ RSpec.describe Clacky::MessageHistory do
       expect(api_messages).to all(satisfy { |m| !m.key?(:subagent_transcript) })
     end
   end
+
+  describe "display_files internal field" do
+    let(:files) { [{ name: "data.csv", type: "csv", path: "/tmp/data.csv" }] }
+
+    it "is persisted internally but stripped from the LLM payload" do
+      history.append(user_msg("analyze this", display_files: files))
+
+      expect(history.to_a.last[:display_files]).to eq(files)
+      expect(history.to_api.last).not_to have_key(:display_files)
+    end
+
+    it "strips image badge metadata from multipart content" do
+      history.append(user_msg([
+        { type: "image_url", image_url: { url: "data:image/png;base64,AA==" },
+          image_path: "/tmp/photo.png", image_name: "photo.png" }
+      ]))
+
+      image_block = history.to_api.last[:content].first
+      expect(image_block).not_to have_key(:image_path)
+      expect(image_block).not_to have_key(:image_name)
+      expect(image_block.dig(:image_url, :url)).to eq("data:image/png;base64,AA==")
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Attachment metadata was not persisted when conversation messages were archived into chunk files. As a result, attachment badges disappeared after compression, and attachment-only user messages could be omitted entirely during session replay.

## Fix

- Persist only lightweight attachment metadata (`name` and `type`) in archived chunks.
- Restore attachment badges when replaying compressed sessions.
- Preserve original image names without storing image paths, previews, contents, or Base64 data.
- Keep attachment display metadata out of normal LLM API payloads.
- Retain attachment-only user messages during replay.

## Test

✅ Verified file and image attachment badges after conversation compression  
✅ Verified attachment-only messages remain visible during replay  
✅ Verified archived chunks contain only attachment names and types  
✅ Verified attachment metadata is excluded from LLM API payloads  
✅ Relevant specs: 100 examples, 0 failures  
✅ Manually tested successfully