### PR TITLE
fix: correct api_extension example comment to use all_sessions (C-5776)

### DIFF
--- a/lib/clacky/extension/api_extension.rb
+++ b/lib/clacky/extension/api_extension.rb
@@ -17,7 +17,7 @@ module Clacky
   #
   #   class MyDashboardExt < Clacky::ApiExtension
   #     get "/summary" do
-  #       json(sessions: session_manager.list.size)
+  #       json(sessions: session_manager.all_sessions.size)
   #     end
   #   end
   #


### PR DESCRIPTION
## Problem

The example comment at `api_extension.rb:20` reads `session_manager.list.size`,
but the `Clacky::SessionManager` returned by `session_manager` has no `list`
method. Extension authors copying this snippet — or an AI generating code from it
— hit a `NoMethodError`.

Not a stale comment: git archaeology shows it was introduced by
`0b9e9e9e feat: installed/local/pack extension`, and `session_manager.rb` had no
`def list` at that commit either. It was wrong the day it was written.

## Fix

```diff
-  #       json(sessions: session_manager.list.size)
+  #       json(sessions: session_manager.all_sessions.size)
```

`all_sessions` (`session_manager.rb:215`) returns an array of hashes, so `.size`
is valid. Comment-only change, no runtime behaviour affected.

## Test

- ✅ Swept every `session_manager.*` reference in the repo — the other 14 call
  sites all map to real methods, no similar mistakes
- ✅ Verified the snippet's other helpers exist: `get` (`:136`) and `json` (`:192`)
  — the example is now copy-paste runnable
- ✅ `ruby -c` passes
- ✅ `bundle exec rspec` → 4059 examples, 0 failures