### PR TITLE
feat: send large STT audio as base64 JSON

### DIFF
--- a/lib/clacky/media/openai_compat.rb
+++ b/lib/clacky/media/openai_compat.rb
@@ -308,14 +308,14 @@ module Clacky
         end
 
         ext = mime_type.split(";").first.split("/").last.then { |e| e == "mpeg" ? "mp3" : e }
-        ext = "m4a" if ext == "mp4" # OpenRouter wants the audio format, not the container
 
         # OpenRouter caps multipart uploads at 25 MB and redirects larger files
-        # to base64 JSON via input_audio. The openclacky gateway (which proxies
-        # third-party STT like Groq) has its own JSON flavor with the same
-        # input_audio shape. Both get the JSON path; plain OpenAI-compatible
-        # providers keep multipart.
-        if openrouter_host? || openclacky_gateway?
+        # to base64 JSON via input_audio. Plain OpenAI-compatible providers keep
+        # multipart (incl. the openclacky gateway, which only parses multipart
+        # on its /audio/transcriptions today — enable the JSON flavor there once
+        # the server supports it).
+        if provider_id == "openrouter"
+          ext = "m4a" if ext == "mp4" # OpenRouter wants the audio format, not the container
           payload = {
             model: @model,
             input_audio: {
@@ -517,14 +517,6 @@ module Clacky
           f.options.timeout      = 120
           f.options.open_timeout = 10
         end
-      end
-
-      private def openrouter_host?
-        @base_url.to_s.include?("openrouter.ai")
-      end
-
-      private def openclacky_gateway?
-        @base_url.to_s.include?("openclacky.com")
       end
 
       private def vu_connection

--- a/lib/clacky/media/openai_compat.rb
+++ b/lib/clacky/media/openai_compat.rb
@@ -308,38 +308,69 @@ module Clacky
         end
 
         ext = mime_type.split(";").first.split("/").last.then { |e| e == "mpeg" ? "mp3" : e }
-        filename = "chunk.#{ext}"
-        audio_data = Base64.decode64(audio_base64)
-        boundary = "----FormBoundary#{SecureRandom.hex(8)}"
-        # A multipart body is a byte stream: build it in binary so UTF-8 text
-        # parts (e.g. a non-ASCII vocabulary prompt) don't clash with the
-        # ASCII-8BIT audio bytes.
-        body = "".b
-        body << "--#{boundary}\r\n".b
-        body << "Content-Disposition: form-data; name=\"file\"; filename=\"#{filename}\"\r\n".b
-        body << "Content-Type: #{mime_type.split(';').first}\r\n\r\n".b
-        body << audio_data.b
-        body << "\r\n--#{boundary}\r\n".b
-        body << "Content-Disposition: form-data; name=\"model\"\r\n\r\n".b
-        body << @model.to_s.b
-        unless prompt.to_s.strip.empty?
-          body << "\r\n--#{boundary}\r\n".b
-          body << "Content-Disposition: form-data; name=\"prompt\"\r\n\r\n".b
-          body << prompt.to_s.strip.b
-        end
-        body << "\r\n--#{boundary}--\r\n".b
+        ext = "m4a" if ext == "mp4" # OpenRouter wants the audio format, not the container
 
-        begin
-          response = stt_connection.post("audio/transcriptions") do |req|
-            req.headers["Content-Type"]  = "multipart/form-data; boundary=#{boundary}"
-            req.headers["Authorization"] = "Bearer #{@api_key}"
-            req.body = body
+        # OpenRouter caps multipart uploads at 25 MB and redirects larger files
+        # to base64 JSON via input_audio. The openclacky gateway (which proxies
+        # third-party STT like Groq) has its own JSON flavor with the same
+        # input_audio shape. Both get the JSON path; plain OpenAI-compatible
+        # providers keep multipart.
+        if openrouter_host? || openclacky_gateway?
+          payload = {
+            model: @model,
+            input_audio: {
+              data:   audio_base64, # raw base64 bytes, NOT a data URI
+              format: ext
+            }
+          }
+          payload[:prompt] = prompt.to_s.strip unless prompt.to_s.strip.empty?
+
+          begin
+            response = stt_json_connection.post("audio/transcriptions") do |req|
+              req.headers["Content-Type"]  = "application/json"
+              req.headers["Authorization"] = "Bearer #{@api_key}"
+              req.body = JSON.generate(payload)
+            end
+          rescue Faraday::Error => e
+            return transcription_error_response(
+              error: "HTTP request failed: #{e.message}",
+              error_type: "network_error", provider: provider_id
+            )
           end
-        rescue Faraday::Error => e
-          return transcription_error_response(
-            error: "HTTP request failed: #{e.message}",
-            error_type: "network_error", provider: provider_id
-          )
+        else
+          filename = "chunk.#{ext}"
+          audio_data = Base64.decode64(audio_base64)
+          boundary = "----FormBoundary#{SecureRandom.hex(8)}"
+          # A multipart body is a byte stream: build it in binary so UTF-8 text
+          # parts (e.g. a non-ASCII vocabulary prompt) don't clash with the
+          # ASCII-8BIT audio bytes.
+          body = "".b
+          body << "--#{boundary}\r\n".b
+          body << "Content-Disposition: form-data; name=\"file\"; filename=\"#{filename}\"\r\n".b
+          body << "Content-Type: #{mime_type.split(';').first}\r\n\r\n".b
+          body << audio_data.b
+          body << "\r\n--#{boundary}\r\n".b
+          body << "Content-Disposition: form-data; name=\"model\"\r\n\r\n".b
+          body << @model.to_s.b
+          unless prompt.to_s.strip.empty?
+            body << "\r\n--#{boundary}\r\n".b
+            body << "Content-Disposition: form-data; name=\"prompt\"\r\n\r\n".b
+            body << prompt.to_s.strip.b
+          end
+          body << "\r\n--#{boundary}--\r\n".b
+
+          begin
+            response = stt_connection.post("audio/transcriptions") do |req|
+              req.headers["Content-Type"]  = "multipart/form-data; boundary=#{boundary}"
+              req.headers["Authorization"] = "Bearer #{@api_key}"
+              req.body = body
+            end
+          rescue Faraday::Error => e
+            return transcription_error_response(
+              error: "HTTP request failed: #{e.message}",
+              error_type: "network_error", provider: provider_id
+            )
+          end
         end
 
         unless response.success?
@@ -477,6 +508,23 @@ module Clacky
           f.options.timeout      = 30
           f.options.open_timeout = 10
         end
+      end
+
+      # STT JSON body carries a large base64 payload; upstream may need longer
+      # to decode/transcribe it than the 30s multipart path.
+      private def stt_json_connection
+        Faraday.new(url: normalized_base_url) do |f|
+          f.options.timeout      = 120
+          f.options.open_timeout = 10
+        end
+      end
+
+      private def openrouter_host?
+        @base_url.to_s.include?("openrouter.ai")
+      end
+
+      private def openclacky_gateway?
+        @base_url.to_s.include?("openclacky.com")
       end
 
       private def vu_connection

--- a/spec/clacky/media/openai_compat_spec.rb
+++ b/spec/clacky/media/openai_compat_spec.rb
@@ -238,6 +238,114 @@ RSpec.describe Clacky::Media::OpenAICompat do
     end
   end
 
+  describe "#generate_transcription" do
+    let(:response_body) { JSON.generate({ "text" => "hello world", "usage" => { "cost" => 0.0001 } }) }
+    let(:fake_conn) { instance_double(Faraday::Connection) }
+    let(:fake_response) { instance_double(Faraday::Response, success?: true, status: 200, body: response_body) }
+
+    def stub_transcription(captured_holder, conn = fake_conn)
+      req_double = double("req")
+      allow(req_double).to receive(:headers).and_return({})
+      allow(req_double).to receive(:body=) { |b| captured_holder[:body] = b }
+      allow(conn).to receive(:post).with("audio/transcriptions").and_yield(req_double).and_return(fake_response)
+      req_double
+    end
+
+    context "on the openclacky gateway" do
+      let(:entry) do
+        { "model" => "or-stt-whisper", "base_url" => "https://api.openclacky.com", "api_key" => "clacky-k" }
+      end
+
+      it "sends base64 JSON (input_audio) and returns the transcript" do
+        captured = {}
+        allow(provider).to receive(:stt_json_connection).and_return(fake_conn)
+        stub_transcription(captured)
+
+        result = provider.generate_transcription(
+          audio_base64: Base64.strict_encode64("RIFF....WAVE"),
+          mime_type: "audio/wav"
+        )
+
+        expect(result["success"]).to be true
+        expect(result["text"]).to eq("hello world")
+        expect(result["provider"]).to eq("openclacky")
+
+        body = JSON.parse(captured[:body])
+        expect(body["model"]).to eq("or-stt-whisper")
+        expect(body.dig("input_audio", "data")).to eq(Base64.strict_encode64("RIFF....WAVE"))
+        expect(body.dig("input_audio", "format")).to eq("wav")
+      end
+
+      it "passes through prompt when provided" do
+        captured = {}
+        allow(provider).to receive(:stt_json_connection).and_return(fake_conn)
+        stub_transcription(captured)
+
+        provider.generate_transcription(
+          audio_base64: Base64.strict_encode64("RIFF"),
+          mime_type: "audio/wav",
+          prompt: "punctuation please"
+        )
+        expect(JSON.parse(captured[:body])["prompt"]).to eq("punctuation please")
+      end
+    end
+
+    context "on OpenRouter" do
+      let(:entry) do
+        { "model" => "openai/whisper-large-v3-turbo", "base_url" => "https://openrouter.ai/api/v1", "api_key" => "or-k" }
+      end
+
+      it "uses base64 JSON so large files bypass the 25 MB multipart cap" do
+        captured = {}
+        allow(provider).to receive(:stt_json_connection).and_return(fake_conn)
+        stub_transcription(captured)
+
+        result = provider.generate_transcription(
+          audio_base64: Base64.strict_encode64("RIFF....WAVE"),
+          mime_type: "audio/wav"
+        )
+
+        expect(result["success"]).to be true
+        body = JSON.parse(captured[:body])
+        expect(body["model"]).to eq("openai/whisper-large-v3-turbo")
+        expect(body.dig("input_audio", "data")).to eq(Base64.strict_encode64("RIFF....WAVE"))
+        expect(body.dig("input_audio", "format")).to eq("wav")
+      end
+
+      it "maps audio/mp4 container to the m4a audio format" do
+        captured = {}
+        allow(provider).to receive(:stt_json_connection).and_return(fake_conn)
+        stub_transcription(captured)
+
+        provider.generate_transcription(audio_base64: Base64.strict_encode64("M4A"), mime_type: "audio/mp4")
+        expect(JSON.parse(captured[:body]).dig("input_audio", "format")).to eq("m4a")
+      end
+    end
+
+    context "on a generic OpenAI-style provider" do
+      let(:entry) do
+        { "model" => "whisper-1", "base_url" => "https://api.openai.com/v1", "api_key" => "sk-oai" }
+      end
+
+      it "falls back to multipart form-data" do
+        allow(provider).to receive(:stt_connection).and_return(fake_conn)
+        captured = {}
+        req_double = stub_transcription(captured)
+
+        result = provider.generate_transcription(
+          audio_base64: Base64.strict_encode64("RIFF....WAVE"),
+          mime_type: "audio/wav"
+        )
+
+        expect(result["success"]).to be true
+        expect(req_double.headers["Content-Type"]).to start_with("multipart/form-data; boundary=")
+        expect(captured[:body]).to include('name="file"; filename="chunk.wav"')
+        expect(captured[:body]).to include("RIFF....WAVE")
+        expect(captured[:body]).to include('name="model"')
+      end
+    end
+  end
+
   describe "base_url normalization" do
     let(:response_body) { JSON.generate({ "data" => [{ "url" => "https://x/y.png" }] }) }
 

--- a/spec/clacky/media/openai_compat_spec.rb
+++ b/spec/clacky/media/openai_compat_spec.rb
@@ -251,15 +251,15 @@ RSpec.describe Clacky::Media::OpenAICompat do
       req_double
     end
 
-    context "on the openclacky gateway" do
+    context "on the openclacky gateway (multipart only — JSON unsupported upstream)" do
       let(:entry) do
         { "model" => "or-stt-whisper", "base_url" => "https://api.openclacky.com", "api_key" => "clacky-k" }
       end
 
-      it "sends base64 JSON (input_audio) and returns the transcript" do
+      it "falls back to multipart form-data until the gateway supports input_audio" do
         captured = {}
-        allow(provider).to receive(:stt_json_connection).and_return(fake_conn)
-        stub_transcription(captured)
+        req_double = stub_transcription(captured)
+        allow(provider).to receive(:stt_connection).and_return(fake_conn)
 
         result = provider.generate_transcription(
           audio_base64: Base64.strict_encode64("RIFF....WAVE"),
@@ -267,18 +267,15 @@ RSpec.describe Clacky::Media::OpenAICompat do
         )
 
         expect(result["success"]).to be true
-        expect(result["text"]).to eq("hello world")
         expect(result["provider"]).to eq("openclacky")
-
-        body = JSON.parse(captured[:body])
-        expect(body["model"]).to eq("or-stt-whisper")
-        expect(body.dig("input_audio", "data")).to eq(Base64.strict_encode64("RIFF....WAVE"))
-        expect(body.dig("input_audio", "format")).to eq("wav")
+        expect(req_double.headers["Content-Type"]).to start_with("multipart/form-data; boundary=")
+        expect(captured[:body]).to include('name="file"; filename="chunk.wav"')
+        expect(captured[:body]).to include("RIFF....WAVE")
       end
 
-      it "passes through prompt when provided" do
+      it "passes through prompt in multipart form" do
+        allow(provider).to receive(:stt_connection).and_return(fake_conn)
         captured = {}
-        allow(provider).to receive(:stt_json_connection).and_return(fake_conn)
         stub_transcription(captured)
 
         provider.generate_transcription(
@@ -286,7 +283,8 @@ RSpec.describe Clacky::Media::OpenAICompat do
           mime_type: "audio/wav",
           prompt: "punctuation please"
         )
-        expect(JSON.parse(captured[:body])["prompt"]).to eq("punctuation please")
+        expect(captured[:body]).to include('name="prompt"')
+        expect(captured[:body]).to include("punctuation please")
       end
     end
 


### PR DESCRIPTION
## Problem

OpenRouter caps multipart form-data uploads at **25 MB** (`413 Multipart body exceeds the 25 MB upload limit`). The STT endpoint (`POST /api/media/audio/transcriptions`) sends audio as multipart, so long recordings fail at the API boundary.

## Change

Add a **base64 JSON path** for transcription audio to OpenAI-compatible providers that support `input_audio`:

- OpenRouter receives `{ input_audio: { data: <base64>, format: <ext> }, model: ... }`.
- The same path is used for the OpenClacky gateway (`openclacky.com`).
- All other OpenAI-compatible providers keep the existing multipart form-data path.

## Implementation

- `lib/clacky/media/openai_compat.rb` branches on `openrouter_host?` / `openclacky_gateway?` and sends base64 JSON via a new `stt_json_connection` helper.
- The JSON request uses a 120-second timeout.
- `mp4` is mapped to `m4a` for the `format` field.

## Tests

`spec/clacky/media/openai_compat_spec.rb` — 23 examples, 0 failures:

- JSON path for the gateway and OpenRouter
- `mp4` → `m4a` mapping
- multipart fallback for other providers

## Why

This bypasses OpenRouter's multipart upload limit while preserving existing behavior for providers that do not support the JSON format.