### PR TITLE
fix(i18n): translate maximum reasoning effort

### DIFF
--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -1432,7 +1432,7 @@ const I18n = (() => {
       "sib.reasoning.medium":    "中",
       "sib.reasoning.high":      "高",
       "sib.reasoning.xhigh": "超高",
-      "sib.reasoning.max": "Max",
+      "sib.reasoning.max": "极高",
       "sessions.thinking":      "思考中…",
       "sessions.default_name":  "会话 {{n}}",
       "sessions.group.cron":     "定时任务",


### PR DESCRIPTION
## Problem

The maximum reasoning effort option remained untranslated as “Max” in the Chinese UI.

## Fix

Updated the Chinese translation to display “极高” while preserving “Max” in English and keeping the internal `max` value unchanged.

## Test

- ✅ Verified the Chinese menu displays: 默认、低、中、高、超高、极高.
- ✅ Verified the English translation remains “Max”.
- ✅ `bundle exec rspec spec/clacky/web/syntax_spec.rb` — 19 examples, 0 failures.