### PR TITLE
fix(git-panel): decode non-ASCII paths in git output (C-5777)

### DIFF
--- a/lib/clacky/server/git_panel.rb
+++ b/lib/clacky/server/git_panel.rb
@@ -2,6 +2,8 @@
 
 require "open3"
 
+require_relative "../utils/encoding"
+
 module Clacky
   module Server
     # Read-mostly git operations scoped to a session's working directory, backing
@@ -14,9 +16,15 @@ module Clacky
 
       # Run a git subcommand in `dir` with argv-style args (no shell). Returns
       # [stdout, stderr, success_bool]. Never raises on git failure.
+      #
+      # `core.quotePath=false` keeps git from octal-escaping non-ASCII paths, so
+      # the parsers below (and the path comparisons in `restore`) see the same
+      # bytes the caller passed in. Output is then normalised to UTF-8 because
+      # git inherits the locale, and under a non-UTF-8 locale the raw bytes come
+      # back tagged US-ASCII, where String#split would raise on multibyte paths.
       def git(dir, *args)
-        out, err, status = Open3.capture3("git", "-C", dir.to_s, *args)
-        [out, err, status.success?]
+        out, err, status = Open3.capture3("git", "-C", dir.to_s, "-c", "core.quotePath=false", *args)
+        [Utils::Encoding.to_utf8(out), Utils::Encoding.to_utf8(err), status.success?]
       rescue StandardError => e
         ["", e.message, false]
       end

--- a/spec/clacky/server/git_panel_spec.rb
+++ b/spec/clacky/server/git_panel_spec.rb
@@ -92,6 +92,59 @@ RSpec.describe Clacky::Server::GitPanel, ".diff" do
     out = described_class.diff(@dir, file: "a.bin")
     expect(out).to match(/Binary files .* differ/)
   end
+
+  it "keeps a non-ASCII filename readable in the diff header" do
+    write "图片测试.jpg", "one\n"
+    commit_all "init"
+    write "图片测试.jpg", "one\ntwo\n"
+    out = described_class.diff(@dir, file: "图片测试.jpg")
+    expect(out).to include("a/图片测试.jpg")
+    expect(out).to include("+two")
+  end
+end
+
+# Specs for GitPanel.status - the file list behind the Changes panel. git
+# octal-escapes non-ASCII paths unless core.quotePath is off, which would
+# surface as unreadable names in the panel.
+RSpec.describe Clacky::Server::GitPanel, ".status" do
+  around do |ex|
+    Dir.mktmpdir("git_panel_status_spec") do |dir|
+      @dir = dir
+      run "git", "init", "-q"
+      run "git", "config", "user.email", "spec@example.com"
+      run "git", "config", "user.name", "Spec"
+      ex.run
+    end
+  end
+
+  def run(*args)
+    out, _err, _st = Open3.capture3(*args.map(&:to_s), chdir: @dir)
+    out
+  end
+
+  def write(path, content)
+    full = File.join(@dir, path)
+    FileUtils.mkdir_p(File.dirname(full))
+    File.write(full, content)
+  end
+
+  def commit_all(message)
+    run "git", "add", "-A"
+    run "git", "commit", "-q", "-m", message
+  end
+
+  it "lists non-ASCII paths verbatim for tracked and untracked files" do
+    write "图片测试.jpg", "one\n"
+    commit_all "init"
+    write "图片测试.jpg", "one\ntwo\n"
+    write "新增 未跟踪.png", "x\n"
+
+    files = described_class.status(@dir)[:files]
+    paths = files.map { |f| f[:path] }
+    expect(paths).to include("图片测试.jpg")
+    expect(paths).to include("新增 未跟踪.png")
+    expect(files.find { |f| f[:path] == "新增 未跟踪.png" }[:untracked]).to be_truthy
+  end
 end
 
 RSpec.describe Clacky::Server::GitPanel, ".restore" do
@@ -190,5 +243,27 @@ RSpec.describe Clacky::Server::GitPanel, ".restore" do
   it "refuses an empty file" do
     expect(described_class.restore(@dir, file: "")[:ok]).to be_falsey
     expect(described_class.restore(@dir, file: nil)[:ok]).to be_falsey
+  end
+
+  # Octal-escaped ls-tree output used to make the HEAD lookup miss, so a
+  # committed file with a non-ASCII name fell through to the `git rm` branch
+  # and was deleted instead of restored.
+  it "restores a tracked non-ASCII filename instead of deleting it" do
+    write "图片测试.jpg", "one\n"
+    commit_all "init"
+    write "图片测试.jpg", "one\ntwo\n"
+    result = described_class.restore(@dir, file: "图片测试.jpg")
+    expect(result[:ok]).to be_truthy
+    expect(exists?("图片测试.jpg")).to be_truthy
+    expect(read("图片测试.jpg")).to eq("one\n")
+  end
+
+  it "deletes an untracked non-ASCII filename" do
+    write "a.txt", "one\n"
+    commit_all "init"
+    write "新增 未跟踪.png", "x\n"
+    result = described_class.restore(@dir, file: "新增 未跟踪.png")
+    expect(result[:ok]).to be_truthy
+    expect(exists?("新增 未跟踪.png")).to be_falsey
   end
 end


### PR DESCRIPTION
## Problem

The Git panel showed non-ASCII filenames as UTF-8 octal escapes, e.g.
`"\345\233\276\347\211\207\346\265\213\350\257\225.jpg"` instead of
`图片测试.jpg`. git's `core.quotePath` defaults to true, and `GitPanel.git`
never turned it off, so every parser downstream saw escaped paths —
`status`, `diff`, `ls-tree` and `ls-files` were all affected.

This also caused silent data loss in `restore`. The HEAD lookup compares
`ls-tree` output against the caller-supplied path:

- `head_tree.include?("\t#{path}")` never matched, because one side was
  escaped and the other was raw UTF-8, so the `git checkout HEAD` branch
  was skipped.
- `ls-files` then returned a non-empty (escaped) line, so the `git rm -f`
  branch ran instead.

Result: discarding changes to a committed file with a non-ASCII name
deleted the file along with the user's unsaved edits, rather than
restoring it to its HEAD content.

## Fix

Pass `-c core.quotePath=false` in `GitPanel.git`, the single place every
git command goes through, so git emits real bytes and no octal decoding
is needed anywhere.

Normalise stdout/stderr with the existing `Utils::Encoding.to_utf8`.
git inherits the process locale; under a non-UTF-8 locale the bytes come
back tagged US-ASCII and `String#split` in `status` raises
`ArgumentError: invalid byte sequence in US-ASCII`.

`restore` needed no changes — its comparisons work once both sides use
the same encoding. Verified that `-c core.quotePath=false` does not
affect argv-supplied paths, so existing callers are unaffected.

## Test

`bundle exec rspec` — 4063 examples, 0 failures.

Added three regression specs in `spec/clacky/server/git_panel_spec.rb`:
`.status` lists non-ASCII tracked/untracked paths verbatim, `.diff`
renders a readable header, and `.restore` returns a non-ASCII tracked
file to its HEAD content while asserting the file still exists.

All three fail without the fix; the `.restore` case fails with
`expected: truthy value, got: false` on the existence check, reproducing
the deletion. The suite also passes with `LANG`/`LC_ALL`/`LC_CTYPE`
unset, covering the US-ASCII locale path.