### PR TITLE
fix(web): improve message navigation for long conversations

### DIFF
--- a/lib/clacky/agent/chunk_index.rb
+++ b/lib/clacky/agent/chunk_index.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Clacky
+  class Agent
+    # Byte ranges only: no message bodies, tool outputs or persistent sidecars.
+    module ChunkIndex
+      private def chunk_section_header(line, directory)
+        if (match = line.match(/\A## Assistant \[Compressed Summary — original conversation at: (.+)\]/))
+          { role: "assistant", nested_chunk: File.join(directory, match[1]) }
+        elsif (match = line.match(/\A## (User|Assistant)(?: \[Task ([1-9]\d*)\])?\z/))
+          { role: match[1].downcase, task_id: match[2]&.to_i }
+        elsif line.start_with?("### Tool Result:")
+          { role: "tool" }
+        end
+      end
+
+      private def chunk_file_version(path)
+        stat = File.stat(path)
+        [stat.size, stat.mtime.to_f, stat.ctime.to_f].join(":")
+      rescue Errno::ENOENT
+        "missing"
+      end
+
+      private def chunk_navigation_index(path)
+        version = chunk_file_version(path)
+        @chunk_index_mutex ||= Mutex.new
+        @chunk_index_mutex.synchronize do
+          @chunk_indexes ||= {}
+          cached = @chunk_indexes[path]
+          return cached if cached && cached[:version] == version
+
+          index = version == "missing" ? { rounds: [], nested: [], section_count: 0 } : scan_chunk_index(path)
+          raise ArgumentError, "History changed while indexing" unless chunk_file_version(path) == version
+
+          @chunk_indexes[path] = index.merge(version: version)
+        end
+      end
+
+      private def scan_chunk_index(path)
+        rounds = []
+        nested = []
+        section_count = 0
+        user_start = nil
+        archived_at = nil
+        front_matter = false
+        directory = File.dirname(path)
+        position = 0
+        File.open(path, "rb") do |file|
+          while (line = file.gets)
+            start = position
+            position += line.bytesize
+            text = line.force_encoding(Encoding::UTF_8).scrub.chomp
+            if start.zero? && text == "---"
+              front_matter = true
+            elsif front_matter
+              front_matter = false if text == "---"
+              archived_at = (Time.parse(text.split(":", 2).last.strip) rescue nil) if text.start_with?("archived_at:")
+            end
+            header = chunk_section_header(text, directory)
+            if header
+              section_count += 1
+              nested << header[:nested_chunk] if header[:nested_chunk]
+              user_start = header[:role] == "user" ? start : nil
+            elsif user_start && !text.strip.empty?
+              # Match replay's empty/metadata-only user handling without
+              # retaining the rest of the user message or any assistant text.
+              visible, events = extract_ext_events_from_text(text)
+              visible, files = extract_display_files_from_text(visible)
+              next if visible.empty? && events.empty? && files.empty?
+
+              rounds.last[:length] = user_start - rounds.last[:start] if rounds.any?
+              rounds << { start: user_start }
+              user_start = nil
+            end
+          end
+          rounds.last[:length] = position - rounds.last[:start] if rounds.any?
+        end
+        { rounds: rounds, nested: nested, section_count: section_count,
+          base_time: (archived_at || File.mtime(path)).to_f }
+      end
+    end
+  end
+end

--- a/lib/clacky/agent/history_navigation.rb
+++ b/lib/clacky/agent/history_navigation.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+module Clacky
+  class Agent
+    # Read-only navigation: locations at startup, one preview on demand.
+    module HistoryNavigation
+      NAVIGATION_PREVIEW_LENGTH = 400
+
+      def history_navigation
+        sources = navigation_sources
+        manifest = sources.map do |source|
+          entry = { key: source[:key], version: source[:version], count: navigation_source_count(source),
+                    volatile: !!source[:rounds] || source[:continuation].to_a.any? }
+          entry[:identities] = source[:rounds].map { |round| round[:user_msg].values_at(:created_at, :task_id) } if source[:rounds]
+          entry
+        end
+        { sources: manifest, total: manifest.sum { |source| source[:count] } }
+      end
+
+      def history_navigation_preview(id:)
+        sources = navigation_sources
+        source_index, offset = navigation_position(sources, id)
+        unless offset && offset < navigation_source_count(sources[source_index])
+          raise ArgumentError, "History location is no longer available"
+        end
+        navigation_entry(navigation_source_rounds(sources, source_index, offset: offset, limit: 1).fetch(0))
+      end
+
+      def replay_history_window(ui, limit: 30, around: nil, before_id: nil, after_id: nil)
+        sources = navigation_sources
+        anchor = around || before_id || after_id
+        source_index, offset = anchor ? navigation_position(sources, anchor) : [sources.length - 1, nil]
+        count = navigation_source_count(sources[source_index])
+        offset ||= count
+        raise ArgumentError, "History location is no longer available" if anchor && offset >= count
+
+        # Around starts at the requested round; before/after are exclusive.
+        forward = !!(around || after_id)
+        offset += 1 if after_id
+        page = []
+        index = source_index
+        while index.between?(0, sources.length - 1) && page.length < limit
+          count = navigation_source_count(sources[index])
+          if forward
+            first = index == source_index ? offset : 0
+            page.concat(navigation_source_rounds(sources, index, offset: first, limit: limit - page.length))
+            index += 1
+          else
+            last = index == source_index ? offset : count
+            first = [last - (limit - page.length), 0].max
+            page = navigation_source_rounds(sources, index, offset: first, limit: last - first) + page
+            index -= 1
+          end
+        end
+
+        if page.empty? && !anchor
+          @history.to_a.each do |message|
+            next if message[:role].to_s == "system" || message[:system_injected]
+            _replay_single_message(message, ui)
+          end
+        else
+          replay_rounds(ui, page)
+        end
+        first = page.first&.dig(:navigation_id)
+        last = page.last&.dig(:navigation_id)
+        first_pos = first && navigation_position(sources, first)
+        last_pos = last && navigation_position(sources, last)
+        has_before = first_pos && (first_pos[1].positive? || first_pos[0].positive?)
+        has_after = last_pos && (last_pos[1] < navigation_source_count(sources[last_pos[0]]) - 1 ||
+          ((last_pos[0] + 1)...sources.length).any? { |i| navigation_source_count(sources[i]).positive? })
+        {
+          has_more: !!has_before, has_after: !!has_after,
+          before_cursor: first, after_cursor: last,
+          round_ids: page.map { |round| round[:navigation_id] }
+        }
+      end
+
+      private def real_history_user?(msg)
+        return false unless msg[:role].to_s == "user" && !msg[:system_injected]
+
+        content = msg[:content]
+        if content.is_a?(String)
+          !content.start_with?("[SYSTEM]")
+        elsif content.is_a?(Array)
+          content.any? { |block| block.is_a?(Hash) && %w[text image image_url].include?((block[:type] || block["type"]).to_s) }
+        else
+          false
+        end
+      end
+
+      private def navigation_sources
+        messages = @history.to_a
+        rounds = []
+        leading = []
+        chunks = []
+        messages.each do |msg|
+          if real_history_user?(msg)
+            rounds << { user_msg: msg, events: [], editable: true }
+          elsif msg[:compressed_summary]
+            paths = if msg[:chunk_path].to_s.empty?
+              session_manager.chunks_for_current(@session_id, @created_at).map { |chunk| chunk[:path] }
+            else
+              sibling_chunks_of(msg[:chunk_path])
+            end
+            chunks.concat(paths)
+          elsif rounds.empty?
+            leading << msg unless msg[:role].to_s == "system" || msg[:system_injected]
+          else
+            rounds.last[:events] << msg
+          end
+        end
+        sources = []
+        visited = Set.new
+        top_level = chunks.map { |path| File.basename(path) }.to_set
+        append_source = lambda do |path|
+          path = File.join(Clacky::SessionManager::SESSIONS_DIR, File.basename(path)) unless File.exist?(path)
+          path = File.expand_path(path)
+          next unless visited.add?(path)
+
+          index = chunk_navigation_index(path)
+          # Legacy nested references precede this source's own rounds. Sibling
+          # chunks already enumerated above must not be counted twice.
+          index[:nested].reverse_each do |nested|
+            append_source.call(nested) unless top_level.include?(File.basename(nested))
+          end
+          sources << { key: File.basename(path), path: path, version: index[:version], index: index }
+        end
+        chunks.uniq.each { |path| append_source.call(path) }
+        @chunk_index_mutex&.synchronize { @chunk_indexes&.delete_if { |path, _| !visited.include?(path) } }
+        last_archive = sources.reverse_each.find { |source| navigation_source_count(source).positive? }
+        last_archive[:continuation] = leading if last_archive
+        version = rounds.map { |round| round[:user_msg].values_at(:created_at, :task_id) }.hash.to_s
+        sources << { key: "live", rounds: rounds, version: version }
+        sources
+      end
+
+      private def navigation_source_count(source)
+        source[:rounds] ? source[:rounds].length : source[:index][:rounds].length
+      end
+
+      private def navigation_id(source, offset)
+        identity = source[:rounds] && offset && source[:rounds][offset]&.dig(:user_msg)&.values_at(:created_at, :task_id)
+        JSON.generate([source[:key], offset, source[:version], identity])
+      end
+
+      private def navigation_position(sources, id)
+        key, offset, version, identity = JSON.parse(id)
+        index = sources.index { |source| source[:key] == key }
+        if index && key == "live" && version != sources[index][:version] && identity.is_a?(Array) && identity.any?
+          matches = sources[index][:rounds].each_index.select do |i|
+            sources[index][:rounds][i][:user_msg].values_at(:created_at, :task_id) == identity
+          end
+          if matches.one?
+            offset = matches.first
+            version = sources[index][:version]
+          end
+        end
+        unless index && sources[index][:version] == version && (offset.nil? || (offset.is_a?(Integer) && offset >= 0))
+          raise ArgumentError, "History location is no longer available"
+        end
+        [index, offset]
+      rescue JSON::ParserError, TypeError
+        raise ArgumentError, "Invalid history location"
+      end
+
+      private def navigation_source_rounds(sources, index, offset: 0, limit: nil)
+        source = sources.fetch(index)
+        count = navigation_source_count(source)
+        length = [limit || count, count - offset].min
+        return [] unless length.positive?
+
+        siblings = sources.filter_map { |entry| entry[:key] if entry[:path] && entry != source }.to_set
+        rounds = if source[:rounds]
+          source[:rounds].slice(offset, length)
+        else
+          ranges = source[:index][:rounds]
+          first = ranges[offset]
+          last = ranges[offset + length - 1]
+          range = { start: first[:start], length: last[:start] + last[:length] - first[:start] }
+          result = parse_chunk_md_to_rounds(source[:path], excluded_paths: siblings, byte_range: range,
+            index: source[:index], round_offset: offset)
+          unless chunk_file_version(source[:path]) == source[:version] && result.length == length
+            raise ArgumentError, "History changed while reading"
+          end
+          result
+        end
+        if rounds.any? && offset + length == count && source[:continuation]
+          rounds.last[:events].concat(source[:continuation])
+        end
+        rounds.each { |round| round[:events].reject! { |event| event[:compressed_summary] } }
+        rounds.each_with_index do |round, position|
+          round[:navigation_id] = navigation_id(source, offset + position)
+        end
+        rounds
+      end
+
+      private def navigation_entry(round)
+        msg = round[:user_msg]
+        user = navigation_preview(msg[:display_text] || extract_text_from_content(msg[:content]))
+        if user.empty?
+          names = Array(msg[:display_files]).map { |file| file[:name] || file["name"] }
+          Array(msg[:content]).each do |block|
+            next unless block.is_a?(Hash) && %w[image image_url].include?((block[:type] || block["type"]).to_s)
+            names << (block[:image_name] || block["image_name"] || "image")
+          end
+          user = navigation_preview(names.compact.join(", "))
+        end
+        # A final reply is the last main-agent response, with no pending tool
+        # work. Earlier narration, reasoning and nested subagent transcripts
+        # must never be substituted for a missing final response.
+        last = round[:events].reverse.find do |event|
+          !event[:system_injected] && !event[:compressed_summary] &&
+            %w[assistant tool].include?(event[:role].to_s)
+        end
+        final = last && last[:role].to_s == "assistant" && !last[:interim] && Array(last[:tool_calls]).empty?
+        answer = final ? navigation_preview(extract_text_from_content(last[:content])) : ""
+        { id: round[:navigation_id], created_at: msg[:created_at], archived: round[:editable] == false,
+          user: user, assistant: answer }
+      end
+
+      private def navigation_preview(text)
+        text.to_s.gsub(/<think>.*?(?:<\/think>|\z)/m, "")
+          .strip[0, NAVIGATION_PREVIEW_LENGTH]
+      end
+    end
+  end
+end

--- a/lib/clacky/agent/history_navigation.rb
+++ b/lib/clacky/agent/history_navigation.rb
@@ -2,9 +2,10 @@
 
 module Clacky
   class Agent
-    # Read-only navigation: locations at startup, one preview on demand.
+    # Read-only navigation: locations at startup, bounded previews on demand.
     module HistoryNavigation
       NAVIGATION_PREVIEW_LENGTH = 400
+      NAVIGATION_PREVIEW_BATCH_LIMIT = 30
 
       def history_navigation
         sources = navigation_sources
@@ -18,12 +19,23 @@ module Clacky
       end
 
       def history_navigation_preview(id:)
-        sources = navigation_sources
-        source_index, offset = navigation_position(sources, id)
-        unless offset && offset < navigation_source_count(sources[source_index])
-          raise ArgumentError, "History location is no longer available"
+        history_navigation_previews(ids: [id]).fetch(0)
+      end
+
+      def history_navigation_previews(ids:)
+        ids = Array(ids)
+        if ids.length > NAVIGATION_PREVIEW_BATCH_LIMIT
+          raise ArgumentError, "Too many history locations"
         end
-        navigation_entry(navigation_source_rounds(sources, source_index, offset: offset, limit: 1).fetch(0))
+
+        sources = navigation_sources
+        ids.map do |id|
+          source_index, offset = navigation_position(sources, id)
+          unless offset && offset < navigation_source_count(sources[source_index])
+            raise ArgumentError, "History location is no longer available"
+          end
+          navigation_entry(navigation_source_rounds(sources, source_index, offset: offset, limit: 1).fetch(0))
+        end
       end
 
       def replay_history_window(ui, limit: 30, around: nil, before_id: nil, after_id: nil)

--- a/lib/clacky/agent/session_serializer.rb
+++ b/lib/clacky/agent/session_serializer.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require "strscan"
+require_relative "history_navigation"
+require_relative "chunk_index"
 
 module Clacky
   class Agent
     # Session serialization for saving and restoring agent state
     # Handles session data serialization and deserialization
     module SessionSerializer
+      include HistoryNavigation
+      include ChunkIndex
       # Restore from a saved session
       # @param session_data [Hash] Saved session data
       def restore_session(session_data)
@@ -289,77 +293,8 @@ module Clacky
       #   created_at < before. Pass nil to get the most recent rounds.
       # @return [Hash] { has_more: Boolean } — whether older rounds exist beyond this page
       def replay_history(ui, limit: 20, before: nil)
-        # Split @history into rounds, each starting at a real user message
-        rounds = []
-        current_round = nil
-
-        @history.to_a.each do |msg|
-          role = msg[:role].to_s
-
-          # A real user message can have either a String content or an Array content
-          # (Array = multipart: text + image blocks). Exclude system-injected messages
-          # and synthetic [SYSTEM] text messages.
-          is_real_user_msg = role == "user" && !msg[:system_injected] &&
-            if msg[:content].is_a?(String)
-              !msg[:content].start_with?("[SYSTEM]")
-            elsif msg[:content].is_a?(Array)
-              # Must contain at least one text or image block (not a tool_result array).
-              # "image_url" covers image-only messages (user sent a picture with no
-              # accompanying text); without it such messages start no round and get
-              # dropped on replay, making the image vanish on session reopen.
-              msg[:content].any? { |b| b.is_a?(Hash) && %w[text image image_url].include?(b[:type].to_s) }
-            else
-              false
-            end
-
-          if is_real_user_msg
-            # Start a new round at each real user message.
-            # editable: true — this message still lives in the active in-memory
-            # @history, so truncate_from_created_at can locate and truncate it.
-            current_round = { user_msg: msg, events: [], editable: true }
-            rounds << current_round
-          elsif current_round
-            current_round[:events] << msg
-          elsif msg[:compressed_summary]
-            # Compressed summary sitting before any user rounds — expand ALL chunk
-            # MD files that belong to the same session (siblings of chunk_path),
-            # in chunk-index ascending order.
-            #
-            # Under the current "single summary + previous_chunks index" scheme,
-            # session.json only keeps the newest compressed_summary message (which
-            # points at the newest chunk). Older chunks (chunk-1..chunk-N-1) are
-            # referenced only as basenames inside the summary text. Expanding just
-            # msg[:chunk_path] would therefore lose all prior chunks on replay.
-            #
-            # chunk_path may be blank when a hot restart's SIGKILL killed the
-            # worker after the chunk file was written but before its path was
-            # persisted into session.json. Fall back to discovering the chunks
-            # on disk from session_id + created_at so the history is not lost.
-            chunk_paths = if msg[:chunk_path].to_s.empty?
-              session_manager.chunks_for_current(@session_id, @created_at).map { |c| c[:path] }
-            else
-              sibling_chunks_of(msg[:chunk_path])
-            end
-            chunk_rounds = chunk_paths.flat_map { |p| parse_chunk_md_to_rounds(p) }
-            rounds.concat(chunk_rounds)
-            # After expanding, treat the last chunk round as the current round so that
-            # any orphaned assistant/tool messages that follow in session.json (belonging
-            # to the same task whose user message was compressed into the chunk) get
-            # appended here instead of being silently discarded.
-            current_round = rounds.last unless chunk_rounds.empty?
-          elsif rounds.last
-            # Orphaned non-user message with no current_round yet (e.g. recent_messages
-            # after compression started mid-task with no leading user message).
-            # Attach to the last known round rather than drop silently.
-            rounds.last[:events] << msg
-          end
-        end
-
-        # Expand any compressed_summary assistant messages sitting inside a round's events.
-        # These occur when compression happened mid-round (rare) — expand them in-place.
-        rounds.each do |round|
-          round[:events].select! { |ev| !ev[:compressed_summary] }
-        end
+        sources = navigation_sources
+        rounds = sources.each_index.flat_map { |index| navigation_source_rounds(sources, index) }
 
         # Apply before-cursor filter: only rounds whose user message created_at < before
         if before
@@ -379,6 +314,11 @@ module Clacky
         # Take the most recent `limit` rounds
         page = rounds.last(limit)
 
+        replay_rounds(ui, page)
+        { has_more: has_more }
+      end
+
+      private def replay_rounds(ui, page)
         page.each do |round|
           msg = round[:user_msg]
           raw_text    = msg[:display_text] || extract_text_from_content(msg[:content])
@@ -410,7 +350,6 @@ module Clacky
           end
         end
 
-        { has_more: has_more }
       end
 
       # Return all chunk MD file paths that belong to the same session as
@@ -446,7 +385,8 @@ module Clacky
       #
       # @param chunk_path [String] Path to the chunk md file
       # @return [Array<Hash>] rounds array (may be empty if file missing/unreadable)
-      private def parse_chunk_md_to_rounds(chunk_path, visited: Set.new)
+      private def parse_chunk_md_to_rounds(chunk_path, visited: Set.new, excluded_paths: Set.new,
+                                          byte_range: nil, index: nil, round_offset: 0)
         return [] unless chunk_path
 
         # 1. Try the stored absolute path first (same machine, normal case).
@@ -468,7 +408,14 @@ module Clacky
 
         # Scrub invalid UTF-8 bytes defensively — chunk files written before
         # the 0.9.37 fix may contain poisoned bytes from file_reader results.
-        raw = File.read(resolved).then do |s|
+        raw = (if byte_range
+          File.open(resolved, "rb") do |file|
+            file.seek(byte_range[:start])
+            file.read(byte_range[:length]).to_s.force_encoding(Encoding::UTF_8)
+          end
+        else
+          File.read(resolved)
+        end).then do |s|
           s.encoding == Encoding::UTF_8 && s.valid_encoding? ? s :
             s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "\u{FFFD}")
         end
@@ -486,7 +433,7 @@ module Clacky
             end
           end
         end
-        base_time = (archived_at || Time.now).to_f
+        base_time = index ? index[:base_time] : (archived_at || File.mtime(resolved)).to_f
         chunk_dir = File.dirname(chunk_path.to_s)
 
         # Split into sections by ## headings
@@ -498,25 +445,12 @@ module Clacky
 
         raw.each_line do |line|
           stripped = line.chomp
-          if (m = stripped.match(/\A## Assistant \[Compressed Summary — original conversation at: (.+)\]/))
-            # Nested chunk reference — record it, treat as assistant section
+          if (header = chunk_section_header(stripped, chunk_dir))
             sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
-            current_role         = "assistant"
+            current_role         = header[:role]
             current_lines        = []
-            current_nested_chunk = File.join(chunk_dir, m[1])
-            current_task_id      = nil
-          elsif (m = stripped.match(/\A## (User|Assistant)(?: \[Task ([1-9]\d*)\])?\z/))
-            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
-            current_role         = m[1].downcase
-            current_lines        = []
-            current_nested_chunk = nil
-            current_task_id      = m[2]&.to_i
-          elsif stripped.match?(/\A### Tool Result:/)
-            sections << { role: current_role, lines: current_lines.dup, nested_chunk: current_nested_chunk, task_id: current_task_id } if current_role
-            current_role         = "tool"
-            current_lines        = []
-            current_nested_chunk = nil
-            current_task_id      = nil
+            current_nested_chunk = header[:nested_chunk]
+            current_task_id      = header[:task_id]
           else
             current_lines << line
           end
@@ -538,11 +472,15 @@ module Clacky
 
           # Nested chunk: expand it recursively, prepend before current rounds
           if sec[:nested_chunk]
-            nested = parse_chunk_md_to_rounds(sec[:nested_chunk], visited: visited)
+            nested = if excluded_paths.include?(File.basename(sec[:nested_chunk]))
+              []
+            else
+              parse_chunk_md_to_rounds(sec[:nested_chunk], visited: visited, excluded_paths: excluded_paths)
+            end
             rounds = nested + rounds unless nested.empty?
             # Also render its summary text as an assistant event in current round if any
             if current_round && !text.empty?
-              current_round[:events] << { role: "assistant", content: text }
+              current_round[:events] << { role: "assistant", content: text, compressed_summary: true }
             end
             next
           end
@@ -552,7 +490,7 @@ module Clacky
           if sec[:role] == "user"
             round_index += 1
             # Synthetic timestamp: spread rounds backwards from archived_at
-            synthetic_ts = base_time - (sections.size - round_index) * 1.0
+            synthetic_ts = base_time - ((index ? index[:section_count] : sections.size) - round_offset - round_index) * 1.0
             user_msg = {
               role: "user",
               content: text,
@@ -594,7 +532,9 @@ module Clacky
 
               # Flush any plain text
               plain_text = remaining_lines.join.strip
-              current_round[:events] << { role: "assistant", content: plain_text } unless plain_text.empty?
+              unless plain_text.empty?
+                current_round[:events] << { role: "assistant", content: plain_text, interim: !pending_tool_entries.empty? }
+              end
 
               # Emit one synthetic tool_calls message per detected tool
               pending_tool_entries.each do |entry|
@@ -774,7 +714,8 @@ module Clacky
             else
               raw_text
             end
-            ui.show_assistant_message(text, files: [], created_at: msg[:created_at])
+            ui.show_assistant_message(text, files: [], created_at: msg[:created_at],
+                                      interim: !!msg[:interim] || Array(msg[:tool_calls]).any?)
           end
 
           # Tool calls embedded in assistant message

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -102,7 +102,7 @@ module Clacky
 
         # Rewrite local image paths to /api/local-image proxy URLs for browser rendering
         rewritten = Utils::FileProcessor.rewrite_local_image_urls(content.to_s)
-        ev = { type: "assistant_message", session_id: @session_id, content: rewritten }
+        ev = { type: "assistant_message", session_id: @session_id, content: rewritten, interim: interim }
         ev[:created_at] = created_at if created_at
         @events << stamp(ev)
       end
@@ -6756,15 +6756,38 @@ module Clacky
 
         unless agent
           Clacky::Logger.warn("[messages] agent is nil", session_id: session_id)
+          if query["navigation"] == "1"
+            return json_response(res, 200, { sources: [], total: 0 })
+          end
+          if query["preview"]
+            return json_response(res, 409, { error: "History location is no longer available" })
+          end
           return json_response(res, 200, { events: [], has_more: false })
         end
 
         # Collect events emitted by replay_history via a lightweight collector UI
+        if query["navigation"] == "1"
+          return json_response(res, 200, agent.history_navigation)
+        end
+        if query["preview"]
+          return json_response(res, 200, agent.history_navigation_preview(id: query["preview"]))
+        end
         collected = []
         collector = HistoryCollector.new(session_id, collected)
-        result    = agent.replay_history(collector, limit: limit, before: before)
+        if query["window"] == "1"
+          result = agent.replay_history_window(collector, limit: limit, around: query["around"],
+            before_id: query["before_id"], after_id: query["after_id"])
+          ids = result.delete(:round_ids)
+          collected.select { |event| event[:type] == "history_user_message" }.each_with_index do |event, index|
+            event[:round_id] = ids[index]
+          end
+        else
+          result = agent.replay_history(collector, limit: limit, before: before)
+        end
 
-        json_response(res, 200, { events: collected, has_more: result[:has_more] })
+        json_response(res, 200, { events: collected }.merge(result))
+      rescue ArgumentError => e
+        json_response(res, 409, { error: e.message })
       end
 
       # ── Project API ───────────────────────────────────────────────────────────

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -6759,6 +6759,9 @@ module Clacky
           if query["navigation"] == "1"
             return json_response(res, 200, { sources: [], total: 0 })
           end
+          if query["previews"]
+            return json_response(res, 200, { previews: [] })
+          end
           if query["preview"]
             return json_response(res, 409, { error: "History location is no longer available" })
           end
@@ -6768,6 +6771,12 @@ module Clacky
         # Collect events emitted by replay_history via a lightweight collector UI
         if query["navigation"] == "1"
           return json_response(res, 200, agent.history_navigation)
+        end
+        if query["previews"]
+          ids = JSON.parse(query["previews"])
+          raise ArgumentError, "History locations must be an array" unless ids.is_a?(Array)
+
+          return json_response(res, 200, { previews: agent.history_navigation_previews(ids: ids) })
         end
         if query["preview"]
           return json_response(res, 200, agent.history_navigation_preview(id: query["preview"]))
@@ -6786,7 +6795,7 @@ module Clacky
         end
 
         json_response(res, 200, { events: collected }.merge(result))
-      rescue ArgumentError => e
+      rescue ArgumentError, JSON::ParserError => e
         json_response(res, 409, { error: e.message })
       end
 

--- a/lib/clacky/server/web_ui_controller.rb
+++ b/lib/clacky/server/web_ui_controller.rb
@@ -105,7 +105,7 @@ module Clacky
         # Channel subscribers receive the original content so they can deliver
         # local images as native attachments via send_file().
         web_content = Clacky::Utils::FileProcessor.rewrite_local_image_urls(content.to_s)
-        emit("assistant_message", content: web_content, files: files, created_at: created_at)
+        emit("assistant_message", content: web_content, files: files, created_at: created_at, interim: interim)
         forward_to_subscribers { |sub| sub.show_assistant_message(content, files: files, interim: interim) }
       end
 

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2808,6 +2808,8 @@ body {
 #chat-panel { flex: 1; display: flex; flex-direction: row; overflow: hidden; position: relative; }
 #chat-main {
   --chat-nav-width: 2.5rem;
+  --chat-nav-expanded-width: 22rem;
+  --chat-nav-row-height: 2rem;
   --chat-nav-scrollbar-space: 12px;
   flex: 1;
   display: flex;
@@ -3271,6 +3273,8 @@ body {
    Absolutely positioned inside #chat-main, vertically synced to #messages
    via JS (ResizeObserver). The track scrolls independently of the chat. */
 .chat-navigator {
+  --chat-nav-frame-top: 0px;
+  --chat-nav-frame-height: 100%;
   position: absolute;
   right: var(--chat-nav-scrollbar-space);
   width: var(--chat-nav-width);
@@ -3278,9 +3282,50 @@ body {
   pointer-events: none;
   display: flex;
   flex-direction: column;
+  transition: width 0.14s ease;
+}
+.chat-nav-frame {
+  position: absolute;
+  z-index: 0;
+  left: 0;
+  right: 0;
+  top: var(--chat-nav-frame-top);
+  height: var(--chat-nav-frame-height);
+  border-radius: 0.75rem;
+  background: var(--color-bg-primary);
+  box-shadow: 0 0 0 1px var(--color-border-primary), 0 0.5rem 1.75rem rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  transition: opacity 0.14s ease;
+  pointer-events: none;
+}
+.chat-nav-viewport {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+.chat-navigator.expanded {
+  width: var(--chat-nav-expanded-width);
+}
+.chat-navigator.expanded .chat-nav-frame {
+  opacity: 1;
+  pointer-events: auto;
+}
+.chat-navigator.expanded .chat-nav-viewport {
+  /* Keep the track geometry stable; only its paint/hit-test viewport changes. */
+  clip-path: inset(
+    calc(var(--chat-nav-frame-top) + 0.75rem)
+    0
+    calc(100% - var(--chat-nav-frame-top) - var(--chat-nav-frame-height) + 0.75rem)
+    0
+    round 0.6875rem
+  );
 }
 .chat-nav-track {
-  flex: 1;
+  position: relative;
+  width: 100%;
+  height: 100%;
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
@@ -3297,41 +3342,92 @@ body {
 .chat-nav-canvas {
   position: relative;
 }
+.chat-nav-row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: var(--chat-nav-row-height);
+  transform: translateY(-50%);
+  border-radius: 0.375rem;
+  transition: background 0.12s ease;
+}
+.chat-navigator.expanded .chat-nav-row:hover,
+.chat-navigator.expanded .chat-nav-row.hovered {
+  background: var(--color-bg-hover);
+}
 .chat-nav-bar {
   position: absolute;
   right: 0.5rem;
+  top: 50%;
+  width: 0.625rem;
   height: 0.1875rem;
   transform: translateY(-50%);
   border-radius: 0.125rem;
-  background: var(--color-border-secondary);
-  cursor: pointer;
-  pointer-events: none;
-  opacity: 0.45;
-  transition: width 0.12s ease, opacity 0.12s ease, background 0.12s ease;
-}
-.chat-nav-bar.nearby {
-  opacity: 0.6;
   background: var(--color-text-muted);
+  pointer-events: none;
+  opacity: 0.62;
+  transition: opacity 0.12s ease, background 0.12s ease;
 }
-.chat-nav-bar.active,
-.chat-nav-bar.hovered {
+.chat-nav-row.active .chat-nav-bar,
+.chat-nav-row.hovered .chat-nav-bar {
   opacity: 1;
   background: var(--color-accent-primary);
 }
+.chat-nav-user {
+  position: absolute;
+  left: 1rem;
+  right: var(--chat-nav-width);
+  top: 50%;
+  transform: translateY(-50%);
+  visibility: hidden;
+  opacity: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.4;
+  transition: color 0.1s ease, opacity 0.1s ease;
+}
+.chat-navigator.expanded .chat-nav-user {
+  visibility: visible;
+  opacity: 1;
+}
+.chat-nav-row.active .chat-nav-user,
+.chat-nav-row.hovered .chat-nav-user {
+  color: var(--color-text-primary);
+}
+.chat-nav-user code {
+  padding: 0.0625rem 0.1875rem;
+  border-radius: 0.1875rem;
+  background: var(--color-bg-tertiary);
+  font-size: 0.9em;
+}
+.chat-nav-row.loading .chat-nav-user::after {
+  content: "";
+  display: block;
+  width: 72%;
+  height: 0.75rem;
+  margin-top: 0.25rem;
+  border-radius: 0.25rem;
+  background: var(--color-border-secondary);
+  animation: chat-nav-pulse 1.2s ease-in-out infinite alternate;
+}
 
-/* ── Hover popup ─────────────────────────────────────────────────────────── */
+/* ── Final-answer tooltip ────────────────────────────────────────────────── */
 .chat-nav-popup {
   position: absolute;
-  right: 100%;
+  z-index: 3;
+  right: calc(100% + 0.5rem);
   top: 0;
-  width: 23rem;
-  max-width: 70vw;
+  width: 20rem;
+  max-width: 55vw;
   max-height: 100%;
   margin: 0;
   padding: 0.75rem;
   text-align: left;
   font: inherit;
-  cursor: pointer;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border-primary);
   border-radius: 0.5rem;
@@ -3340,25 +3436,17 @@ body {
   flex-direction: column;
   gap: 0.375rem;
   overflow: hidden;
-  pointer-events: auto;
+  pointer-events: none;
 }
 .chat-nav-popup[hidden] { display: none; }
-.chat-nav-user,
 .chat-nav-answer {
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   overflow: hidden;
   overflow-wrap: anywhere;
   font-size: 0.8125rem;
   line-height: 1.5;
-}
-.chat-nav-user {
-  color: var(--color-text-primary);
-  font-weight: 600;
-}
-.chat-nav-answer {
-  -webkit-line-clamp: 3;
   color: var(--color-text-secondary);
 }
 .chat-nav-popup code {
@@ -3382,7 +3470,13 @@ body {
   to { opacity: 0.8; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .chat-nav-bar { transition: none; }
+  .chat-navigator,
+  .chat-nav-frame,
+  .chat-nav-track,
+  .chat-nav-row,
+  .chat-nav-bar,
+  .chat-nav-user { transition: none; }
+  .chat-nav-row.loading .chat-nav-user::after,
   .chat-nav-popup.loading span { animation: none; }
 }
 

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -2806,7 +2806,16 @@ body {
 
 /* ── Chat panel ──────────────────────────────────────────────────────────── */
 #chat-panel { flex: 1; display: flex; flex-direction: row; overflow: hidden; position: relative; }
-#chat-main { flex: 1; display: flex; flex-direction: column; overflow: hidden; position: relative; min-width: 0; }
+#chat-main {
+  --chat-nav-width: 2.5rem;
+  --chat-nav-scrollbar-space: 12px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+  min-width: 0;
+}
 
 /* ── Session extension slots (agent-scoped panels mount here) ───────────────
    Each slot is laid out by the host; an empty slot collapses to zero so it
@@ -3254,16 +3263,17 @@ body {
   flex-direction: column;
   gap: 0.75rem;
 }
+.has-chat-navigator > .chat-messages-scroll {
+  padding-right: calc(var(--chat-nav-width) + var(--chat-nav-overlay-space, var(--chat-nav-scrollbar-space)) + 0.5rem);
+}
 
 /* ── Chat navigator (right-edge minimap) ───────────────────────────────────
    Absolutely positioned inside #chat-main, vertically synced to #messages
-   via JS (ResizeObserver). Bars are evenly distributed; the active one
-   (matching current scroll position) is highlighted. Hover opens a popup
-   listing every message preview; click scrolls to that message. */
+   via JS (ResizeObserver). The track scrolls independently of the chat. */
 .chat-navigator {
   position: absolute;
-  right: 0;
-  width: 1.5rem;
+  right: var(--chat-nav-scrollbar-space);
+  width: var(--chat-nav-width);
   z-index: 10;
   pointer-events: none;
   display: flex;
@@ -3271,35 +3281,40 @@ body {
 }
 .chat-nav-track {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.25rem;
-  padding: 0.625rem 0.375rem;
-  pointer-events: none;
-  overflow: hidden;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: none;
+  overscroll-behavior: contain;
+  pointer-events: auto;
+  cursor: pointer;
+}
+.chat-nav-track::-webkit-scrollbar { display: none; }
+.chat-nav-track:focus-visible {
+  outline: 1px solid var(--color-accent-primary);
+  outline-offset: -1px;
+}
+.chat-nav-canvas {
+  position: relative;
 }
 .chat-nav-bar {
+  position: absolute;
+  right: 0.5rem;
   height: 0.1875rem;
-  flex-shrink: 0;
+  transform: translateY(-50%);
   border-radius: 0.125rem;
   background: var(--color-border-secondary);
   cursor: pointer;
-  pointer-events: auto;
+  pointer-events: none;
   opacity: 0.45;
-  transition: opacity 0.15s ease, background 0.15s ease, transform 0.12s ease;
+  transition: width 0.12s ease, opacity 0.12s ease, background 0.12s ease;
 }
-.chat-nav-bar:hover {
-  opacity: 0.85;
+.chat-nav-bar.nearby {
+  opacity: 0.6;
   background: var(--color-text-muted);
-  transform: scaleX(1.6);
 }
+.chat-nav-bar.active,
 .chat-nav-bar.hovered {
-  opacity: 0.85;
-  background: var(--color-text-muted);
-  transform: scaleX(1.6);
-}
-.chat-nav-bar.active {
   opacity: 1;
   background: var(--color-accent-primary);
 }
@@ -3309,60 +3324,66 @@ body {
   position: absolute;
   right: 100%;
   top: 0;
-  width: 17rem;
-  max-width: 60vw;
+  width: 23rem;
+  max-width: 70vw;
   max-height: 100%;
-  margin-right: 0.25rem;
+  margin: 0;
+  padding: 0.75rem;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border-primary);
   border-radius: 0.5rem;
   box-shadow: 0 0.25rem 1.5rem rgba(0, 0, 0, 0.12);
   display: flex;
   flex-direction: column;
+  gap: 0.375rem;
   overflow: hidden;
   pointer-events: auto;
 }
-.chat-nav-popup-header {
-  flex-shrink: 0;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--color-border-secondary);
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.chat-nav-popup-list {
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding: 0.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.0625rem;
-}
-.chat-nav-popup-item {
-  padding: 0.4375rem 0.625rem;
-  border-radius: 0.375rem;
-  cursor: pointer;
-  font-size: 0.8125rem;
-  line-height: 1.4;
-  color: var(--color-text-secondary);
-  display: flex;
-  align-items: flex-start;
-  gap: 0.375rem;
-  transition: background 0.1s ease, color 0.1s ease;
-}
-.chat-nav-popup-item:hover,
-.chat-nav-popup-item.highlighted {
-  background: var(--color-bg-hover);
-  color: var(--color-text-primary);
-}
-.chat-nav-popup-item-text {
+.chat-nav-popup[hidden] { display: none; }
+.chat-nav-user,
+.chat-nav-answer {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+.chat-nav-user {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+.chat-nav-answer {
+  -webkit-line-clamp: 3;
+  color: var(--color-text-secondary);
+}
+.chat-nav-popup code {
+  padding: 0.0625rem 0.1875rem;
+  border-radius: 0.1875rem;
+  background: var(--color-bg-tertiary);
+  font-size: 0.9em;
+  white-space: normal;
+}
+.chat-nav-popup.loading span {
+  width: 100%;
+  height: 1rem;
+  margin: 0.25rem 0;
+  border-radius: 0.25rem;
+  background: var(--color-border-secondary);
+  animation: chat-nav-pulse 1.2s ease-in-out infinite alternate;
+}
+.chat-nav-popup.loading .chat-nav-answer { width: 80%; height: 2.5rem; }
+@keyframes chat-nav-pulse {
+  from { opacity: 0.35; }
+  to { opacity: 0.8; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-nav-bar { transition: none; }
+  .chat-nav-popup.loading span { animation: none; }
 }
 
 /* Empty-state hint: shown inside #messages when a session has no messages yet.

--- a/lib/clacky/web/components/chat-navigator.js
+++ b/lib/clacky/web/components/chat-navigator.js
@@ -2,18 +2,23 @@
 "use strict";
 
 (() => {
-  const STEP = 12;
+  const STEP = 32;
   const PADDING = 20;
-  const LENS_RADIUS = 3;
   const PREVIEW_DELAY = 120;
+  // Navigation IDs include source versions and are URL encoded in a GET query.
+  // Keep each batch below WEBrick's request-target limit, then drain visible
+  // rows serially through _renderTicks() after every response.
+  const PREVIEW_BATCH_SIZE = 8;
   const PREVIEW_CACHE_SIZE = 80;
   const BOTTOM_TOLERANCE = 1;
-  let nav, track, canvas, popup, userPreview, answerPreview, messages, chatMain;
+  let nav, track, canvas, popup, answerPreview, messages, chatMain;
   let sessionId = null;
   let items = [];
   let loaded = [];
   let activeIdx = -1;
   let hoveredIdx = -1;
+  let expanded = false;
+  let hoveringMessage = false;
   let loading = false;
   let failed = false;
   let jumping = false;
@@ -21,15 +26,18 @@
   let generation = 0;
   let refreshTimer, syncTimer, hideTimer, scrollFrame;
   let pointerY = null;
-  let previewTimer, previewRequest, previewTarget;
-  let previewDue = false;
-  let previewFailure = null;
+  let previewTimer, previewRequest, previewQueueKey;
+  const previewFailures = new Set();
   const previews = new Map();
   const renderedTicks = new Map();
   const previewText = new WeakMap();
 
+  function _contentSpan() {
+    return Math.max(0, (items.length - 1) * STEP);
+  }
+
   function _baseOffset() {
-    return Math.max(PADDING, (track.clientHeight - items.length * STEP) / 2);
+    return Math.max(PADDING, (track.clientHeight - _contentSpan()) / 2);
   }
 
   function _tickY(index) {
@@ -40,6 +48,24 @@
     if (!items.length) return -1;
     const index = Math.round((y + track.scrollTop - _baseOffset()) / STEP);
     return Math.max(0, Math.min(items.length - 1, index));
+  }
+
+  function _visibleBounds() {
+    const first = Math.max(0, Math.floor((track.scrollTop - _baseOffset()) / STEP) - 2);
+    const last = Math.min(items.length, first + Math.ceil(track.clientHeight / STEP) + 5);
+    return { first, last };
+  }
+
+  function _intersectsViewport(index) {
+    const y = _tickY(index) - track.scrollTop;
+    return y + STEP / 2 > 0 && y - STEP / 2 < track.clientHeight;
+  }
+
+  function _visiblePreviewIds(first, last) {
+    return items.slice(first, last)
+      .map((item, offset) => ({ id: item.id, index: first + offset }))
+      .filter(item => _intersectsViewport(item.index))
+      .map(item => item.id);
   }
 
   function _syncBounds() {
@@ -60,7 +86,8 @@
     nav.style.right = `${main.right - rect.right + scrollbarSpace}px`;
     nav.style.top = `${top - main.top}px`;
     nav.style.height = `${Math.max(0, rect.bottom - top - 16)}px`;
-    popup.style.maxWidth = `${Math.max(0, rect.width - scrollbarSpace - parseFloat(getComputedStyle(nav).width) - 12)}px`;
+    const expandedWidth = parseFloat(getComputedStyle(chatMain).getPropertyValue("--chat-nav-expanded-width")) || 368;
+    popup.style.maxWidth = `${Math.max(0, rect.width - scrollbarSpace - expandedWidth - 12)}px`;
     _renderTicks();
   }
 
@@ -69,10 +96,15 @@
     const visible = items.length > 1 || loading || failed;
     nav.style.display = visible ? "" : "none";
     chatMain.classList.toggle("has-chat-navigator", visible);
-    canvas.style.height = `${Math.max(track.clientHeight, items.length * STEP + PADDING * 2)}px`;
-    // Only visible ticks and a small buffer get DOM nodes.
-    const first = Math.max(0, Math.floor((track.scrollTop - _baseOffset()) / STEP) - LENS_RADIUS - 2);
-    const last = Math.min(items.length, first + Math.ceil(track.clientHeight / STEP) + LENS_RADIUS * 2 + 5);
+    const contentHeight = _contentSpan() + PADDING * 2;
+    canvas.style.height = `${Math.max(track.clientHeight, contentHeight)}px`;
+    const compact = items.length > 0 && contentHeight <= track.clientHeight;
+    const frameTop = compact ? Math.max(0, _baseOffset() - STEP / 2 - 8) : 0;
+    const frameHeight = compact ? Math.min(track.clientHeight - frameTop, items.length * STEP + 16) : track.clientHeight;
+    nav.style.setProperty("--chat-nav-frame-top", `${frameTop}px`);
+    nav.style.setProperty("--chat-nav-frame-height", `${frameHeight}px`);
+    // Only visible rows and a small buffer get DOM nodes.
+    const { first, last } = _visibleBounds();
     for (const [index, tick] of renderedTicks) {
       if (index < first || index >= last) { tick.remove(); renderedTicks.delete(index); }
     }
@@ -80,24 +112,40 @@
       let tick = renderedTicks.get(i);
       if (!tick) {
         tick = document.createElement("div");
-        tick.className = "chat-nav-bar";
+        tick.className = "chat-nav-row";
+        const user = document.createElement("span");
+        user.className = "chat-nav-user";
+        const bar = document.createElement("span");
+        bar.className = "chat-nav-bar";
+        tick.appendChild(user);
+        tick.appendChild(bar);
         tick.id = `chat-nav-tick-${i}`;
         tick.setAttribute("role", "option");
         renderedTicks.set(i, tick);
         canvas.appendChild(tick);
       }
-      const distance = hoveredIdx < 0 ? Infinity : Math.abs(i - hoveredIdx);
+      const preview = previews.get(items[i].id);
+      const previewFailed = previewFailures.has(items[i].id);
       tick.classList.toggle("active", i === activeIdx);
       tick.classList.toggle("hovered", i === hoveredIdx);
-      tick.classList.toggle("nearby", distance > 0 && distance <= LENS_RADIUS);
+      tick.classList.toggle("loading", expanded && !preview && !previewFailed);
+      tick.classList.toggle("failed", previewFailed);
       tick.style.top = `${_tickY(i)}px`;
-      tick.style.width = `${distance <= LENS_RADIUS ? 30 - distance * 6 : 9}px`;
       tick.setAttribute("aria-selected", String(i === hoveredIdx));
-      tick.setAttribute("aria-label", previews.get(items[i].id)?.user || I18n.t("chat.nav.round", { number: i + 1 }));
+      tick.setAttribute("aria-label", preview?.user || I18n.t("chat.nav.round", { number: i + 1 }));
+      if (expanded) {
+        const user = preview
+          ? preview.user || I18n.t("chat.nav.empty")
+          : previewFailed ? I18n.t("chat.nav.retry") : "";
+        _setPreview(tick.querySelector(".chat-nav-user"), user);
+      }
     }
-    if (hoveredIdx >= first && hoveredIdx < last) track.setAttribute("aria-activedescendant", `chat-nav-tick-${hoveredIdx}`);
+    if (hoveredIdx >= first && hoveredIdx < last) {
+      track.setAttribute("aria-activedescendant", `chat-nav-tick-${hoveredIdx}`);
+    }
     else track.removeAttribute("aria-activedescendant");
     _renderPreview();
+    if (expanded && !loading && !failed) _queueVisiblePreviews(first, last);
   }
 
   function _setPreview(element, text) {
@@ -107,61 +155,70 @@
   }
 
   function _renderPreview() {
-    if (!popup || (hoveredIdx < 0 && pointerY === null)) return;
+    if (!popup) return;
+    if (!expanded || !hoveringMessage || hoveredIdx < 0) {
+      popup.hidden = true;
+      return;
+    }
     popup.hidden = false;
     const item = items[hoveredIdx];
     const preview = item && previews.get(item.id);
-    const previewFailed = item && previewFailure === item.id;
+    const previewFailed = item && previewFailures.has(item.id);
     const skeleton = !failed && !previewFailed && (jumping || (item ? !preview : loading));
     popup.classList.toggle("loading", skeleton);
     popup.setAttribute("aria-busy", String(skeleton));
-    _setPreview(userPreview, skeleton ? "" : preview?.user || I18n.t(failed || previewFailed ? "chat.nav.retry" : "chat.nav.empty"));
     _setPreview(answerPreview, skeleton ? "" : failed || previewFailed ? I18n.t("chat.nav.retry") : preview?.assistant || I18n.t("chat.nav.noReply"));
     const center = item ? _tickY(hoveredIdx) - track.scrollTop : pointerY || 0;
     popup.style.top = `${Math.max(0, Math.min(center - popup.offsetHeight / 2, nav.clientHeight - popup.offsetHeight))}px`;
-    if (!loading && !failed) _queuePreview(item);
   }
 
-  function _queuePreview(item) {
-    if (previewTarget === item?.id) return;
-    clearTimeout(previewTimer);
-    previewTarget = item?.id;
-    previewDue = false;
-    previewFailure = null;
-    if (!item) return;
-    if (previews.has(item.id)) {
-      const cached = previews.get(item.id);
-      previews.delete(item.id);
-      previews.set(item.id, cached);
+  function _queueVisiblePreviews(first, last) {
+    if (!expanded || previewRequest) return;
+    const ids = _visiblePreviewIds(first, last)
+      .filter(id => !previews.has(id) && !previewFailures.has(id))
+      .slice(0, PREVIEW_BATCH_SIZE);
+    const key = ids.join("\n");
+    if (!ids.length) {
+      clearTimeout(previewTimer);
+      previewQueueKey = null;
       return;
     }
-    previewTimer = setTimeout(() => { previewDue = true; _loadPreview(); }, PREVIEW_DELAY);
+    if (previewQueueKey === key) return;
+
+    clearTimeout(previewTimer);
+    previewQueueKey = key;
+    previewTimer = setTimeout(() => {
+      previewQueueKey = null;
+      _loadVisiblePreviews(ids);
+    }, PREVIEW_DELAY);
   }
 
-  async function _loadPreview() {
-    if (!previewDue || previewRequest || !previewTarget || previews.has(previewTarget)) return;
-    previewDue = false;
-    const request = { id: previewTarget, generation, controller: new AbortController() };
+  async function _loadVisiblePreviews(ids) {
+    ids = ids.filter(id => !previews.has(id));
+    if (previewRequest || !ids.length) return;
+    const request = { ids, generation, controller: new AbortController() };
     previewRequest = request;
     try {
-      const params = new URLSearchParams({ preview: request.id });
+      const params = new URLSearchParams({ previews: JSON.stringify(request.ids) });
       const res = await fetch(`/api/sessions/${sessionId}/messages?${params}`, { signal: request.controller.signal });
       if (res.status === 409 && request.generation === generation) refresh();
-      if (!res.ok) throw new Error(`Preview: ${res.status}`);
+      if (!res.ok) throw new Error(`Previews: ${res.status}`);
       const data = await res.json();
       if (request.generation !== generation) return;
-      previews.delete(request.id);
-      previews.set(request.id, data);
-      while (previews.size > PREVIEW_CACHE_SIZE) previews.delete(previews.keys().next().value);
+      for (const preview of data.previews || []) {
+        previews.delete(preview.id);
+        previews.set(preview.id, preview);
+        previewFailures.delete(preview.id);
+        while (previews.size > PREVIEW_CACHE_SIZE) previews.delete(previews.keys().next().value);
+      }
     } catch (error) {
-      if (error.name !== "AbortError" && request.generation === generation) previewFailure = request.id;
+      if (error.name !== "AbortError" && request.generation === generation) {
+        request.ids.forEach(id => previewFailures.add(id));
+      }
     } finally {
       if (previewRequest === request) {
         previewRequest = null;
         _renderTicks();
-        // At most one request runs at a time; moving across many ticks retains
-        // only the latest target, not a queue of every crossed message.
-        _loadPreview();
       }
     }
   }
@@ -170,15 +227,23 @@
     clearTimeout(previewTimer);
     previewRequest?.controller.abort();
     previewRequest = null;
-    previewTarget = null;
-    previewDue = false;
-    previewFailure = null;
+    previewQueueKey = null;
+    previewFailures.clear();
   }
 
-  function _hover(y) {
+  function _expand() {
+    clearTimeout(hideTimer);
+    if (expanded) return;
+    expanded = true;
+    nav.classList.add("expanded");
+    _renderTicks();
+  }
+
+  function _hover(y, showAnswer = false) {
     pointerY = y;
     clearTimeout(hideTimer);
     hoveredIdx = _nearest(y);
+    hoveringMessage = showAnswer;
     _renderTicks();
   }
 
@@ -187,10 +252,11 @@
     hideTimer = setTimeout(() => {
       hoveredIdx = -1;
       pointerY = null;
-      clearTimeout(previewTimer);
-      previewTarget = null;
-      previewDue = false;
+      hoveringMessage = false;
+      expanded = false;
+      nav.classList.remove("expanded");
       popup.hidden = true;
+      _cancelPreview();
       _renderTicks();
     }, 160);
   }
@@ -241,17 +307,10 @@
     if (failed) { refresh(); return; }
     const item = items[hoveredIdx];
     if (!item || jumping) return;
-    if (previewFailure === item.id) {
-      previewTarget = null;
-      _queuePreview(item);
-      _renderPreview();
-      return;
-    }
     const id = sessionId;
     const element = loaded.find(entry => entry.index === hoveredIdx)?.el;
     if (element?.isConnected) {
       messages.scrollTop += element.getBoundingClientRect().top - messages.getBoundingClientRect().top - 12;
-      _hide();
       return;
     }
     jumping = true;
@@ -259,8 +318,7 @@
     const success = await Sessions.jumpToHistory(item.id);
     if (id !== sessionId) return;
     jumping = false;
-    if (success) _hide();
-    else {
+    if (!success) {
       failed = true;
       _renderPreview();
       _setPreview(answerPreview, I18n.t("chat.history_load_failed"));
@@ -331,7 +389,8 @@
     _cancelPreview();
     activeIdx = hoveredIdx = -1;
     pointerY = null;
-    jumping = failed = false;
+    hoveringMessage = expanded = jumping = failed = false;
+    nav?.classList.remove("expanded");
     if (popup) popup.hidden = true;
     _loadIndex();
   }
@@ -342,26 +401,35 @@
     if (!messages || !chatMain) return;
     nav = document.createElement("div");
     nav.className = "chat-navigator";
-    nav.innerHTML = '<div class="chat-nav-track" tabindex="0" role="listbox"><div class="chat-nav-canvas"></div></div>' +
-      '<button type="button" class="chat-nav-popup" hidden><span class="chat-nav-user"></span><span class="chat-nav-answer"></span></button>';
+    nav.innerHTML = '<div class="chat-nav-frame" aria-hidden="true"></div>' +
+      '<div class="chat-nav-viewport"><div class="chat-nav-track" tabindex="0" role="listbox"><div class="chat-nav-canvas"></div></div></div>' +
+      '<div class="chat-nav-popup" hidden><span class="chat-nav-answer"></span></div>';
     chatMain.appendChild(nav);
     track = nav.querySelector(".chat-nav-track");
     canvas = nav.querySelector(".chat-nav-canvas");
     popup = nav.querySelector(".chat-nav-popup");
-    userPreview = nav.querySelector(".chat-nav-user");
     answerPreview = nav.querySelector(".chat-nav-answer");
     track.setAttribute("aria-label", I18n.t("chat.nav.title"));
-    track.addEventListener("pointermove", event => _hover(event.clientY - track.getBoundingClientRect().top));
+    track.addEventListener("pointerenter", event => {
+      _expand();
+      _hover(event.clientY - track.getBoundingClientRect().top, false);
+    });
+    track.addEventListener("pointermove", event => {
+      const overMessage = !!event.target.closest?.(".chat-nav-user");
+      _hover(event.clientY - track.getBoundingClientRect().top, overMessage);
+    });
     track.addEventListener("click", _jump);
     track.addEventListener("wheel", event => {
       event.preventDefault();
       event.stopPropagation();
       const delta = event.deltaY * (event.deltaMode === 1 ? STEP : event.deltaMode === 2 ? track.clientHeight : 1);
       track.scrollTop += delta;
-      _hover(event.clientY - track.getBoundingClientRect().top);
+      const overMessage = !!event.target.closest?.(".chat-nav-user");
+      _hover(event.clientY - track.getBoundingClientRect().top, overMessage);
     }, { passive: false });
     track.addEventListener("scroll", _renderTicks, { passive: true });
     track.addEventListener("keydown", event => {
+      _expand();
       let index = hoveredIdx >= 0 ? hoveredIdx : Math.max(activeIdx, 0);
       if (event.key === "ArrowUp") index--;
       else if (event.key === "ArrowDown") index++;
@@ -375,7 +443,6 @@
       _reveal(hoveredIdx);
       _renderTicks();
     });
-    popup.addEventListener("click", _jump);
     nav.addEventListener("pointerenter", () => clearTimeout(hideTimer));
     nav.addEventListener("pointerleave", _hide);
     nav.addEventListener("focusout", event => { if (!nav.contains(event.relatedTarget)) _hide(); });

--- a/lib/clacky/web/components/chat-navigator.js
+++ b/lib/clacky/web/components/chat-navigator.js
@@ -1,260 +1,402 @@
-// ── Chat Navigator - vertical minimap on the right edge of the chat ────────
-//
-// Shows one bar per user message. Hovering a bar opens a scrollable popup
-// listing every user message preview; clicking a bar or popup item scrolls
-// the chat to that message.
-//
-// The navigator element is absolutely positioned inside #chat-main and its
-// vertical bounds are synced to #messages via ResizeObserver so it never
-// overlaps the composer / info bar below.
-//
-// Depends on: global $ helper (app.js), I18n.
-// ───────────────────────────────────────────────────────────────────────────
+// ── Chat Navigator — lightweight round index, independent of loaded DOM ──
 "use strict";
 
 (() => {
-  const $ = (id) => document.getElementById(id);
-
-  const NAV_SELECTOR = ".msg-user-wrap";
-
-  let nav, track, popup, popupList;
-  let messages, chatMain;
-  let items = [];          // [{ el, bar, popupItem, type, preview }]
+  const STEP = 12;
+  const PADDING = 20;
+  const LENS_RADIUS = 3;
+  const PREVIEW_DELAY = 120;
+  const PREVIEW_CACHE_SIZE = 80;
+  const BOTTOM_TOLERANCE = 1;
+  let nav, track, canvas, popup, userPreview, answerPreview, messages, chatMain;
+  let sessionId = null;
+  let items = [];
+  let loaded = [];
   let activeIdx = -1;
-  let mo, ro;
-  let rebuildTimer = null;
-  let scrollTimer = null;
-  let hideTimer = null;
   let hoveredIdx = -1;
+  let loading = false;
+  let failed = false;
+  let jumping = false;
+  let controller;
+  let generation = 0;
+  let refreshTimer, syncTimer, hideTimer, scrollFrame;
+  let pointerY = null;
+  let previewTimer, previewRequest, previewTarget;
+  let previewDue = false;
+  let previewFailure = null;
+  const previews = new Map();
+  const renderedTicks = new Map();
+  const previewText = new WeakMap();
 
-  // ── Preview text extraction ────────────────────────────────────────────
-
-  function _previewFor(el) {
-    const bubble = el.querySelector(".msg-user");
-    if (!bubble) return "";
-    const clone = bubble.cloneNode(true);
-    clone
-      .querySelectorAll("img, .msg-pdf-badge, .msg-user-action-bar, .msg-time")
-      .forEach((e) => e.remove());
-    const text = clone.textContent.trim();
-    return text || (I18n.t("chat.nav.empty") || "(empty)");
+  function _baseOffset() {
+    return Math.max(PADDING, (track.clientHeight - items.length * STEP) / 2);
   }
 
-  // ── Position sync ───────────────────────────────────────────────────────
+  function _tickY(index) {
+    return _baseOffset() + index * STEP;
+  }
+
+  function _nearest(y) {
+    if (!items.length) return -1;
+    const index = Math.round((y + track.scrollTop - _baseOffset()) / STEP);
+    return Math.max(0, Math.min(items.length - 1, index));
+  }
 
   function _syncBounds() {
-    if (!nav || !messages || !chatMain) return;
-    const msgRect = messages.getBoundingClientRect();
-    const mainRect = chatMain.getBoundingClientRect();
-    nav.style.top = msgRect.top - mainRect.top + "px";
-    nav.style.height = msgRect.height + "px";
+    const rect = messages.getBoundingClientRect();
+    const main = chatMain.getBoundingClientRect();
+    const opener = document.getElementById("btn-aside-open");
+    const openerStyle = opener && getComputedStyle(opener);
+    // Reserve the opener's CSS geometry even when the expanded aside hides it.
+    const openerBottom = opener
+      ? opener.parentElement.getBoundingClientRect().top + parseFloat(openerStyle.top) + parseFloat(openerStyle.height)
+      : rect.top;
+    const top = Math.max(rect.top, openerBottom) + 12;
+    const scrollbarWidth = messages.offsetWidth - messages.clientWidth;
+    const scrollbarSpace = Math.max(scrollbarWidth,
+      parseFloat(getComputedStyle(nav).getPropertyValue("--chat-nav-scrollbar-space")) || 12);
+    // Classic scrollbars already consume layout width; reserve only the overlay remainder.
+    chatMain.style.setProperty("--chat-nav-overlay-space", `${scrollbarSpace - scrollbarWidth}px`);
+    nav.style.right = `${main.right - rect.right + scrollbarSpace}px`;
+    nav.style.top = `${top - main.top}px`;
+    nav.style.height = `${Math.max(0, rect.bottom - top - 16)}px`;
+    popup.style.maxWidth = `${Math.max(0, rect.width - scrollbarSpace - parseFloat(getComputedStyle(nav).width) - 12)}px`;
+    _renderTicks();
   }
 
-  // ── Rebuild bars + popup list ───────────────────────────────────────────
-
-  function _scheduleRebuild() {
-    clearTimeout(rebuildTimer);
-    rebuildTimer = setTimeout(_rebuild, 120);
+  function _renderTicks() {
+    if (!track) return;
+    const visible = items.length > 1 || loading || failed;
+    nav.style.display = visible ? "" : "none";
+    chatMain.classList.toggle("has-chat-navigator", visible);
+    canvas.style.height = `${Math.max(track.clientHeight, items.length * STEP + PADDING * 2)}px`;
+    // Only visible ticks and a small buffer get DOM nodes.
+    const first = Math.max(0, Math.floor((track.scrollTop - _baseOffset()) / STEP) - LENS_RADIUS - 2);
+    const last = Math.min(items.length, first + Math.ceil(track.clientHeight / STEP) + LENS_RADIUS * 2 + 5);
+    for (const [index, tick] of renderedTicks) {
+      if (index < first || index >= last) { tick.remove(); renderedTicks.delete(index); }
+    }
+    for (let i = first; i < last; i++) {
+      let tick = renderedTicks.get(i);
+      if (!tick) {
+        tick = document.createElement("div");
+        tick.className = "chat-nav-bar";
+        tick.id = `chat-nav-tick-${i}`;
+        tick.setAttribute("role", "option");
+        renderedTicks.set(i, tick);
+        canvas.appendChild(tick);
+      }
+      const distance = hoveredIdx < 0 ? Infinity : Math.abs(i - hoveredIdx);
+      tick.classList.toggle("active", i === activeIdx);
+      tick.classList.toggle("hovered", i === hoveredIdx);
+      tick.classList.toggle("nearby", distance > 0 && distance <= LENS_RADIUS);
+      tick.style.top = `${_tickY(i)}px`;
+      tick.style.width = `${distance <= LENS_RADIUS ? 30 - distance * 6 : 9}px`;
+      tick.setAttribute("aria-selected", String(i === hoveredIdx));
+      tick.setAttribute("aria-label", previews.get(items[i].id)?.user || I18n.t("chat.nav.round", { number: i + 1 }));
+    }
+    if (hoveredIdx >= first && hoveredIdx < last) track.setAttribute("aria-activedescendant", `chat-nav-tick-${hoveredIdx}`);
+    else track.removeAttribute("aria-activedescendant");
+    _renderPreview();
   }
 
-  function _rebuild() {
-    if (!messages || !track) return;
-    const els = Array.from(messages.querySelectorAll(NAV_SELECTOR));
-    items = els.map((el) => ({
-      el,
-      preview: _previewFor(el),
-    }));
+  function _setPreview(element, text) {
+    if (previewText.get(element) === text) return;
+    element.innerHTML = MarkdownPreview.render(text);
+    previewText.set(element, text);
+  }
 
-    // Hide navigator when content fits without scrolling
-    const scrollable = messages.scrollHeight > messages.clientHeight + 40;
-    nav.style.display = scrollable && items.length > 1 ? "" : "none";
-    if (!scrollable || items.length <= 1) return;
+  function _renderPreview() {
+    if (!popup || (hoveredIdx < 0 && pointerY === null)) return;
+    popup.hidden = false;
+    const item = items[hoveredIdx];
+    const preview = item && previews.get(item.id);
+    const previewFailed = item && previewFailure === item.id;
+    const skeleton = !failed && !previewFailed && (jumping || (item ? !preview : loading));
+    popup.classList.toggle("loading", skeleton);
+    popup.setAttribute("aria-busy", String(skeleton));
+    _setPreview(userPreview, skeleton ? "" : preview?.user || I18n.t(failed || previewFailed ? "chat.nav.retry" : "chat.nav.empty"));
+    _setPreview(answerPreview, skeleton ? "" : failed || previewFailed ? I18n.t("chat.nav.retry") : preview?.assistant || I18n.t("chat.nav.noReply"));
+    const center = item ? _tickY(hoveredIdx) - track.scrollTop : pointerY || 0;
+    popup.style.top = `${Math.max(0, Math.min(center - popup.offsetHeight / 2, nav.clientHeight - popup.offsetHeight))}px`;
+    if (!loading && !failed) _queuePreview(item);
+  }
 
-    // Build bars
-    track.innerHTML = "";
-    items.forEach((item, i) => {
-      const bar = document.createElement("div");
-      bar.className = "chat-nav-bar";
-      bar.dataset.idx = String(i);
-      bar.title = item.preview.slice(0, 120);
-      bar.addEventListener("mouseenter", () => _onBarHover(i));
-      bar.addEventListener("click", () => _scrollToIdx(i));
-      track.appendChild(bar);
-      item.bar = bar;
+  function _queuePreview(item) {
+    if (previewTarget === item?.id) return;
+    clearTimeout(previewTimer);
+    previewTarget = item?.id;
+    previewDue = false;
+    previewFailure = null;
+    if (!item) return;
+    if (previews.has(item.id)) {
+      const cached = previews.get(item.id);
+      previews.delete(item.id);
+      previews.set(item.id, cached);
+      return;
+    }
+    previewTimer = setTimeout(() => { previewDue = true; _loadPreview(); }, PREVIEW_DELAY);
+  }
+
+  async function _loadPreview() {
+    if (!previewDue || previewRequest || !previewTarget || previews.has(previewTarget)) return;
+    previewDue = false;
+    const request = { id: previewTarget, generation, controller: new AbortController() };
+    previewRequest = request;
+    try {
+      const params = new URLSearchParams({ preview: request.id });
+      const res = await fetch(`/api/sessions/${sessionId}/messages?${params}`, { signal: request.controller.signal });
+      if (res.status === 409 && request.generation === generation) refresh();
+      if (!res.ok) throw new Error(`Preview: ${res.status}`);
+      const data = await res.json();
+      if (request.generation !== generation) return;
+      previews.delete(request.id);
+      previews.set(request.id, data);
+      while (previews.size > PREVIEW_CACHE_SIZE) previews.delete(previews.keys().next().value);
+    } catch (error) {
+      if (error.name !== "AbortError" && request.generation === generation) previewFailure = request.id;
+    } finally {
+      if (previewRequest === request) {
+        previewRequest = null;
+        _renderTicks();
+        // At most one request runs at a time; moving across many ticks retains
+        // only the latest target, not a queue of every crossed message.
+        _loadPreview();
+      }
+    }
+  }
+
+  function _cancelPreview() {
+    clearTimeout(previewTimer);
+    previewRequest?.controller.abort();
+    previewRequest = null;
+    previewTarget = null;
+    previewDue = false;
+    previewFailure = null;
+  }
+
+  function _hover(y) {
+    pointerY = y;
+    clearTimeout(hideTimer);
+    hoveredIdx = _nearest(y);
+    _renderTicks();
+  }
+
+  function _hide() {
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => {
+      hoveredIdx = -1;
+      pointerY = null;
+      clearTimeout(previewTimer);
+      previewTarget = null;
+      previewDue = false;
+      popup.hidden = true;
+      _renderTicks();
+    }, 160);
+  }
+
+  function _reveal(index) {
+    if (index < 0) return;
+    const y = _tickY(index);
+    if (y < track.scrollTop + PADDING || y > track.scrollTop + track.clientHeight - PADDING) {
+      track.scrollTop = Math.max(0, y - track.clientHeight / 2);
+    }
+  }
+
+  function _updateActive() {
+    if (!loaded.length) return;
+    const threshold = messages.getBoundingClientRect().top + 30;
+    let found = loaded[0].index;
+    for (const entry of loaded) {
+      if (entry.el.getBoundingClientRect().top > threshold) break;
+      found = entry.index;
+    }
+    const atBottom = messages.scrollHeight - messages.scrollTop - messages.clientHeight <= BOTTOM_TOLERANCE;
+    if (atBottom && !Sessions.isHistoricalWindow()) found = loaded[loaded.length - 1].index;
+    activeIdx = found;
+    if (pointerY === null) _reveal(activeIdx);
+    _renderTicks();
+  }
+
+  function syncMessages() {
+    if (!messages || sessionId !== Sessions.activeId) return;
+    const byId = new Map(items.map((item, index) => [item.id, index]));
+    const liveByTime = new Map();
+    items.forEach((item, index) => {
+      if (!item.archived && item.created_at) liveByTime.set(String(item.created_at), index);
     });
-
-    // Build popup list (lazy: build once per rebuild)
-    popupList.innerHTML = "";
-    items.forEach((item, i) => {
-      const li = document.createElement("div");
-      li.className = "chat-nav-popup-item";
-      li.dataset.idx = String(i);
-      li.innerHTML =
-        `<span class="chat-nav-popup-item-text">${escapeHtml(item.preview)}</span>`;
-      li.addEventListener("mouseenter", () => _onItemHover(i));
-      li.addEventListener("click", () => _scrollToIdx(i));
-      popupList.appendChild(li);
-      item.popupItem = li;
+    loaded = [];
+    messages.querySelectorAll(".msg-user-wrap").forEach(el => {
+      const bubble = el.querySelector(".msg-user");
+      let index = byId.get(bubble?.dataset.roundId);
+      // Only optimistic live bubbles need a timestamp fallback. Archived
+      // targets always use source locators, never synthetic timestamps.
+      if (index === undefined && bubble?.dataset.editable !== "false") index = liveByTime.get(bubble?.dataset.createdAt);
+      if (index !== undefined) loaded.push({ index, el });
     });
-
-    activeIdx = -1;
     _updateActive();
   }
 
-  // ── Active bar tracking ─────────────────────────────────────────────────
+  async function _jump() {
+    if (failed) { refresh(); return; }
+    const item = items[hoveredIdx];
+    if (!item || jumping) return;
+    if (previewFailure === item.id) {
+      previewTarget = null;
+      _queuePreview(item);
+      _renderPreview();
+      return;
+    }
+    const id = sessionId;
+    const element = loaded.find(entry => entry.index === hoveredIdx)?.el;
+    if (element?.isConnected) {
+      messages.scrollTop += element.getBoundingClientRect().top - messages.getBoundingClientRect().top - 12;
+      _hide();
+      return;
+    }
+    jumping = true;
+    _renderPreview();
+    const success = await Sessions.jumpToHistory(item.id);
+    if (id !== sessionId) return;
+    jumping = false;
+    if (success) _hide();
+    else {
+      failed = true;
+      _renderPreview();
+      _setPreview(answerPreview, I18n.t("chat.history_load_failed"));
+    }
+  }
 
-  function _updateActive() {
-    if (!items.length) return;
-    const threshold = messages.getBoundingClientRect().top + 30;
-    let idx = 0;
-    for (let i = 0; i < items.length; i++) {
-      if (!items[i].el || !items[i].el.isConnected) {
-        _scheduleRebuild();
-        return;
+  async function _loadIndex() {
+    if (!sessionId || !nav) return;
+    controller?.abort();
+    controller = new AbortController();
+    const signal = controller.signal;
+    const requestGeneration = ++generation;
+    _cancelPreview();
+    const id = sessionId;
+    loading = true;
+    failed = false;
+    _renderTicks();
+    try {
+      const res = await fetch(`/api/sessions/${id}/messages?navigation=1`, { signal });
+      if (!res.ok) throw new Error(`Navigation: ${res.status}`);
+      const data = await res.json();
+      if (requestGeneration !== generation || sessionId !== Sessions.activeId) return;
+      const anchorId = items[hoveredIdx]?.id;
+      const firstVisibleId = items[Math.max(0, Math.floor((track.scrollTop - _baseOffset()) / STEP))]?.id;
+      const sources = new Map(data.sources.map(source => [source.key, source]));
+      for (const key of previews.keys()) {
+        const [source, , version] = JSON.parse(key);
+        if (!sources.has(source) || sources.get(source).version !== version || sources.get(source).volatile) previews.delete(key);
       }
-      const top = items[i].el.getBoundingClientRect().top;
-      if (top <= threshold) idx = i;
-      else break;
-    }
-    if (idx !== activeIdx) {
-      activeIdx = idx;
-      items.forEach((item, i) => {
-        item.bar.classList.toggle("active", i === idx);
-      });
-    }
-  }
-
-  function _onScroll() {
-    clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(_updateActive, 80);
-  }
-
-  // ── Popup interaction ───────────────────────────────────────────────────
-
-  function _onBarHover(idx) {
-    clearTimeout(hideTimer);
-    _showPopup(idx);
-  }
-
-  function _onItemHover(idx) {
-    clearTimeout(hideTimer);
-    hoveredIdx = idx;
-    items.forEach((item, i) => {
-      item.bar.classList.toggle("hovered", i === idx);
-    });
-  }
-
-  function _showPopup(idx) {
-    if (!popup || !items.length) return;
-    hoveredIdx = idx;
-    popup.style.display = "flex";
-
-    items.forEach((item, i) => {
-      item.popupItem.classList.toggle("highlighted", i === idx);
-      item.bar.classList.toggle("hovered", i === idx);
-    });
-
-    // Position popup vertically centered on the hovered bar
-    const bar = items[idx].bar;
-    const navRect = nav.getBoundingClientRect();
-    const barRect = bar.getBoundingClientRect();
-    const barCenter = barRect.top + barRect.height / 2 - navRect.top;
-    popup.style.top = "";
-    popup.style.bottom = "";
-    const popupHeight = popup.offsetHeight;
-    let top = barCenter - popupHeight / 2;
-    top = Math.max(48, Math.min(top, navRect.height - popupHeight));
-    popup.style.top = top + "px";
-
-    const target = items[idx].popupItem;
-    if (target) {
-      const listRect = popupList.getBoundingClientRect();
-      const itemRect = target.getBoundingClientRect();
-      const offset =
-        itemRect.top - listRect.top - (listRect.height - itemRect.height) / 2;
-      popupList.scrollTop += offset;
+      items = data.sources.flatMap(source => Array.from({ length: source.count }, (_, offset) => {
+        const identity = source.identities?.[offset] || null;
+        return { id: JSON.stringify([source.key, offset, source.version, identity]),
+          archived: !source.identities, created_at: identity?.[0] };
+      }));
+      hoveredIdx = anchorId ? items.findIndex(item => item.id === anchorId) : -1;
+      _renderTicks();
+      if (pointerY !== null && firstVisibleId) {
+        const first = items.findIndex(item => item.id === firstVisibleId);
+        if (first >= 0) track.scrollTop = Math.max(0, _baseOffset() + first * STEP);
+      }
+      syncMessages();
+    } catch (error) {
+      if (error.name !== "AbortError" && requestGeneration === generation) failed = true;
+    } finally {
+      if (requestGeneration === generation) {
+        loading = false;
+        if (pointerY !== null && hoveredIdx < 0) hoveredIdx = _nearest(pointerY);
+        _renderTicks();
+      }
     }
   }
 
-  function _hidePopup() {
+  function refresh() {
+    if (!sessionId) return;
+    clearTimeout(refreshTimer);
+    refreshTimer = setTimeout(_loadIndex, 350);
+  }
+
+  function setSession(id) {
+    controller?.abort();
+    clearTimeout(refreshTimer);
     clearTimeout(hideTimer);
-    hideTimer = setTimeout(() => {
-      if (!popup) return;
-      popup.style.display = "none";
-      hoveredIdx = -1;
-      items.forEach((item) => {
-        item.bar.classList.remove("hovered");
-        item.popupItem.classList.remove("highlighted");
-      });
-    }, 200);
+    generation++;
+    sessionId = id;
+    items = [];
+    loaded = [];
+    previews.clear();
+    _cancelPreview();
+    activeIdx = hoveredIdx = -1;
+    pointerY = null;
+    jumping = failed = false;
+    if (popup) popup.hidden = true;
+    _loadIndex();
   }
-
-  // ── Scroll to message ───────────────────────────────────────────────────
-
-  function _scrollToIdx(idx) {
-    if (!items[idx] || !items[idx].el) return;
-    const el = items[idx].el;
-    const msgRect = messages.getBoundingClientRect();
-    const elRect = el.getBoundingClientRect();
-    const offset = elRect.top - msgRect.top;
-    messages.scrollTop += offset - 12;
-    _hidePopup();
-  }
-
-  // ── Init ────────────────────────────────────────────────────────────────
 
   function init() {
-    messages = $("messages");
-    chatMain = $("chat-main");
+    messages = document.getElementById("messages");
+    chatMain = document.getElementById("chat-main");
     if (!messages || !chatMain) return;
-
     nav = document.createElement("div");
     nav.className = "chat-navigator";
-    nav.style.display = "none";
-    nav.innerHTML =
-      '<div class="chat-nav-track"></div>' +
-      '<div class="chat-nav-popup" style="display:none">' +
-      '<div class="chat-nav-popup-header">' +
-      '<span class="chat-nav-popup-title"></span>' +
-      "</div>" +
-      '<div class="chat-nav-popup-list"></div>' +
-      "</div>";
+    nav.innerHTML = '<div class="chat-nav-track" tabindex="0" role="listbox"><div class="chat-nav-canvas"></div></div>' +
+      '<button type="button" class="chat-nav-popup" hidden><span class="chat-nav-user"></span><span class="chat-nav-answer"></span></button>';
     chatMain.appendChild(nav);
     track = nav.querySelector(".chat-nav-track");
+    canvas = nav.querySelector(".chat-nav-canvas");
     popup = nav.querySelector(".chat-nav-popup");
-    popupList = nav.querySelector(".chat-nav-popup-list");
-
-    const titleEl = nav.querySelector(".chat-nav-popup-title");
-    if (titleEl) titleEl.textContent = I18n.t("chat.nav.title") || "Messages";
-
-    // Hover open / leave close
-    nav.addEventListener("mouseenter", () => clearTimeout(hideTimer));
-    nav.addEventListener("mouseleave", _hidePopup);
-
-    // Observe message children changes (add / remove / clear)
-    mo = new MutationObserver(() => _scheduleRebuild());
-    mo.observe(messages, { childList: true });
-
-    // Sync navigator bounds when layout changes
-    ro = new ResizeObserver(() => {
-      _syncBounds();
-      _scheduleRebuild();
+    userPreview = nav.querySelector(".chat-nav-user");
+    answerPreview = nav.querySelector(".chat-nav-answer");
+    track.setAttribute("aria-label", I18n.t("chat.nav.title"));
+    track.addEventListener("pointermove", event => _hover(event.clientY - track.getBoundingClientRect().top));
+    track.addEventListener("click", _jump);
+    track.addEventListener("wheel", event => {
+      event.preventDefault();
+      event.stopPropagation();
+      const delta = event.deltaY * (event.deltaMode === 1 ? STEP : event.deltaMode === 2 ? track.clientHeight : 1);
+      track.scrollTop += delta;
+      _hover(event.clientY - track.getBoundingClientRect().top);
+    }, { passive: false });
+    track.addEventListener("scroll", _renderTicks, { passive: true });
+    track.addEventListener("keydown", event => {
+      let index = hoveredIdx >= 0 ? hoveredIdx : Math.max(activeIdx, 0);
+      if (event.key === "ArrowUp") index--;
+      else if (event.key === "ArrowDown") index++;
+      else if (event.key === "Home") index = 0;
+      else if (event.key === "End") index = items.length - 1;
+      else if (event.key === "Enter" || event.key === " ") { event.preventDefault(); _jump(); return; }
+      else if (event.key === "Escape") { _hide(); return; }
+      else return;
+      event.preventDefault();
+      hoveredIdx = Math.max(0, Math.min(items.length - 1, index));
+      _reveal(hoveredIdx);
+      _renderTicks();
     });
-    ro.observe(chatMain);
-    ro.observe(messages);
-
-    // Track scroll position for active bar
-    messages.addEventListener("scroll", _onScroll, { passive: true });
-
-    // Re-render title on language change
+    popup.addEventListener("click", _jump);
+    nav.addEventListener("pointerenter", () => clearTimeout(hideTimer));
+    nav.addEventListener("pointerleave", _hide);
+    nav.addEventListener("focusout", event => { if (!nav.contains(event.relatedTarget)) _hide(); });
+    new MutationObserver(() => {
+      clearTimeout(syncTimer);
+      syncTimer = setTimeout(syncMessages, 100);
+    }).observe(messages, { childList: true });
+    const observer = new ResizeObserver(_syncBounds);
+    observer.observe(messages);
+    observer.observe(chatMain);
+    messages.addEventListener("scroll", () => {
+      cancelAnimationFrame(scrollFrame);
+      scrollFrame = requestAnimationFrame(_updateActive);
+    }, { passive: true });
     document.addEventListener("langchange", () => {
-      const t = nav.querySelector(".chat-nav-popup-title");
-      if (t) t.textContent = I18n.t("chat.nav.title") || "Messages";
+      track.setAttribute("aria-label", I18n.t("chat.nav.title"));
+      _renderPreview();
     });
-
     _syncBounds();
-    _scheduleRebuild();
+    if (Sessions.activeId) setSession(Sessions.activeId);
   }
 
-  window.ChatNavigator = { init };
+  window.ChatNavigator = { init, setSession, refresh, syncMessages };
 })();

--- a/lib/clacky/web/i18n.js
+++ b/lib/clacky/web/i18n.js
@@ -127,7 +127,11 @@ const I18n = (() => {
       "chat.empty.tip2":     "Summarize and organize information",
       "chat.empty.tip3":     "Upload an image or file for me to analyze",
       "chat.nav.title":      "Messages",
+      "chat.nav.round":      "Message {{number}}",
       "chat.nav.empty":      "(empty)",
+      "chat.nav.noReply":    "No final reply yet",
+      "chat.nav.retry":      "Navigation could not load. Click to retry.",
+      "chat.nav.latest":     "Back to latest messages ↓",
 
       // ── Session list ──
       "sessions.empty":         "No sessions yet",
@@ -1297,7 +1301,11 @@ const I18n = (() => {
       "chat.empty.tip2":     "归纳总结、整理信息",
       "chat.empty.tip3":     "上传图片或文件，让我帮你分析",
       "chat.nav.title":      "消息导航",
+      "chat.nav.round":      "第 {{number}} 条消息",
       "chat.nav.empty":      "（空）",
+      "chat.nav.noReply":    "暂无最终回复",
+      "chat.nav.retry":      "导航加载失败，点击重试",
+      "chat.nav.latest":     "回到最新消息 ↓",
 
       // ── Session list ──
       "sessions.empty":         "暂无会话",

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -17,7 +17,7 @@
 
 const Sessions = (() => {
   const _sessions          = [];  // [{ id, name, status, total_tasks, total_cost }]
-  const _historyState      = {};  // { [session_id]: { hasMore, oldestCreatedAt, loading, loaded } }
+  const _historyState      = {};  // Per-session history window, cursors and in-flight request.
   const _renderedCreatedAt = {};  // { [session_id]: Set<number> } — dedup by created_at
   const _drafts            = new Map();  // { [session_id]: composer textarea draft }
   const _attachmentDrafts  = new Map();  // { [session_id]: { images: [...], files: [...] } }
@@ -346,11 +346,8 @@ const Sessions = (() => {
     // Clear the pane and dedup state; history will be re-fetched from API.
     RenderTarget.outer().innerHTML = "";
     delete _renderedCreatedAt[id];
-    if (_historyState[id]) {
-      _historyState[id].oldestCreatedAt = null;
-      _historyState[id].hasMore         = true;
-      _historyState[id].loading         = false;  // reset so next fetch is not skipped
-    }
+    _historyState[id]?.controller?.abort();
+    delete _historyState[id];
     // Reset scroll tracking when switching sessions
     _userScrolledUp = false;
   }
@@ -411,6 +408,12 @@ const Sessions = (() => {
   function _showNewMessageBanner() {
     const banner = $("new-message-banner");
     if (!banner) return;
+    const label = banner.querySelector("span");
+    if (label) {
+      const key = Sessions.isHistoricalWindow() ? "chat.nav.latest" : "chat.newMessageHint";
+      label.dataset.i18n = key;
+      label.textContent = I18n.t(key);
+    }
     banner.style.display = "block";
   }
 
@@ -547,6 +550,10 @@ const Sessions = (() => {
     
     // Click to scroll to bottom
     banner.addEventListener("click", () => {
+      if (Sessions.isHistoricalWindow()) {
+        Sessions.loadLatestHistory();
+        return;
+      }
       messages.scrollTop = messages.scrollHeight;
       _userScrolledUp = false;
       _hideNewMessageBanner();
@@ -568,7 +575,7 @@ const Sessions = (() => {
     // so a content update never moves us "away from bottom" and never trips a
     // false positive here. The 150px threshold in _isAtBottom is extra slack.
     messages.addEventListener("scroll", () => {
-      if (_isAtBottom(messages)) {
+      if (_isAtBottom(messages) && !Sessions.isHistoricalWindow()) {
         _userScrolledUp = false;
         _hideNewMessageBanner();
       } else {
@@ -1122,7 +1129,7 @@ const Sessions = (() => {
       `</span>`;
   }
 
-  function _sendMessage() {
+  async function _sendMessage() {
     if (_sending) return;
     const input   = $("user-input");
     const content = Composer.text(input).trim();
@@ -1146,6 +1153,11 @@ const Sessions = (() => {
     }
 
     _sending = true;
+    if (Sessions.isHistoricalWindow()) {
+      const id = Sessions.activeId;
+      const loaded = await Sessions.loadLatestHistory();
+      if (!loaded || Sessions.activeId !== id) { _sending = false; return; }
+    }
 
     let bubbleHtml = content ? SkillAC.renderUserMessageHtml(content) : "";
     if (mentionChips.length > 0) {
@@ -1401,6 +1413,8 @@ const Sessions = (() => {
       const messages = e.currentTarget;
       if (messages.scrollTop < 80 && Sessions.activeId && Sessions.hasMoreHistory(Sessions.activeId)) {
         Sessions.loadMoreHistory(Sessions.activeId);
+      } else if (_isAtBottom(messages) && Sessions.isHistoricalWindow()) {
+        Sessions.loadNewerHistory();
       }
     });
 
@@ -1798,6 +1812,7 @@ const Sessions = (() => {
         bubbleHtml += SkillAC.renderUserMessageHtml(ev.content || "", ev.skill_command, ev.skill_command_display);
         el.innerHTML = bubbleHtml;
         if (ev.created_at) el.dataset.createdAt = ev.created_at;
+        if (ev.round_id) el.dataset.roundId = ev.round_id;
         // Messages archived into a compressed chunk can't be edited (the backend
         // truncate keys off the active in-memory history). Flag them so the edit
         // affordance stays hidden.
@@ -1981,40 +1996,56 @@ const Sessions = (() => {
 
   // Fetch one page of history and insert into #messages or cache.
   // before=null means most recent page; prepend=true for scroll-up load.
-  async function _fetchHistory(id, before = null, prepend = false) {
-    const state = _historyState[id] || (_historyState[id] = { hasMore: true, oldestCreatedAt: null, loading: false });
-    if (state.loading) return;
+  async function _fetchHistory(id, before = null, prepend = false, options = {}) {
+    const state = _historyState[id] || (_historyState[id] = { hasMore: true, loading: false });
+    if (state.loading && !options.replace) return false;
+    state.controller?.abort();
+    const controller = new AbortController();
+    state.controller = controller;
+    const wasHistorical = !!state.hasAfter;
+    const liveRevision = state.liveRevision || 0;
+    if (options.around) state.hasAfter = true;
+    if (options.replace) state.replacing = true;
     state.loading = true;
+    let succeeded = false;
 
     try {
-      const params = new URLSearchParams({ limit: 30 });
-      if (before) params.set("before", before);
+      const params = new URLSearchParams({ limit: 30, window: 1 });
+      if (before) params.set("before_id", before);
+      if (options.around) params.set("around", options.around);
+      if (options.after) params.set("after_id", options.after);
 
-      const res = await fetch(`/api/sessions/${id}/messages?${params}`);
+      const res = await fetch(`/api/sessions/${id}/messages?${params}`, { signal: controller.signal });
+      if (id !== _activeId || _historyState[id] !== state || state.controller !== controller) return false;
       if (!res.ok) {
+        if (res.status === 409) window.ChatNavigator?.refresh();
         if (id === _activeId) {
           let reason = "";
           try { const d = await res.json(); reason = d.error || ""; } catch {}
           const suffix = reason ? `: ${reason}` : "";
           Sessions.appendMsg("info", `${I18n.t("chat.history_load_failed")} (${res.status}${suffix})`);
         }
-        return;
+        return false;
       }
       const data = await res.json();
+      if (id !== _activeId || _historyState[id] !== state || state.controller !== controller) return false;
 
-      state.hasMore = !!data.has_more;
+      if (!options.after) {
+        state.hasMore = !!data.has_more;
+        state.beforeCursor = data.before_cursor;
+      }
+      if (!prepend) {
+        state.hasAfter = !!data.has_after;
+        state.afterCursor = data.after_cursor;
+      }
+      if (options.replace) {
+        window._closeAllPhases?.("incomplete");
+        Sessions.collapseToolGroup();
+        RenderTarget.outer().replaceChildren();
+        delete _renderedCreatedAt[id];
+      }
 
       const events = data.events || [];
-      if (events.length === 0) return;
-
-      // Track oldest created_at for next cursor (scroll-up pagination)
-      events.forEach(ev => {
-        if (ev.type === "history_user_message" && ev.created_at) {
-          if (state.oldestCreatedAt === null || ev.created_at < state.oldestCreatedAt) {
-            state.oldestCreatedAt = ev.created_at;
-          }
-        }
-      });
 
       // Pre-scan: mark each request_feedback as answered.
       // A feedback card is disabled as soon as any subsequent history_user_message appears
@@ -2022,7 +2053,7 @@ const Sessions = (() => {
       {
         let lastFeedbackIdx = -1;
         events.forEach((ev, i) => {
-          if (ev.type === "request_feedback") { ev._answered = false; lastFeedbackIdx = i; }
+          if (ev.type === "request_feedback") { ev._answered = !!data.has_after; lastFeedbackIdx = i; }
           if (ev.type === "history_user_message" && lastFeedbackIdx >= 0 && i > lastFeedbackIdx) {
             events[lastFeedbackIdx]._answered = true;
             lastFeedbackIdx = -1;
@@ -2041,8 +2072,8 @@ const Sessions = (() => {
 
       events.forEach(ev => {
         if (ev.type === "history_user_message") {
-          currentCreatedAt = ev.created_at;
-          skipRound        = currentCreatedAt && dedup.has(currentCreatedAt);
+          currentCreatedAt = ev.round_id || ev.created_at;
+          skipRound = currentCreatedAt && (dedup.has(currentCreatedAt) || (ev.editable !== false && dedup.has(ev.created_at)));
           if (!skipRound && currentCreatedAt) dedup.add(currentCreatedAt);
         }
         if (!skipRound) _renderHistoryEvent(ev, frag, historyCtx);
@@ -2069,10 +2100,16 @@ const Sessions = (() => {
           } else {
             messages.appendChild(frag);
           }
-          messages.scrollTop = messages.scrollHeight;
+          if (options.around) {
+            messages.scrollTop = 0;
+            _userScrolledUp = true;
+          } else if (!options.after) {
+            messages.scrollTop = messages.scrollHeight;
+            _userScrolledUp = false;
+          }
           // Flush any tool_stdout lines that arrived via WS before this history
           // fetch completed (race condition on session switch).
-          if (!prepend) _flushPendingStdout();
+          if (!prepend && !state.hasAfter) _flushPendingStdout();
         }
 
         // If no more history remains, insert a "beginning of conversation" marker at the top.
@@ -2088,7 +2125,7 @@ const Sessions = (() => {
 
         // Restore transient UI state based on session status after initial load
         // (not prepend, which is scroll-up pagination — no need to re-restore then)
-        if (!prepend) {
+        if (!prepend && !state.hasAfter) {
           const session = _sessions.find(s => s.id === id);
           if (session) {
             if (session.status === "running") {
@@ -2110,13 +2147,35 @@ const Sessions = (() => {
             }
           }
         }
+        if (state.hasAfter) _showNewMessageBanner();
+        else _hideNewMessageBanner();
+        window.ChatNavigator?.syncMessages();
       }
+      succeeded = true;
+    } catch (error) {
+      if (error.name !== "AbortError" && id === _activeId && state.controller === controller) {
+        Sessions.appendMsg("info", escapeHtml(I18n.t("chat.history_load_failed")));
+      }
+      return false;
     } finally {
-      state.loading = false;
+      if (state.controller === controller) {
+        state.loading = false;
+        state.replacing = false;
+        if (!succeeded) state.hasAfter = wasHistorical;
+      }
       // After loading finishes, re-evaluate the empty-state hint in case
       // the session is genuinely empty (no events + no existing DOM content).
-      if (id === _activeId) _updateEmptyHint();
+      if (id === _activeId) {
+        _updateEmptyHint();
+        _refreshEditButtons(RenderTarget.outer());
+      }
     }
+    // A live message may have arrived after the server took its snapshot while
+    // this detached window was loading. Reconcile before resuming live output.
+    if (succeeded && !state.hasAfter && (state.liveRevision || 0) !== liveRevision && id === _activeId) {
+      return _fetchHistory(id, null, false, { replace: true });
+    }
+    return succeeded;
   }
 
   // ── Private helpers ───────────────────────────────────────────────────
@@ -2232,7 +2291,7 @@ const Sessions = (() => {
   }
 
   function _refreshEditButtons(container, status) {
-    const running = (status || Sessions.find(Sessions.activeId)?.status) === "running";
+    const running = (status || Sessions.find(Sessions.activeId)?.status) === "running" || Sessions.isHistoricalWindow();
     const btns = Array.from(container.querySelectorAll(".msg-edit-btn"));
     btns.forEach((btn, i) => {
       btn.style.display = !running && i === btns.length - 1 ? "" : "none";
@@ -2250,6 +2309,7 @@ const Sessions = (() => {
   }
 
   function _enterEditMode(el) {
+    if (Sessions.isHistoricalWindow()) return;
     if (_activeSessionIsRunning() || el.classList.contains("editing")) return;
     el.classList.add("editing");
 
@@ -2324,6 +2384,7 @@ const Sessions = (() => {
   }
 
   function _submitEdit(el, newContent) {
+    if (Sessions.isHistoricalWindow()) return;
     if (!newContent) return;
     if (!Sessions.activeId) return;
     if (_activeSessionIsRunning()) {
@@ -4890,6 +4951,7 @@ const Sessions = (() => {
 
     /** Load the most recent page of history for a session (called on first visit). */
     loadHistory(id) {
+      window.ChatNavigator?.setSession(id);
       return _fetchHistory(id, null, false);
     },
 
@@ -4897,7 +4959,41 @@ const Sessions = (() => {
     loadMoreHistory(id) {
       const state = _historyState[id];
       if (!state || !state.hasMore) return;
-      return _fetchHistory(id, state.oldestCreatedAt, true);
+      return _fetchHistory(id, state.beforeCursor, true);
+    },
+
+    isHistoricalWindow() {
+      const state = _historyState[_activeId];
+      return !!(state?.hasAfter || state?.replacing);
+    },
+
+    loadNewerHistory() {
+      const state = _historyState[_activeId];
+      if (!state?.hasAfter || !state.afterCursor) return;
+      return _fetchHistory(_activeId, null, false, { after: state.afterCursor });
+    },
+
+    jumpToHistory(roundId) {
+      return _fetchHistory(_activeId, null, false, { around: roundId, replace: true });
+    },
+
+    async loadLatestHistory() {
+      const id = _activeId;
+      const loaded = await _fetchHistory(id, null, false, { replace: true });
+      if (loaded && id === _activeId && Sessions.find(id)?.status === "running") {
+        WS.send({ type: "subscribe", session_id: id });
+      }
+      return loaded;
+    },
+
+    deferLiveHistory(event) {
+      if (!Sessions.isHistoricalWindow()) return false;
+      if (["history_user_message", "assistant_message", "tool_call", "tool_result"].includes(event.type)) {
+        const state = _historyState[_activeId];
+        state.liveRevision = (state.liveRevision || 0) + 1;
+      }
+      _showNewMessageBanner();
+      return true;
     },
 
     /** Check if there is more history to load for a session. */

--- a/lib/clacky/web/utils.js
+++ b/lib/clacky/web/utils.js
@@ -56,6 +56,40 @@ const IME = (() => {
   return { track, bindEnter };
 })();
 
+// Compact, non-interactive Markdown for short previews. Only inline formatting
+// is emitted; raw HTML and images cannot introduce active content.
+const MarkdownPreview = (() => {
+  function render(text) {
+    if (!text) return "";
+    if (typeof marked === "undefined") return escapeHtml(text);
+
+    const renderer = new marked.Renderer();
+    renderer.html = renderer.image = renderer.checkbox = () => "";
+    renderer.hr = renderer.br = () => " ";
+    renderer.link = function({ tokens }) { return this.parser.parseInline(tokens); };
+    renderer.paragraph = renderer.heading = function({ tokens }) {
+      return this.parser.parseInline(tokens) + " ";
+    };
+    renderer.blockquote = renderer.listitem = function({ tokens }) {
+      return this.parser.parse(tokens).trim() + " ";
+    };
+    renderer.list = function({ items }) {
+      return items.map(item => this.listitem(item)).join("");
+    };
+    renderer.table = function({ header, rows }) {
+      return [header, ...rows].map(row => row.map(cell => this.parser.parseInline(cell.tokens)).join(" ")).join(" ") + " ";
+    };
+    renderer.code = function({ text }) { return `<code>${escapeHtml(text)}</code> `; };
+    try {
+      return marked.parse(text, { gfm: true, breaks: false, renderer }).trim();
+    } catch (_) {
+      return escapeHtml(text);
+    }
+  }
+
+  return { render };
+})();
+
 const Tooltip = (() => {
   const GAP = 8;
   let el = null;

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -226,6 +226,20 @@ function _dispatchEvent(ev) {
     }
   }
 
+  const eventSession = ev.session_id || ev.session?.id;
+  if (eventSession === Sessions.activeId) {
+    if (["history_user_message", "task_finished", "interrupted"].includes(ev.type) ||
+        (ev.type === "session_update" && (ev.status || ev.session))) {
+      window.ChatNavigator?.refresh();
+    }
+    // Keep live output out of a detached historical window. Session status,
+    // notifications and extension delivery above continue normally.
+    const historyOutput = ["history_user_message", "assistant_message", "tool_call", "tool_result",
+      "tool_error", "tool_stdout", "phase_start", "phase_end", "request_feedback", "progress",
+      "complete", "interrupted", "info", "warning", "success", "error", "token_usage"];
+    if (historyOutput.includes(ev.type) && Sessions.deferLiveHistory(ev)) return;
+  }
+
   switch (ev.type) {
 
     // ── Phase grouping ─────────────────────────────────────────────────
@@ -424,6 +438,7 @@ function _dispatchEvent(ev) {
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.clearProgress();
       Sessions.appendMsg("assistant", ev.content);
+      if (!ev.phase_id && !ev.interim) window.ChatNavigator?.refresh();
       break;
 
     case "tool_call":

--- a/spec/clacky/agent/history_navigation_spec.rb
+++ b/spec/clacky/agent/history_navigation_spec.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+require "clacky/server/http_server"
+
+RSpec.describe Clacky::Agent::HistoryNavigation do
+  let(:directory) { Dir.mktmpdir("navigation-spec") }
+  let(:events) { [] }
+  let(:collector) { Clacky::Server::HistoryCollector.new("navigation-test", events) }
+
+  after { FileUtils.rm_rf(directory) }
+
+  def agent_for(messages)
+    Class.new do
+      include Clacky::Agent::SessionSerializer
+      attr_reader :history
+      def initialize(messages)
+        @history = Clacky::MessageHistory.new(messages)
+      end
+    end.new(messages)
+  end
+
+  def user(text, time = 1)
+    { role: "user", content: text, created_at: time }
+  end
+
+  def assistant(text, **options)
+    { role: "assistant", content: text }.merge(options)
+  end
+
+  def chunk(number, body)
+    path = File.join(directory, "session-chunk-#{number}.md")
+    File.write(path, "---\narchived_at: 2026-03-01T10:00:00Z\n---\n#{body}")
+    path
+  end
+
+  def archived_agent(path, tail = [])
+    agent_for([assistant("summary", compressed_summary: true, chunk_path: path)] + tail)
+  end
+
+  def all_entries(agent)
+    agent.history_navigation[:sources].flat_map do |source|
+      Array.new(source[:count]) do |offset|
+        id = JSON.generate([source[:key], offset, source[:version], source[:identities]&.[](offset)])
+        agent.history_navigation_preview(id: id)
+      end
+    end
+  end
+
+  it "indexes user turns and only their final main-agent answer" do
+    agent = agent_for([
+      user("First"), assistant("Investigating", tool_calls: [{ name: "read" }]),
+      { role: "tool", content: "private output", subagent_transcript: [{ role: "assistant", content: "subagent answer" }] },
+      assistant("<think>hidden reasoning</think>Final answer"),
+      user("Second", 2), assistant("Working", tool_calls: [{ name: "ask_user" }]),
+      user("synthetic", 3).merge(system_injected: true)
+    ])
+    expect(all_entries(agent).map { |entry| [entry[:user], entry[:assistant]] }).to eq([
+      ["First", "Final answer"], ["Second", ""]
+    ])
+  end
+
+  it "does not mistake interrupted tool work or reasoning-only output for a final answer" do
+    agent = agent_for([user("run"), assistant("Earlier answer"), assistant("", tool_calls: [{ name: "read" }]),
+      { role: "tool", content: "interrupted" }])
+    expect(all_entries(agent).first[:assistant]).to eq("")
+    agent.history.append(assistant("<think>reasoning only</think>"))
+    expect(all_entries(agent).first[:assistant]).to eq("")
+  end
+
+  it "uses attachment names for image-only turns without encoding image data" do
+    agent = agent_for([user([{ type: "image_url", image_name: "screenshot.png", image_url: { url: "data:image/png;base64,PRIVATE" } }])])
+    entry = all_entries(agent).first
+    expect(entry[:user]).to eq("screenshot.png")
+    expect(JSON.generate(entry)).not_to include("PRIVATE")
+  end
+
+  it "bounds previews and excludes tool outputs from the index" do
+    agent = agent_for([user("x" * 1000), assistant("y" * 1000), { role: "tool", content: "secret" * 10000 }])
+    entry = all_entries(agent).first
+    expect(entry[:user].length).to eq(400)
+    expect(JSON.generate(entry).length).to be < 1000
+  end
+
+  it "preserves Markdown structure for compact client rendering without exposing reasoning" do
+    markdown = "# Result\n\n**Fixed** `List<T>`\n\n- First\n- Second\n\n```ruby\nputs '<tag>'\n```"
+    agent = agent_for([user("**Review**\n\n`main`"), assistant("<think>private reasoning</think>\n#{markdown}")])
+    entry = all_entries(agent).first
+    expect(entry[:user]).to eq("**Review**\n\n`main`")
+    expect(entry[:assistant]).to eq(markdown)
+    expect(entry[:assistant]).not_to include("private reasoning")
+  end
+
+  it "counts all archived and live turns without parsing bodies or producing previews" do
+    path = chunk(1, "## User\nOld\n## Assistant\nArchived answer\n")
+    agent = archived_agent(path, [user("Live", 20), assistant("Live answer")])
+    expect(agent).not_to receive(:parse_chunk_md_to_rounds)
+    expect(agent).not_to receive(:navigation_entry)
+    expect(agent).not_to receive(:parse_tool_calls_line)
+    manifest = agent.history_navigation
+    expect(manifest[:total]).to eq(2)
+    expect(manifest[:sources].map { |source| source[:count] }).to eq([1, 1])
+    expect(JSON.generate(manifest)).not_to include("Archived answer", "Live answer")
+  end
+
+  it "does not use colliding archived timestamps as navigation identities" do
+    chunk(1, "## User\nFirst\n## Assistant\nOne\n")
+    path = chunk(2, "## User\nSecond\n## Assistant\nTwo\n")
+    agent = archived_agent(path)
+    entries = all_entries(agent)
+    expect(entries.map { |entry| entry[:created_at] }.uniq.length).to eq(1)
+    expect(entries.map { |entry| entry[:id] }.uniq.length).to eq(2)
+    result = agent.replay_history_window(collector, around: entries.last[:id], limit: 1)
+    expect(events.first[:content]).to eq("Second")
+    expect(result).to include(has_more: true, has_after: false)
+    expect(events.first[:editable]).to eq(false)
+  end
+
+  it "supports exclusive before and after windows across chunk/live boundaries" do
+    path = chunk(1, "## User\nOld\n## Assistant\nArchived answer\n")
+    agent = archived_agent(path, [user("Middle", 20), assistant("Two"), user("Newest", 30)])
+    entries = all_entries(agent)
+    before = agent.replay_history_window(collector, before_id: entries[1][:id], limit: 1)
+    expect(events.first[:content]).to eq("Old")
+    expect(before).to include(has_more: false, has_after: true)
+    events.clear
+    after = agent.replay_history_window(collector, after_id: entries[0][:id], limit: 1)
+    expect(events.first[:content]).to eq("Middle")
+    expect(after).to include(has_more: true, has_after: true)
+  end
+
+  it "preserves the live continuation of an archived user turn" do
+    path = chunk(1, "## User\nOld\n## Assistant\nReading\n_Tool calls: read_\n")
+    agent = archived_agent(path, [assistant("Final continued answer")])
+    entries = all_entries(agent)
+    expect(entries.first[:assistant]).to eq("Final continued answer")
+    agent.replay_history_window(collector, around: entries.first[:id])
+    expect(events.count { |event| event[:content] == "Final continued answer" }).to eq(1)
+  end
+
+  it "attaches live continuation to the last user turn when newer archives have no user turns" do
+    original = chunk(1, "## User\nQuestion\n## Assistant\nEarlier answer\n")
+    path = chunk(2, "## Assistant\nSummary-only archive\n")
+    agent = archived_agent(path, [assistant("Final continued answer")])
+    manifest = agent.history_navigation
+    expect(manifest[:total]).to eq(1)
+    expect(manifest[:sources].find { |source| source[:key] == File.basename(original) }[:volatile]).to eq(true)
+    entry = all_entries(agent).first
+    expect(entry[:assistant]).to eq("Final continued answer")
+    result = agent.replay_history_window(collector, around: entry[:id])
+    expect(result).to include(has_more: false, has_after: false)
+    expect(events.count { |event| event[:content] == "Final continued answer" }).to eq(1)
+  end
+
+  it "keeps archived tool narration interim during both preview and replay" do
+    path = chunk(1, "## User\nRun\n## Assistant\nLet me check\n_Tool calls: read_\n")
+    agent = archived_agent(path)
+    entry = all_entries(agent).first
+    expect(entry[:assistant]).to eq("")
+    agent.replay_history_window(collector, around: entry[:id])
+    expect(events.find { |event| event[:type] == "assistant_message" }[:interim]).to eq(true)
+  end
+
+  it "rejects stale live locators after editing instead of jumping to another turn" do
+    agent = agent_for([user("First", 10), user("Second", 20)])
+    id = all_entries(agent).last[:id]
+    agent.history.replace_all([user("Different", 30), user("Other", 40)])
+    expect { agent.replay_history_window(collector, around: id) }.to raise_error(ArgumentError)
+    expect(events).to be_empty
+  end
+
+  it "rejects malformed and out-of-range locators" do
+    agent = agent_for([user("First")])
+    expect { agent.replay_history_window(collector, around: "not-json") }.to raise_error(ArgumentError)
+    id = JSON.parse(all_entries(agent).first[:id])
+    id[1] = 500
+    expect { agent.replay_history_window(collector, around: JSON.generate(id)) }.to raise_error(ArgumentError)
+  end
+
+  it "keeps an existing live target addressable when a newer user turn arrives" do
+    agent = agent_for([user("First", 10), user("Second", 20)])
+    id = all_entries(agent).last[:id]
+    agent.history.append(user("Third", 30))
+    agent.replay_history_window(collector, around: id, limit: 1)
+    expect(events.first[:content]).to eq("Second")
+  end
+
+  it "does not duplicate sibling chunks also referenced by a nested summary" do
+    chunk(1, "## User\nOriginal\n## Assistant\nOriginal answer\n")
+    path = chunk(2, "## Assistant [Compressed Summary — original conversation at: session-chunk-1.md]\nSummary\n## User\nNewer\n")
+    agent = archived_agent(path)
+    expect(all_entries(agent).map { |entry| entry[:user] }).to eq(["Original", "Newer"])
+    agent.replay_history_window(collector)
+    expect(events.select { |event| event[:type] == "history_user_message" }.size).to eq(2)
+  end
+
+  it "uses current live continuation summaries even after an earlier index was cached" do
+    path = chunk(1, "## User\nQuestion\n## Assistant\nWorking\n_Tool calls: read_\n")
+    agent = archived_agent(path, [assistant("Still working", tool_calls: [{ name: "read" }])])
+    expect(all_entries(agent).first[:assistant]).to eq("")
+    expect(agent.history_navigation[:sources].find { |source| source[:key] == File.basename(path) }[:volatile]).to eq(true)
+    agent.history.append(assistant("Finished"))
+    expect(all_entries(agent).first[:assistant]).to eq("Finished")
+  end
+
+  it "returns the complete turn count and identities without preview pagination" do
+    agent = agent_for((1..450).map { |i| user("Question #{i}", i) })
+    expect(agent.history_navigation[:total]).to eq(450)
+    expect(all_entries(agent).map { |entry| entry[:user] }).to eq((1..450).map { |i| "Question #{i}" })
+  end
+
+  it "reuses byte indexes without caching full message bodies" do
+    path = chunk(1, "## User\nOld\n## Assistant\nOriginal\n")
+    agent = archived_agent(path)
+    all_entries(agent)
+    expect(agent).not_to receive(:scan_chunk_index)
+    expect(all_entries(agent).first[:assistant]).to eq("Original")
+    expect(JSON.generate(agent.instance_variable_get(:@chunk_indexes))).not_to include("Original")
+  end
+
+  it "invalidates a rewritten archive and keeps missing chunks harmless" do
+    path = chunk(1, "## User\nOld\n## Assistant\nOriginal\n")
+    agent = archived_agent(path)
+    original = all_entries(agent).first[:id]
+    File.write(path, "## User\nNew\n## Assistant\nChanged answer\n")
+    expect(all_entries(agent).first[:assistant]).to eq("Changed answer")
+    expect { agent.replay_history_window(collector, around: original) }.to raise_error(ArgumentError)
+    File.unlink(path)
+    expect(all_entries(agent)).to be_empty
+  end
+
+  it "reads only the requested round's bytes even in an archive exceeding 2000 turns" do
+    path = chunk(1, (1..2100).map { |i| "## User\nQuestion #{i}\n## Assistant\nAnswer #{i}\n" }.join)
+    agent = archived_agent(path)
+    source = agent.history_navigation[:sources].first
+    expect(source[:count]).to eq(2100)
+    id = JSON.generate([source[:key], 1500, source[:version], nil])
+    expect(agent).not_to receive(:scan_chunk_index)
+    expect(agent).to receive(:parse_chunk_md_to_rounds).with(path, hash_including(
+      byte_range: { start: kind_of(Integer), length: be < 100 }, round_offset: 1500
+    )).twice.and_call_original
+    2.times { expect(agent.history_navigation_preview(id: id)[:assistant]).to eq("Answer 1501") }
+  end
+
+  it "matches replay for empty users, attachment-only users, nested archives and UTF-8 offsets" do
+    nested = File.join(directory, "legacy.md")
+    File.write(nested, "## User\n旧记录\n## Assistant\n旧回复\n")
+    path = chunk(1, <<~MD)
+      ## Assistant [Compressed Summary — original conversation at: legacy.md]
+      Summary
+      ## User
+
+      ## User
+      _Display files: []_
+      ## User [Task 3]
+      _Display files: [{"name":"截图.png","type":"image"}]_
+      ## Assistant
+      图片回复
+      ## User
+      最后一轮
+      ## Assistant
+      最终回复
+    MD
+    agent = archived_agent(path)
+    full = agent.send(:parse_chunk_md_to_rounds, path)
+    entries = all_entries(agent)
+    expect(entries.map { |entry| entry[:assistant] }).to eq(["旧回复", "图片回复", "最终回复"])
+    entries.each_with_index do |entry, position|
+      events.clear
+      agent.replay_history_window(collector, around: entry[:id], limit: 1)
+      expect(events.first[:created_at]).to eq(full[position][:user_msg][:created_at])
+    end
+  end
+
+  it "does not repeatedly scan a session with more than six archives" do
+    paths = (1..8).map { |i| chunk(i, "## User\nQuestion #{i}\n## Assistant\nAnswer #{i}\n") }
+    agent = archived_agent(paths.last)
+    expect(agent.history_navigation[:total]).to eq(8)
+    expect(agent).not_to receive(:scan_chunk_index)
+    expect(all_entries(agent).size).to eq(8)
+  end
+
+  it "rejects a preview if the archive is rewritten during the range read" do
+    path = chunk(1, "## User\nQuestion\n## Assistant\nAnswer\n")
+    agent = archived_agent(path)
+    id = all_entries(agent).first[:id]
+    allow(agent).to receive(:parse_chunk_md_to_rounds).and_wrap_original do |original, *args, **kwargs|
+      result = original.call(*args, **kwargs)
+      File.write(path, "## User\nReplacement\n## Assistant\nNew answer\n")
+      result
+    end
+    expect { agent.history_navigation_preview(id: id) }.to raise_error(ArgumentError, /changed/)
+  end
+end

--- a/spec/clacky/server/history_navigation_spec.rb
+++ b/spec/clacky/server/history_navigation_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe "Session history navigation API" do
     expect(response[:body]).not_to have_key(:events)
   end
 
+  it "returns a bounded batch of previews in request order" do
+    manifest = request(navigation: 1)[:body][:sources].first
+    ids = 2.times.map do |offset|
+      JSON.generate([manifest[:key], offset, manifest[:version], manifest[:identities][offset]])
+    end
+    response = request(previews: JSON.generate(ids))
+    expect(response[:status]).to eq(200)
+    expect(response[:body][:previews].map { |entry| entry[:user] }).to eq(["First", "Second"])
+    expect(response[:body]).not_to have_key(:events)
+  end
+
+  it "rejects malformed or oversized preview batches" do
+    expect(request(previews: "not-json")[:status]).to eq(409)
+    expect(request(previews: JSON.generate([first_id] * 31))[:status]).to eq(409)
+  end
+
   it "stamps source IDs onto user events and provides both pagination directions" do
     id = first_id
     response = request(window: 1, around: id, limit: 1)

--- a/spec/clacky/server/history_navigation_spec.rb
+++ b/spec/clacky/server/history_navigation_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "clacky/server/http_server"
+
+RSpec.describe "Session history navigation API" do
+  let(:server) { Clacky::Server::HttpServer.allocate }
+  let(:agent) do
+    Class.new do
+      include Clacky::Agent::SessionSerializer
+      def initialize
+        @history = Clacky::MessageHistory.new([
+          { role: "user", content: "First", created_at: 10 },
+          { role: "assistant", content: "Answer" },
+          { role: "user", content: "Second", created_at: 20 }
+        ])
+      end
+    end.new
+  end
+
+  before do
+    registry = double("registry", ensure: true)
+    allow(registry).to receive(:with_session).with("test").and_yield({ agent: agent })
+    server.instance_variable_set(:@registry, registry)
+    allow(server).to receive(:json_response) { |_res, status, body| { status: status, body: body } }
+  end
+
+  def request(query)
+    server.send(:api_session_messages, "test", double(query_string: URI.encode_www_form(query)), Object.new)
+  end
+
+  def first_id
+    source = request(navigation: 1)[:body][:sources].first
+    JSON.generate([source[:key], 0, source[:version], source[:identities].first])
+  end
+
+  it "returns counts and identities without replaying or previewing message bodies" do
+    expect(agent).not_to receive(:replay_history)
+    expect(agent).not_to receive(:navigation_entry)
+    response = request(navigation: 1)
+    expect(response[:status]).to eq(200)
+    expect(response[:body][:total]).to eq(2)
+    expect(JSON.generate(response[:body])).not_to include("First", "Answer")
+    expect(response[:body]).not_to have_key(:events)
+  end
+
+  it "returns just the requested preview" do
+    response = request(preview: first_id)
+    expect(response[:status]).to eq(200)
+    expect(response[:body]).to include(user: "First", assistant: "Answer")
+    expect(response[:body]).not_to have_key(:events)
+  end
+
+  it "stamps source IDs onto user events and provides both pagination directions" do
+    id = first_id
+    response = request(window: 1, around: id, limit: 1)
+    expect(response[:body]).to include(has_more: false, has_after: true, before_cursor: id, after_cursor: id)
+    expect(response[:body][:events].first).to include(type: "history_user_message", round_id: id, content: "First")
+  end
+
+  it "rejects a stale or malformed location without returning a different page" do
+    response = request(window: 1, around: "bad-location")
+    expect(response[:status]).to eq(409)
+    expect(response[:body]).to have_key(:error)
+    expect(response[:body]).not_to have_key(:events)
+    expect(request(preview: "bad-location")[:status]).to eq(409)
+  end
+
+  it "preserves the existing timestamp-based API for other callers" do
+    response = request(before: 20, limit: 1)
+    expect(response[:status]).to eq(200)
+    expect(response[:body][:events].first[:content]).to eq("First")
+  end
+
+  it "does not mistake an unavailable agent for an empty preview" do
+    registry = server.instance_variable_get(:@registry)
+    allow(registry).to receive(:with_session).with("test").and_yield({ agent: nil })
+    expect(request(navigation: 1)[:body]).to eq(sources: [], total: 0)
+    expect(request(preview: "old-location")[:status]).to eq(409)
+  end
+end

--- a/spec/clacky/web/chat_navigation_spec.rb
+++ b/spec/clacky/web/chat_navigation_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "open3"
+
+RSpec.describe "Chat navigation interactions" do
+  it "passes the navigation and history-window runtime regressions" do
+    script = File.expand_path("../../support/chat_navigation_test.js", __dir__)
+    output, status = Open3.capture2e("node", script)
+    expect(status.success?).to be(true), output
+  end
+end

--- a/spec/support/chat_navigation_test.js
+++ b/spec/support/chat_navigation_test.js
@@ -20,8 +20,15 @@ class Element {
     this.isConnected = true;
     this.hidden = false;
     this.classes = new Set();
-    this.classList = { toggle: (name, on) => on ? this.classes.add(name) : this.classes.delete(name) };
+    this.classList = {
+      add: name => this.classes.add(name),
+      remove: name => this.classes.delete(name),
+      toggle: (name, on) => on ? this.classes.add(name) : this.classes.delete(name),
+      contains: name => this.classes.has(name),
+    };
   }
+  set className(value) { this._className = value; this.classes = new Set(value.split(/\s+/).filter(Boolean)); }
+  get className() { return this._className || ""; }
   setAttribute(key, value) { this.attrs[key] = value; }
   removeAttribute(key) { delete this.attrs[key]; }
   addEventListener(key, fn) { this.handlers[key] = fn; }
@@ -29,7 +36,16 @@ class Element {
   remove() { if (this.parentNode) this.parentNode.children = this.parentNode.children.filter(child => child !== this); }
   replaceChildren(...children) { this.children = []; children.forEach(child => this.appendChild(child)); }
   insertBefore(child) { this.children.unshift(...(child.fragment ? child.children : [child])); }
-  querySelector() { return null; }
+  querySelector(selector) {
+    if (!selector.startsWith(".")) return null;
+    const name = selector.slice(1);
+    for (const child of this.children) {
+      if (child.classes?.has(name)) return child;
+      const nested = child.querySelector?.(selector);
+      if (nested) return nested;
+    }
+    return null;
+  }
   querySelectorAll() { return []; }
   getBoundingClientRect() { return { top: 40, bottom: 400, height: 360, left: 0, right: 500, width: 500 }; }
   get firstChild() { return this.children[0]; }
@@ -75,12 +91,12 @@ function markdownPreviewTests() {
 }
 
 async function navigatorTests() {
-  const nodes = Object.fromEntries(["nav", "track", "canvas", "popup", "userPreview", "answerPreview", "messages", "chatMain"].map(key => [key, new Element()]));
+  const nodes = Object.fromEntries(["nav", "track", "canvas", "popup", "answerPreview", "messages", "chatMain"].map(key => [key, new Element()]));
   const context = vm.createContext({
     window: {}, document, console, URLSearchParams, AbortController,
     setTimeout, clearTimeout, I18n: { t: key => key },
     Sessions: { activeId: "test", jumpToHistory: async () => true, isHistoricalWindow: () => false },
-    getComputedStyle: () => ({ width: "40px", getPropertyValue: () => "12px" }),
+    getComputedStyle: element => ({ width: "40px", getPropertyValue: name => name === "--chat-nav-expanded-width" ? "352px" : "12px" }),
     ...nodes,
   });
   loadMarkdownPreview(context);
@@ -88,14 +104,23 @@ async function navigatorTests() {
   let source = fs.readFileSync(sourcePath("components/chat-navigator.js"), "utf8");
   source = source.replace("window.ChatNavigator = {", `window.testing = {
     configure(data, nodes, cached = true) {
-      items = data; ({nav, track, canvas, popup, userPreview, answerPreview, messages, chatMain} = nodes);
-      sessionId = 'test'; hoveredIdx = -1; pointerY = null;
-      _cancelPreview(); clearTimeout(hideTimer); loading = failed = jumping = false;
+      items = data; ({nav, track, canvas, popup, answerPreview, messages, chatMain} = nodes);
+      sessionId = 'test'; hoveredIdx = -1; pointerY = null; hoveringMessage = false; expanded = false;
+      nav.classList.remove('expanded'); _cancelPreview(); clearTimeout(hideTimer); loading = failed = jumping = false;
       previews.clear(); if (cached) data.forEach(item => previews.set(item.id, item));
     },
-    _hover, _hide, _nearest, _tickY, _renderTicks, _renderPreview, _jump, _loadIndex, _syncBounds, _cancelPreview,
-    state() { return {items, activeIdx, hoveredIdx, loading, failed, previewFailure, cacheSize: previews.size}; },
-    requestPreviewNow() { clearTimeout(previewTimer); previewDue = true; return _loadPreview(); },
+    _expand, _hover, _hide, _nearest, _tickY, _visibleBounds, _renderTicks, _renderPreview, _jump,
+    _loadIndex, _syncBounds, _cancelPreview,
+    state() { return {items, activeIdx, hoveredIdx, expanded, loading, failed,
+      previewFailures: Array.from(previewFailures), cacheSize: previews.size}; },
+    loadVisibleNow() {
+      clearTimeout(previewTimer); previewQueueKey = null;
+      const bounds = _visibleBounds();
+      return _loadVisiblePreviews(_visiblePreviewIds(bounds.first, bounds.last)
+        .filter(id => !previews.has(id) && !previewFailures.has(id)).slice(0, PREVIEW_BATCH_SIZE));
+    },
+    loadIdsNow(ids) { return _loadVisiblePreviews(ids); },
+    setLoaded(value) { loaded = value; },
     setLoading(value) { loading = value; },
   }; window.ChatNavigator = {`);
   vm.runInContext(source, context);
@@ -128,13 +153,25 @@ async function navigatorTests() {
 
   const tickPositions = entries.map((_, i) => api._tickY(i));
   const canvasHeight = nodes.canvas.style.height;
-  api._hover(86); // exactly between two baseline ticks, rather than on a tick
+  assert.equal(tickPositions[0], parseFloat(canvasHeight) - tickPositions.at(-1),
+    "the first and last rows keep equal vertical insets");
+  nodes.track.scrollTop = 10;
+  api._renderTicks();
+  assert.equal(nodes.canvas.children.find(row => row.id === "chat-nav-tick-0").hidden, false,
+    "a partially clipped edge row remains rendered");
+  nodes.track.scrollTop = 0;
+  api._renderTicks();
+  api._expand();
+  api._hover(86, true); // exactly between two baseline ticks, rather than on a tick
   assert.ok(api.state().hoveredIdx >= 0, "gaps select nearest tick");
+  assert.equal(api.state().expanded, true);
+  assert.ok(nodes.nav.classes.has("expanded"), "hover expands a framed panel to the left");
   assert.deepEqual(entries.map((_, i) => api._tickY(i)), tickPositions, "hover does not move any tick vertically");
   assert.equal(nodes.canvas.style.height, canvasHeight, "hover does not change the track content height");
   assert.equal(nodes.popup.hidden, false);
   const index = api.state().hoveredIdx;
-  assert.equal(nodes.userPreview.innerHTML, `Question ${index}`);
+  const hoveredRow = nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index}`);
+  assert.equal(hoveredRow.querySelector(".chat-nav-user").innerHTML, `Question ${index}`);
   assert.equal(nodes.answerPreview.innerHTML, `Answer ${index}`);
   const renderCalls = vm.runInContext("renderCalls", context);
   api._renderPreview();
@@ -142,34 +179,56 @@ async function navigatorTests() {
   entries[index].assistant = "**Updated** `answer`";
   api._renderPreview();
   assert.equal(nodes.answerPreview.innerHTML, "<strong>Updated</strong> <code>answer</code>", "new reply updates the cached preview");
-  assert.ok(nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index}`).classes.has("hovered"));
+  assert.ok(hoveredRow.classes.has("hovered"));
   const css = fs.readFileSync(sourcePath("app.css"), "utf8");
-  const hoveredStyle = css.match(/\.chat-nav-bar\.hovered\s*\{([^}]+)\}/)[1];
+  const hoveredStyle = css.match(/\.chat-nav-row\.hovered \.chat-nav-bar\s*\{([^}]+)\}/)[1];
   assert.match(hoveredStyle, /background:\s*var\(--color-accent-primary\)/);
   assert.match(hoveredStyle, /opacity:\s*1;/);
-  assert.equal(nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index}`).style.width, "30px");
-  assert.equal(nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index + 1}`).style.width, "24px",
-    "neighbors still expand horizontally");
-  assert.equal(api._tickY(index + 1) - api._tickY(index), 12, "neighbors keep their original spacing");
+  assert.match(css, /\.chat-nav-user\s*\{[^}]*left:\s*1rem;[^}]*color:\s*var\(--color-text-muted\);[^}]*font-size:\s*0\.875rem;/s,
+    "expanded messages use a roomier muted text style");
+  assert.match(css, /\.chat-nav-row\.active \.chat-nav-user,\s*\.chat-nav-row\.hovered \.chat-nav-user\s*\{[^}]*color:\s*var\(--color-text-primary\);/s,
+    "the active and hovered messages use the primary text color");
+  assert.match(source, /chat-nav-frame.*chat-nav-viewport.*chat-nav-track/s,
+    "the navigator renders the track inside a dedicated visual viewport");
+  assert.match(css, /\.chat-navigator\.expanded \.chat-nav-viewport\s*\{[^}]*clip-path:\s*inset\([^}]*var\(--chat-nav-frame-top\)[^}]*var\(--chat-nav-frame-height\)[^}]*0\.75rem[^}]*round 0\.6875rem/s,
+    "the expanded viewport reserves fixed edge space and clips rows to the frame");
+  assert.doesNotMatch(source, /chat-nav-edge-mask/,
+    "the navigator no longer relies on overlay masks for edge spacing");
+  assert.doesNotMatch(css, /\.chat-nav-bar\.nearby/, "neighbor-wave styling is removed");
+  assert.doesNotMatch(source, /distance <=|LENS_RADIUS/, "neighbor bars no longer change width");
+  assert.equal(api._tickY(index + 1) - api._tickY(index), 32, "rows use the wider fixed spacing in both states");
   const neighborY = api._tickY(index + 1);
-  api._hover(neighborY);
-  api._hover(neighborY);
+  api._hover(neighborY, true);
+  api._hover(neighborY, true);
   assert.equal(api.state().hoveredIdx, index + 1, "selection stays stable at visual center");
-  api._hover(1);
+  api._hover(1, true);
   assert.equal(nodes.popup.style.top, "0px", "preview stays below toolbar");
-  api._hover(359);
+  api._hover(359, true);
   assert.ok(parseFloat(nodes.popup.style.top) + nodes.popup.offsetHeight <= 360, "preview stays above composer");
+  api._hover(359, false);
+  assert.equal(nodes.popup.hidden, true, "AI tooltip only appears over the user-message column");
   let target;
   context.Sessions.jumpToHistory = async id => { target = id; return true; };
   await api._jump();
   assert.equal(target, entries[api.state().hoveredIdx].id, "unloaded target uses source locator");
+  assert.equal(api.state().expanded, true, "loading a history target keeps the navigation expanded");
+
+  api.configure(entries, nodes);
+  api._expand();
+  api._hover(api._tickY(0), true);
+  api.setLoaded([{ index: 0, el: { isConnected: true, getBoundingClientRect: () => ({ top: 100 }) } }]);
+  nodes.messages.getBoundingClientRect = () => ({ top: 40, bottom: 400, height: 360, left: 0, right: 500, width: 500 });
+  await api._jump();
+  assert.equal(api.state().expanded, true, "jumping to an already-rendered target keeps the navigation expanded");
+  delete nodes.messages.getBoundingClientRect;
 
   api.configure(entries, nodes);
   nodes.track.scrollTop = parseFloat(canvasHeight) - nodes.track.clientHeight;
   api._renderTicks();
   const bottomScroll = nodes.track.scrollTop;
   for (const y of [1, 180, 359]) {
-    api._hover(y);
+    api._expand();
+    api._hover(y, true);
     assert.deepEqual(entries.map((_, i) => api._tickY(i)), tickPositions, "hover near the bottom keeps all tick positions fixed");
     assert.equal(nodes.canvas.style.height, canvasHeight);
     assert.equal(nodes.track.scrollTop, bottomScroll, "hover does not shift the navigation scroll position");
@@ -179,19 +238,21 @@ async function navigatorTests() {
   api._hide();
   await new Promise(resolve => setTimeout(resolve, 180));
   assert.equal(nodes.popup.hidden, true);
+  assert.equal(api.state().expanded, false);
+  assert.ok(!nodes.nav.classes.has("expanded"));
   assert.deepEqual(entries.map((_, i) => api._tickY(i)), tickPositions, "leaving hover keeps tick positions fixed");
   assert.equal(nodes.track.scrollTop, bottomScroll);
   nodes.track.scrollTop = 0;
   assert.equal(api._nearest(-100), 0);
   assert.equal(api._nearest(100000), entries.length - 1);
 
-  api.configure([], nodes);
-  api.setLoading(true);
-  api._hover(50);
+  api.configure(entries, nodes, false);
+  api._expand();
+  api._hover(50, true);
   assert.equal(nodes.popup.attrs["aria-busy"], "true");
   assert.ok(nodes.popup.classes.has("loading"), "loading renders a skeleton");
-  assert.equal(nodes.userPreview.innerHTML, "");
   assert.equal(nodes.answerPreview.innerHTML, "");
+  assert.ok(nodes.canvas.children.some(row => row.classes.has("loading")), "visible user rows reuse the skeleton state");
 
   api.configure(entries, nodes, false);
   api._syncBounds();
@@ -242,42 +303,62 @@ async function navigatorTests() {
   const requests = [];
   let resolvePreview;
   context.fetch = url => { requests.push(url); return new Promise(resolve => { resolvePreview = resolve; }); };
-  api._hover(86);
-  const firstPreviewId = entries[api.state().hoveredIdx].id;
-  assert.equal(requests.length, 0, "moving the mouse does not immediately issue a request");
-  assert.equal(nodes.popup.attrs["aria-busy"], "true", "uncached preview displays a skeleton");
-  const pendingPreview = api.requestPreviewNow();
+  api._expand();
+  api._hover(86, true);
+  assert.equal(requests.length, 0, "expanding does not immediately issue a request");
+  assert.equal(nodes.popup.attrs["aria-busy"], "true", "uncached answer tooltip displays a skeleton");
+  const firstBounds = api._visibleBounds();
+  const pendingPreview = api.loadVisibleNow();
   assert.equal(requests.length, 1);
-  api._hover(150);
-  api._hover(250);
-  const latestPreviewId = entries[api.state().hoveredIdx].id;
-  await api.requestPreviewNow();
-  assert.equal(requests.length, 1, "rapid movement does not create concurrent preview requests");
-  resolvePreview({ ok: true, json: async () => ({ id: firstPreviewId, user: "Old", assistant: "Old answer" }) });
+  const firstRequestedIds = JSON.parse(new URL(requests[0], "http://localhost").searchParams.get("previews"));
+  assert.deepEqual(firstRequestedIds, entries.slice(firstBounds.first, firstBounds.last).map(item => item.id).slice(0, 8),
+    "expanded navigation requests a URI-safe batch from only the visible rows");
+  assert.ok(requests[0].length < 2048, "preview batches remain below common request-target limits");
+  assert.ok(!firstRequestedIds.includes(entries[100].id), "off-screen rows stay unloaded");
+  resolvePreview({ ok: true, json: async () => ({ previews: firstRequestedIds.map((id, i) => ({
+    id, user: `Loaded ${i}`, assistant: i === 2 ? "**Final** answer" : `Answer ${i}`,
+  })) }) });
   await pendingPreview;
-  assert.equal(requests.length, 2, "only the latest waiting target is fetched");
-  assert.equal(new URL(requests[1], "http://localhost").searchParams.get("preview"), latestPreviewId);
-  assert.equal(nodes.answerPreview.innerHTML, "", "a late response does not replace the hovered preview");
-  resolvePreview({ ok: true, json: async () => ({ id: latestPreviewId, user: "Latest", assistant: "**Final** answer" }) });
-  await new Promise(resolve => setImmediate(resolve));
+  api._cancelPreview();
+  const loadedIndex = firstBounds.first + 2;
+  api._hover(api._tickY(loadedIndex) - nodes.track.scrollTop, true);
   assert.equal(nodes.answerPreview.innerHTML, "<strong>Final</strong> answer");
   assert.equal(nodes.popup.attrs["aria-busy"], "false");
-  api._hover(86);
-  await api.requestPreviewNow();
-  assert.equal(requests.length, 2, "revisiting a cached tick does not fetch again");
+  await api.loadIdsNow(firstRequestedIds);
+  assert.equal(requests.length, 1, "cached rows are not fetched again");
+
+  nodes.track.scrollTop = 3200;
+  api._renderTicks();
+  let secondRequest;
+  context.fetch = async url => {
+    secondRequest = url;
+    const ids = JSON.parse(new URL(url, "http://localhost").searchParams.get("previews"));
+    return { ok: true, json: async () => ({ previews: ids.map(id => ({ id, user: "New row", assistant: "New answer" })) }) };
+  };
+  await api.loadVisibleNow();
+  api._cancelPreview();
+  const secondRequestedIds = JSON.parse(new URL(secondRequest, "http://localhost").searchParams.get("previews"));
+  assert.ok(secondRequestedIds.every(id => !firstRequestedIds.includes(id)), "scrolling loads only newly visible rows");
 
   api.configure(entries, nodes, false);
+  api._expand();
   context.fetch = async () => { throw new Error("offline"); };
-  api._hover(86);
-  await api.requestPreviewNow();
-  assert.equal(api.state().previewFailure, entries[api.state().hoveredIdx].id);
+  api._hover(86, true);
+  await api.loadVisibleNow();
+  assert.ok(api.state().previewFailures.length > 0);
   assert.equal(nodes.popup.attrs["aria-busy"], "false", "failure does not leave a permanent skeleton");
 
-  context.fetch = async url => ({ ok: true, json: async () => ({ id: new URL(url, "http://localhost").searchParams.get("preview"), user: "Question", assistant: "Answer" }) });
-  for (let i = 0; i < 90; i++) {
-    nodes.track.scrollTop = i * 12;
-    api._hover(100);
-    await api.requestPreviewNow();
+  api.configure(entries, nodes, false);
+  api._expand();
+  context.fetch = async url => {
+    const ids = JSON.parse(new URL(url, "http://localhost").searchParams.get("previews"));
+    return { ok: true, json: async () => ({ previews: ids.map(id => ({ id, user: "Question", assistant: "Answer" })) }) };
+  };
+  for (let i = 0; i < 12; i++) {
+    nodes.track.scrollTop = i * 640;
+    api._renderTicks();
+    await api.loadVisibleNow();
+    api._cancelPreview();
   }
   assert.equal(api.state().cacheSize, 80, "preview cache has a fixed upper bound");
   api._cancelPreview();
@@ -294,13 +375,14 @@ async function navigatorTests() {
   assert.equal(api.state().items.length, 5000, "all ticks are available from source counts");
   assert.ok(nodes.canvas.children.length < 50);
 
-  api._hover(86);
+  api._expand();
+  api._hover(86, true);
   let resolveStalePreview;
   context.fetch = () => new Promise(resolve => { resolveStalePreview = resolve; });
-  const stalePreview = api.requestPreviewNow();
+  const stalePreview = api.loadVisibleNow();
   context.fetch = async () => ({ ok: true, json: async () => ({ total: 0, sources: [] }) });
   context.window.ChatNavigator.setSession("test");
-  resolveStalePreview({ ok: true, json: async () => ({ user: "Stale", assistant: "Stale" }) });
+  resolveStalePreview({ ok: true, json: async () => ({ previews: [{ id: entries[0].id, user: "Stale", assistant: "Stale" }] }) });
   await stalePreview;
   assert.equal(api.state().cacheSize, 0, "a switched session cannot inherit an old preview response");
 

--- a/spec/support/chat_navigation_test.js
+++ b/spec/support/chat_navigation_test.js
@@ -1,0 +1,402 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+class Element {
+  constructor() {
+    this.style = { setProperty(name, value) { this[name] = value; } };
+    this.dataset = {};
+    this.attrs = {};
+    this.children = [];
+    this.handlers = {};
+    this.clientHeight = 360;
+    this.clientWidth = this.offsetWidth = 500;
+    this.offsetHeight = 110;
+    this.scrollHeight = 1000;
+    this.scrollTop = 0;
+    this.isConnected = true;
+    this.hidden = false;
+    this.classes = new Set();
+    this.classList = { toggle: (name, on) => on ? this.classes.add(name) : this.classes.delete(name) };
+  }
+  setAttribute(key, value) { this.attrs[key] = value; }
+  removeAttribute(key) { delete this.attrs[key]; }
+  addEventListener(key, fn) { this.handlers[key] = fn; }
+  appendChild(child) { child.parentNode = this; this.children.push(...(child.fragment ? child.children : [child])); }
+  remove() { if (this.parentNode) this.parentNode.children = this.parentNode.children.filter(child => child !== this); }
+  replaceChildren(...children) { this.children = []; children.forEach(child => this.appendChild(child)); }
+  insertBefore(child) { this.children.unshift(...(child.fragment ? child.children : [child])); }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+  getBoundingClientRect() { return { top: 40, bottom: 400, height: 360, left: 0, right: 500, width: 500 }; }
+  get firstChild() { return this.children[0]; }
+}
+
+const document = {
+  createElement: () => new Element(),
+  createDocumentFragment: () => Object.assign(new Element(), { fragment: true }),
+  getElementById: () => null,
+};
+const sourcePath = name => path.resolve(__dirname, "../../lib/clacky/web", name);
+
+function loadMarkdownPreview(context) {
+  vm.runInContext(fs.readFileSync(sourcePath("vendor/marked/marked.min.js"), "utf8"), context);
+  const app = fs.readFileSync(sourcePath("app.js"), "utf8");
+  vm.runInContext(app.slice(app.indexOf("function escapeHtml("), app.indexOf("// ── Router")), context);
+  vm.runInContext(fs.readFileSync(sourcePath("utils.js"), "utf8"), context);
+}
+
+function markdownPreviewTests() {
+  const context = vm.createContext({});
+  loadMarkdownPreview(context);
+  const render = vm.runInContext("MarkdownPreview.render", context);
+  assert.equal(render("查完了，**通用分组**，`GROUPED_SOURCES`，*完成*。"),
+    "查完了，<strong>通用分组</strong>，<code>GROUPED_SOURCES</code>，<em>完成</em>。");
+  assert.equal(render("# Heading\n\n- **First**\n- Second\n\n> Quote"),
+    "Heading <strong>First</strong> Second Quote");
+  assert.equal(render("```html\n<img src=x onerror=alert(1)>\n```"),
+    "<code>&lt;img src=x onerror=alert(1)&gt;</code>");
+  assert.equal(render("`List<T>` & text"), "<code>List&lt;T&gt;</code> &amp; text");
+  assert.equal(render("[**Link**](javascript:alert(1)) ![image](https://example.com/image.png)"), "<strong>Link</strong>");
+  assert.equal(render("<script>alert(1)</script>\n\nSafe <img src=x onerror=alert(1)>"), "Safe");
+  assert.equal(render("| Name | Value |\n| --- | --- |\n| **Key** | `value` |"),
+    "Name Value <strong>Key</strong> <code>value</code>");
+  assert.equal(render("- [x] Done\n- [ ] Pending"), "Done Pending");
+  assert.equal(render("```js\nconst value = 1;"), "<code>const value = 1;</code>", "accepts a truncated code fence");
+  assert.equal(render(""), "");
+  assert.match(context.marked.parse("# Heading"), /<h1>/, "preview renderer does not change global marked defaults");
+  context.marked = { ...context.marked, parse: () => { throw new Error("malformed Markdown"); } };
+  assert.equal(render("<broken>"), "&lt;broken&gt;");
+  context.marked = undefined;
+  assert.equal(render("<fallback>"), "&lt;fallback&gt;");
+}
+
+async function navigatorTests() {
+  const nodes = Object.fromEntries(["nav", "track", "canvas", "popup", "userPreview", "answerPreview", "messages", "chatMain"].map(key => [key, new Element()]));
+  const context = vm.createContext({
+    window: {}, document, console, URLSearchParams, AbortController,
+    setTimeout, clearTimeout, I18n: { t: key => key },
+    Sessions: { activeId: "test", jumpToHistory: async () => true, isHistoricalWindow: () => false },
+    getComputedStyle: () => ({ width: "40px", getPropertyValue: () => "12px" }),
+    ...nodes,
+  });
+  loadMarkdownPreview(context);
+  vm.runInContext("const originalRender = MarkdownPreview.render; let renderCalls = 0; MarkdownPreview.render = text => { renderCalls++; return originalRender(text); };", context);
+  let source = fs.readFileSync(sourcePath("components/chat-navigator.js"), "utf8");
+  source = source.replace("window.ChatNavigator = {", `window.testing = {
+    configure(data, nodes, cached = true) {
+      items = data; ({nav, track, canvas, popup, userPreview, answerPreview, messages, chatMain} = nodes);
+      sessionId = 'test'; hoveredIdx = -1; pointerY = null;
+      _cancelPreview(); clearTimeout(hideTimer); loading = failed = jumping = false;
+      previews.clear(); if (cached) data.forEach(item => previews.set(item.id, item));
+    },
+    _hover, _hide, _nearest, _tickY, _renderTicks, _renderPreview, _jump, _loadIndex, _syncBounds, _cancelPreview,
+    state() { return {items, activeIdx, hoveredIdx, loading, failed, previewFailure, cacheSize: previews.size}; },
+    requestPreviewNow() { clearTimeout(previewTimer); previewDue = true; return _loadPreview(); },
+    setLoading(value) { loading = value; },
+  }; window.ChatNavigator = {`);
+  vm.runInContext(source, context);
+  const api = context.window.testing;
+  const entries = Array.from({ length: 1000 }, (_, i) => ({ id: JSON.stringify(["live", i, "v1"]), user: `Question ${i}`, assistant: `Answer ${i}` }));
+  api.configure(entries, nodes);
+  api._renderTicks();
+  assert.ok(nodes.canvas.children.length < 50, "virtualizes thousands of ticks");
+
+  nodes.messages.querySelectorAll = () => entries.slice(0, 2).map((item, i) => ({
+    querySelector: () => ({ dataset: { roundId: item.id } }),
+    getBoundingClientRect: () => ({ top: i === 0 ? -100 : 100 }),
+  }));
+  nodes.messages.scrollTop = nodes.messages.scrollHeight - nodes.messages.clientHeight;
+  context.window.ChatNavigator.syncMessages();
+  assert.equal(api.state().activeIdx, 1, "at the latest bottom, selects the last loaded turn even below the top threshold");
+  context.Sessions.isHistoricalWindow = () => true;
+  context.window.ChatNavigator.syncMessages();
+  assert.equal(api.state().activeIdx, 0, "the bottom of a historical page keeps position-based highlighting");
+  context.Sessions.isHistoricalWindow = () => false;
+  nodes.messages.scrollTop -= 20;
+  context.window.ChatNavigator.syncMessages();
+  assert.equal(api.state().activeIdx, 0, "near the bottom is not the same as reaching it");
+  nodes.messages.scrollTop = nodes.messages.scrollHeight - nodes.messages.clientHeight - 0.5;
+  context.window.ChatNavigator.syncMessages();
+  assert.equal(api.state().activeIdx, 1, "fractional scroll rounding does not prevent bottom detection");
+  delete nodes.messages.querySelectorAll;
+  nodes.messages.scrollTop = 0;
+  context.window.ChatNavigator.syncMessages();
+
+  const tickPositions = entries.map((_, i) => api._tickY(i));
+  const canvasHeight = nodes.canvas.style.height;
+  api._hover(86); // exactly between two baseline ticks, rather than on a tick
+  assert.ok(api.state().hoveredIdx >= 0, "gaps select nearest tick");
+  assert.deepEqual(entries.map((_, i) => api._tickY(i)), tickPositions, "hover does not move any tick vertically");
+  assert.equal(nodes.canvas.style.height, canvasHeight, "hover does not change the track content height");
+  assert.equal(nodes.popup.hidden, false);
+  const index = api.state().hoveredIdx;
+  assert.equal(nodes.userPreview.innerHTML, `Question ${index}`);
+  assert.equal(nodes.answerPreview.innerHTML, `Answer ${index}`);
+  const renderCalls = vm.runInContext("renderCalls", context);
+  api._renderPreview();
+  assert.equal(vm.runInContext("renderCalls", context), renderCalls, "unchanged preview is not parsed again");
+  entries[index].assistant = "**Updated** `answer`";
+  api._renderPreview();
+  assert.equal(nodes.answerPreview.innerHTML, "<strong>Updated</strong> <code>answer</code>", "new reply updates the cached preview");
+  assert.ok(nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index}`).classes.has("hovered"));
+  const css = fs.readFileSync(sourcePath("app.css"), "utf8");
+  const hoveredStyle = css.match(/\.chat-nav-bar\.hovered\s*\{([^}]+)\}/)[1];
+  assert.match(hoveredStyle, /background:\s*var\(--color-accent-primary\)/);
+  assert.match(hoveredStyle, /opacity:\s*1;/);
+  assert.equal(nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index}`).style.width, "30px");
+  assert.equal(nodes.canvas.children.find(tick => tick.id === `chat-nav-tick-${index + 1}`).style.width, "24px",
+    "neighbors still expand horizontally");
+  assert.equal(api._tickY(index + 1) - api._tickY(index), 12, "neighbors keep their original spacing");
+  const neighborY = api._tickY(index + 1);
+  api._hover(neighborY);
+  api._hover(neighborY);
+  assert.equal(api.state().hoveredIdx, index + 1, "selection stays stable at visual center");
+  api._hover(1);
+  assert.equal(nodes.popup.style.top, "0px", "preview stays below toolbar");
+  api._hover(359);
+  assert.ok(parseFloat(nodes.popup.style.top) + nodes.popup.offsetHeight <= 360, "preview stays above composer");
+  let target;
+  context.Sessions.jumpToHistory = async id => { target = id; return true; };
+  await api._jump();
+  assert.equal(target, entries[api.state().hoveredIdx].id, "unloaded target uses source locator");
+
+  api.configure(entries, nodes);
+  nodes.track.scrollTop = parseFloat(canvasHeight) - nodes.track.clientHeight;
+  api._renderTicks();
+  const bottomScroll = nodes.track.scrollTop;
+  for (const y of [1, 180, 359]) {
+    api._hover(y);
+    assert.deepEqual(entries.map((_, i) => api._tickY(i)), tickPositions, "hover near the bottom keeps all tick positions fixed");
+    assert.equal(nodes.canvas.style.height, canvasHeight);
+    assert.equal(nodes.track.scrollTop, bottomScroll, "hover does not shift the navigation scroll position");
+    assert.equal(api._nearest(api._tickY(api.state().hoveredIdx) - bottomScroll), api.state().hoveredIdx,
+      "scrolled ticks remain selectable at their visible centers");
+  }
+  api._hide();
+  await new Promise(resolve => setTimeout(resolve, 180));
+  assert.equal(nodes.popup.hidden, true);
+  assert.deepEqual(entries.map((_, i) => api._tickY(i)), tickPositions, "leaving hover keeps tick positions fixed");
+  assert.equal(nodes.track.scrollTop, bottomScroll);
+  nodes.track.scrollTop = 0;
+  assert.equal(api._nearest(-100), 0);
+  assert.equal(api._nearest(100000), entries.length - 1);
+
+  api.configure([], nodes);
+  api.setLoading(true);
+  api._hover(50);
+  assert.equal(nodes.popup.attrs["aria-busy"], "true");
+  assert.ok(nodes.popup.classes.has("loading"), "loading renders a skeleton");
+  assert.equal(nodes.userPreview.innerHTML, "");
+  assert.equal(nodes.answerPreview.innerHTML, "");
+
+  api.configure(entries, nodes, false);
+  api._syncBounds();
+  assert.equal(nodes.nav.style.right, "12px", "overlay scrollbar retains its own hit area");
+  assert.equal(nodes.chatMain.style["--chat-nav-overlay-space"], "12px", "content leaves room for the overlay scrollbar");
+  assert.ok(nodes.chatMain.classes.has("has-chat-navigator"), "visible navigation reserves content space");
+  nodes.messages.clientWidth = 480;
+  api._syncBounds();
+  assert.equal(nodes.nav.style.right, "20px", "classic scrollbar uses its actual width");
+  assert.equal(nodes.chatMain.style["--chat-nav-overlay-space"], "0px", "classic scrollbar width is not counted twice");
+  nodes.messages.clientWidth = 500;
+  assert.match(css, /\.has-chat-navigator > \.chat-messages-scroll\s*\{\s*padding-right:\s*calc\(var\(--chat-nav-width\)/,
+    "message content and navigation share the same width variable");
+  assert.match(css, /\.chat-navigator\s*\{[^}]*width:\s*var\(--chat-nav-width\)/);
+  api.configure(entries.slice(0, 1), nodes);
+  api._renderTicks();
+  assert.ok(!nodes.chatMain.classes.has("has-chat-navigator"), "hidden navigation restores normal content spacing");
+  api.configure(entries, nodes, false);
+
+  const opener = new Element();
+  opener.parentElement = nodes.chatMain;
+  let openerHidden = false;
+  const openerStyle = { top: "8px", height: "32px" };
+  opener.getBoundingClientRect = () => openerHidden ? { top: 0, bottom: 0, height: 0 } : { top: 48, bottom: 80, height: 32 };
+  context.document = { ...document, getElementById: id => id === "btn-aside-open" ? opener : null };
+  const defaultComputedStyle = context.getComputedStyle;
+  context.getComputedStyle = element => element === opener ? openerStyle : defaultComputedStyle(element);
+  api._syncBounds();
+  const closedAsideBounds = { top: nodes.nav.style.top, height: nodes.nav.style.height };
+  assert.equal(closedAsideBounds.top, "52px", "navigation leaves space below the aside opener");
+  openerHidden = true;
+  api._syncBounds();
+  assert.deepEqual({ top: nodes.nav.style.top, height: nodes.nav.style.height }, closedAsideBounds,
+    "opening the aside keeps the same navigation range even though the opener has no layout box");
+  openerStyle.top = "10px";
+  openerStyle.height = "40px";
+  api._syncBounds();
+  assert.equal(nodes.nav.style.top, "62px", "reserved space follows the opener's CSS dimensions even when hidden");
+  nodes.messages.getBoundingClientRect = () => ({ top: 140, bottom: 350, height: 210, left: 0, right: 500, width: 500 });
+  api._syncBounds();
+  assert.equal(nodes.nav.style.top, "112px", "a taller session banner still limits the navigation's top edge");
+  assert.equal(nodes.nav.style.height, "182px", "navigation still follows the message viewport's bottom edge");
+  delete nodes.messages.getBoundingClientRect;
+  context.document = document;
+  context.getComputedStyle = defaultComputedStyle;
+  api._syncBounds();
+
+  const requests = [];
+  let resolvePreview;
+  context.fetch = url => { requests.push(url); return new Promise(resolve => { resolvePreview = resolve; }); };
+  api._hover(86);
+  const firstPreviewId = entries[api.state().hoveredIdx].id;
+  assert.equal(requests.length, 0, "moving the mouse does not immediately issue a request");
+  assert.equal(nodes.popup.attrs["aria-busy"], "true", "uncached preview displays a skeleton");
+  const pendingPreview = api.requestPreviewNow();
+  assert.equal(requests.length, 1);
+  api._hover(150);
+  api._hover(250);
+  const latestPreviewId = entries[api.state().hoveredIdx].id;
+  await api.requestPreviewNow();
+  assert.equal(requests.length, 1, "rapid movement does not create concurrent preview requests");
+  resolvePreview({ ok: true, json: async () => ({ id: firstPreviewId, user: "Old", assistant: "Old answer" }) });
+  await pendingPreview;
+  assert.equal(requests.length, 2, "only the latest waiting target is fetched");
+  assert.equal(new URL(requests[1], "http://localhost").searchParams.get("preview"), latestPreviewId);
+  assert.equal(nodes.answerPreview.innerHTML, "", "a late response does not replace the hovered preview");
+  resolvePreview({ ok: true, json: async () => ({ id: latestPreviewId, user: "Latest", assistant: "**Final** answer" }) });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(nodes.answerPreview.innerHTML, "<strong>Final</strong> answer");
+  assert.equal(nodes.popup.attrs["aria-busy"], "false");
+  api._hover(86);
+  await api.requestPreviewNow();
+  assert.equal(requests.length, 2, "revisiting a cached tick does not fetch again");
+
+  api.configure(entries, nodes, false);
+  context.fetch = async () => { throw new Error("offline"); };
+  api._hover(86);
+  await api.requestPreviewNow();
+  assert.equal(api.state().previewFailure, entries[api.state().hoveredIdx].id);
+  assert.equal(nodes.popup.attrs["aria-busy"], "false", "failure does not leave a permanent skeleton");
+
+  context.fetch = async url => ({ ok: true, json: async () => ({ id: new URL(url, "http://localhost").searchParams.get("preview"), user: "Question", assistant: "Answer" }) });
+  for (let i = 0; i < 90; i++) {
+    nodes.track.scrollTop = i * 12;
+    api._hover(100);
+    await api.requestPreviewNow();
+  }
+  assert.equal(api.state().cacheSize, 80, "preview cache has a fixed upper bound");
+  api._cancelPreview();
+
+  api.configure([], nodes, false);
+  nodes.track.scrollTop = 0;
+  let indexRequests = 0;
+  context.fetch = async () => {
+    indexRequests++;
+    return { ok: true, json: async () => ({ total: 5000, sources: [{ key: "archive", version: "v1", count: 5000, volatile: false }] }) };
+  };
+  await api._loadIndex();
+  assert.equal(indexRequests, 1, "startup fetches only the compact manifest, not all previews");
+  assert.equal(api.state().items.length, 5000, "all ticks are available from source counts");
+  assert.ok(nodes.canvas.children.length < 50);
+
+  api._hover(86);
+  let resolveStalePreview;
+  context.fetch = () => new Promise(resolve => { resolveStalePreview = resolve; });
+  const stalePreview = api.requestPreviewNow();
+  context.fetch = async () => ({ ok: true, json: async () => ({ total: 0, sources: [] }) });
+  context.window.ChatNavigator.setSession("test");
+  resolveStalePreview({ ok: true, json: async () => ({ user: "Stale", assistant: "Stale" }) });
+  await stalePreview;
+  assert.equal(api.state().cacheSize, 0, "a switched session cannot inherit an old preview response");
+
+  // An old request resolves after switching sessions; it must not overwrite the new index.
+  let resolveOld;
+  context.fetch = () => new Promise(resolve => { resolveOld = resolve; });
+  api.configure([], nodes);
+  const old = api._loadIndex();
+  context.Sessions.activeId = "new-session";
+  context.fetch = async () => ({ ok: true, json: async () => ({ total: 0, sources: [] }) });
+  context.window.ChatNavigator.setSession("new-session");
+  resolveOld({ ok: true, json: async () => ({ total: 1000, sources: [{ key: "live", version: "v1", count: 1000 }] }) });
+  await old;
+  await Promise.resolve();
+  assert.equal(api.state().items.length, 0, "ignores stale session index response");
+}
+
+async function historyTests() {
+  const messages = new Element();
+  const source = fs.readFileSync(sourcePath("sessions.js"), "utf8");
+  const fetchFunction = source.slice(source.indexOf("  async function _fetchHistory("), source.indexOf("  // ── Private helpers", source.indexOf("  async function _fetchHistory(")));
+  const state = {};
+  const context = vm.createContext({
+    document, URLSearchParams, AbortController, console,
+    _historyState: state, _renderedCreatedAt: {}, _activeId: "a", _sessions: [], _userScrolledUp: false,
+    RenderTarget: { outer: () => messages }, window: {}, I18n: { t: key => key }, escapeHtml: text => text,
+    _collapseToolGroup() {}, _refreshEditButtons() {}, _updateEmptyHint() {}, _flushPendingStdout() {},
+    _showNewMessageBanner() {}, _hideNewMessageBanner() {},
+    _renderHistoryEvent(ev, fragment) { fragment.appendChild(ev); },
+    Sessions: { _sessionProgress: {}, collapseToolGroup() {}, appendMsg() {} },
+  });
+  vm.runInContext(fetchFunction, context);
+  const event = id => ({ type: "history_user_message", round_id: id, created_at: 10, content: id, editable: false });
+  const response = (events, extra = {}) => ({ ok: true, json: async () => ({ events, has_more: true, has_after: false, ...extra }) });
+  context.fetch = async () => response([event("chunk-one"), event("chunk-two")]);
+  await context._fetchHistory("a");
+  assert.equal(messages.children.length, 2, "identical synthetic timestamps do not deduplicate different archived turns");
+
+  messages.scrollTop = 70;
+  context.fetch = async () => response([event("chunk-three")], { has_after: true, after_cursor: "chunk-three" });
+  await context._fetchHistory("a", null, false, { after: "chunk-two" });
+  assert.equal(messages.scrollTop, 70, "appending a newer page does not jump to the bottom");
+  assert.equal(state.a.hasAfter, true);
+
+  context.fetch = async () => response([event("target")], { has_after: true });
+  await context._fetchHistory("a", null, false, { around: "target", replace: true });
+  assert.equal(messages.children.length, 1, "direct navigation replaces rather than accumulating all intermediate history");
+  assert.equal(messages.children[0].content, "target");
+  assert.equal(messages.scrollTop, 0);
+
+  let resolveOld;
+  context.fetch = () => new Promise(resolve => { resolveOld = resolve; });
+  const old = context._fetchHistory("a", null, false, { around: "stale", replace: true });
+  context.fetch = async () => response([event("latest")]);
+  await context._fetchHistory("a", null, false, { replace: true });
+  resolveOld(response([event("stale")]));
+  await old;
+  assert.equal(messages.children[0].content, "latest", "late history requests cannot overwrite the selected window");
+  assert.equal(state.a.hasAfter, false);
+
+  context.fetch = async () => { throw new Error("network unavailable"); };
+  await context._fetchHistory("a", null, false, { around: "missing", replace: true });
+  assert.equal(messages.children[0].content, "latest", "failed jump preserves existing conversation");
+  assert.equal(state.a.hasAfter, false, "failed jump restores latest-window state");
+  assert.equal(state.a.loading, false);
+
+  let requests = 0;
+  context.fetch = async () => {
+    requests++;
+    if (requests === 1) state.a.liveRevision = 1;
+    return response([event(requests === 1 ? "snapshot" : "caught-up")]);
+  };
+  await context._fetchHistory("a", null, false, { replace: true });
+  assert.equal(requests, 2, "reconciles live output received while returning to latest");
+  assert.equal(messages.children[0].content, "caught-up");
+
+  const refreshStart = source.indexOf("  function _refreshEditButtons(");
+  const refreshFunction = source.slice(refreshStart, source.indexOf("  function _extractUserBubbleText", refreshStart));
+  vm.runInContext(refreshFunction, context);
+  const buttons = [new Element(), new Element()];
+  const container = { querySelectorAll: selector => selector === ".msg-edit-btn" ? buttons : [] };
+  context.Sessions.find = () => ({ status: "idle" });
+  context.Sessions.isHistoricalWindow = () => true;
+  context._refreshEditButtons(container);
+  assert.ok(buttons.every(button => button.style.display === "none"), "old windows expose no editable user message");
+  context.Sessions.isHistoricalWindow = () => false;
+  context._refreshEditButtons(container);
+  assert.equal(buttons[0].style.display, "none");
+  assert.equal(buttons[1].style.display, "", "only the last user message is editable at latest");
+  context._refreshEditButtons(container, "running");
+  assert.ok(buttons.every(button => button.style.display === "none"));
+}
+
+(async () => {
+  markdownPreviewTests();
+  await navigatorTests();
+  await historyTests();
+  console.log("Navigation geometry, virtual rendering, preview, request races and history pagination passed");
+})().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION

<img width="1512" height="864" alt="Snapzy_2026-09-03_14-58-43_007" src="https://github.com/user-attachments/assets/0ce4ada5-ad6e-4cda-b14e-4733ea4a295b" />

## Problem
Message navigation was difficult to target, overlapped message controls, and depended on manually loaded history.

## Fix
✅ Add nearest-tick selection, expanded neighboring ticks, theme highlighting, and a bounded scrollable navigation rail.
✅ Show compact Markdown previews of the user message and final assistant reply, with skeleton loading.
✅ Load a lightweight history index and fetch previews on demand, using bounded caching and virtualized ticks.
✅ Navigate directly to unloaded history using stable locations and windowed replay.
✅ Keep message controls and scrollbars accessible, preserve editing restrictions, and leave archive formats unchanged.

## Test
✅ 586 focused regression and code-style checks passed.
✅ Verified preview loading, history navigation, message controls, and scrollbar interaction in the browser.