### PR TITLE
fix(web): stabilize billing toolbar layout (C-5726)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -12681,26 +12681,6 @@ body.setup-mode[data-theme="dark"] {
   border-color: var(--color-accent-primary);
 }
 
-@media (max-width: 700px) {
-  .billing-controls .segmented-control {
-    flex: 1 0 100%;
-  }
-  .billing-model-filter {
-    width: auto;
-    flex: 1 1 0;
-  }
-}
-
-@media (max-width: 500px) {
-  .billing-controls .segmented-control {
-    overflow-x: auto;
-  }
-  .billing-controls .segmented-control__btn {
-    flex: 1 0 auto;
-    padding-inline: 0.5rem;
-  }
-}
-
 /* ── Stats Row ───────────────────────────────────────────────────────── */
 .billing-stats-row {
   display: grid;
@@ -14786,6 +14766,26 @@ body.setup-mode[data-theme="dark"] {
   #billing-body { padding: 1rem 1rem 1rem; }
   #trash-body   { padding: 1rem 1rem 1rem; }
 
+  .billing-controls .segmented-control {
+    flex: 1 0 100%;
+  }
+  .billing-controls .segmented-control__btn {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+  .billing-model-filter {
+    width: auto;
+    flex: 1 1 0;
+  }
+  @media (max-width: 500px) {
+    .billing-controls .segmented-control {
+      overflow-x: auto;
+    }
+    .billing-controls .segmented-control__btn {
+      flex: 1 0 auto;
+      padding-inline: 0.5rem;
+    }
+  }
   .billing-heatmap-row { grid-template-columns: 1fr; }
 
   /* ── MCP page ── */

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -12574,31 +12574,43 @@ body.setup-mode[data-theme="dark"] {
 }
 .billing-top-bar {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
   gap: 1rem;
 }
 .billing-title-row {
   display: flex;
   align-items: baseline;
+  flex-wrap: wrap;
   gap: 0.75rem;
+  min-width: 0;
 }
 .billing-title-row h2 {
   font-size: 1.5rem;
   font-weight: 500;
   color: var(--color-text-primary);
   margin: 0;
+  flex-shrink: 0;
 }
 .billing-subtitle {
   font-size: 0.875rem;
   color: var(--color-text-secondary);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .billing-controls {
   display: flex;
   align-items: center;
   gap: 0.625rem;
   flex-wrap: wrap;
+}
+.billing-controls .segmented-control {
+  flex: 0 0 auto;
+}
+.billing-controls .segmented-control,
+.billing-model-filter,
+.billing-share-btn {
+  height: 2rem;
 }
 
 /* ── Disclaimer notice ──────────────────────────────────────────────── */
@@ -12616,14 +12628,19 @@ body.setup-mode[data-theme="dark"] {
 
 /* ── Model Filter ────────────────────────────────────────────────────── */
 .billing-model-filter {
-  padding: 0.5375rem 1.75rem 0.5375rem 0.75rem;
+  width: 16rem;
+  flex: 0 0 16rem;
+  min-width: 0;
+  padding: 0 1.75rem 0 0.75rem;
   border: 1px solid var(--color-border-primary);
   border-radius: 8px;
   background: var(--color-bg-secondary);
   color: var(--color-text-primary);
   font-size: 0.8125rem;
   cursor: pointer;
-  min-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
@@ -12644,6 +12661,8 @@ body.setup-mode[data-theme="dark"] {
 .billing-share-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  margin-left: auto;
   gap: 0.375rem;
   padding: 0.4375rem 0.75rem;
   border: 1px solid var(--color-border-primary);
@@ -12660,6 +12679,26 @@ body.setup-mode[data-theme="dark"] {
   background: var(--color-bg-tertiary);
   color: var(--color-text-primary);
   border-color: var(--color-accent-primary);
+}
+
+@media (max-width: 700px) {
+  .billing-controls .segmented-control {
+    flex: 1 0 100%;
+  }
+  .billing-model-filter {
+    width: auto;
+    flex: 1 1 0;
+  }
+}
+
+@media (max-width: 500px) {
+  .billing-controls .segmented-control {
+    overflow-x: auto;
+  }
+  .billing-controls .segmented-control__btn {
+    flex: 1 0 auto;
+    padding-inline: 0.5rem;
+  }
 }
 
 /* ── Stats Row ───────────────────────────────────────────────────────── */


### PR DESCRIPTION

<img width="1510" height="551" alt="Snapzy_2026-09-01_16-01-35_011" src="https://github.com/user-attachments/assets/efe14f85-23e9-4b12-afce-8703bc818d08" />

## Problem

The Billing title, usage summary, period selector, model filter, and share button competed for space in the same wrapping row. Long usage values or model names could push controls onto another line and cause inconsistent alignment across languages.

## Fix

- Separate the Billing title and summary from the controls row.
- Keep the period selector at a compact natural width.
- Constrain long model names without allowing the select to expand the layout.
- Align the share button to the right side of the controls row.
- Use a consistent height for the period selector, model filter, and share button.
- Preserve responsive wrapping for narrow screens.

## Test

✅ Manually verified the desktop layout with long model names  
✅ Verified the period selector, model filter, and share button have equal heights  
✅ Verified the share button remains aligned to the right  
✅ Verified CSS structure is valid