### PR TITLE
fix(web): light group unread dot for backend-created sessions (C-5771)

### DIFF
--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -3501,7 +3501,11 @@ const Sessions = (() => {
           return !t || t < latest;
         };
         const renderGroup = source => {
-          const rows = _sessions.filter(s => s.source === source && !s.project_id);
+          // Scan _extraSessions too: a session created by the backend (e.g. a
+          // scheduler run) only reaches the client as a session_update, which
+          // patch() stores there — it would otherwise never light the dot.
+          const inGroup = s => s.source === source && !s.project_id;
+          const rows = _sessions.filter(inGroup).concat(_extraSessions.filter(inGroup));
           const dotStatus = ["running", "awaiting_feedback"].find(st => rows.some(s => s.status === st))
             || (rows.some(s => _recentlyDone.has(s.id)) ? "done" : null);
           _renderGroupItem(list, source, _groups.get(source).count, dotStatus);


### PR DESCRIPTION
## Problem

When the scheduler creates a new cron session in the background, the sidebar "Scheduled tasks" group entry updates its count but not its unread dot. The dot only appears after the user opens the group, loads its session list, and goes back.

`renderGroup()` computed the dot status by filtering `_sessions` only. A session created by the backend reaches the client solely as a `session_update` event, and `patch()` stores unknown ids in `_extraSessions` (a deliberately separate cache that must not pollute the `loadMore` pagination cursor). The count read `_groups.get(source).count`, which `patch()` does maintain, hence the split behaviour.

## Fix

Include `_extraSessions` in the dot scan inside `renderGroup()`. The dot is an aggregate, not a rendered row, so it does not touch the pagination cursor contract of `_extraSessions`.

## Test

Verified in a live browser against a running server:

- baseline: group entry `(24)`, dot `null`
- inject a cron `session_update` with `status: "running"` via `Sessions.patch()` + `renderList()`: entry becomes `(25)` with dot `dot-running` (was `null` before the fix)
- `Sessions.markDone()` on the same id: dot becomes `dot-done`
- after `clearDone()` + `remove()`: dot back to `null`, count restored

`bundle exec rspec`: 3820 examples, 0 failures.