### PR TITLE
fix(channel): require slash prefix for help commands (C-5641)

### DIFF
--- a/lib/clacky/server/channel/channel_manager.rb
+++ b/lib/clacky/server/channel/channel_manager.rb
@@ -272,7 +272,7 @@ module Clacky
         end
 
         # Handle built-in commands
-        if text&.match?(KNOWN_COMMAND) || text&.match?(/\A([\?h]|help)\z/i)
+        if text&.match?(KNOWN_COMMAND)
           handle_command(adapter, event, text)
           return
         end
@@ -366,7 +366,7 @@ module Clacky
         key     = channel_key(event)
 
         case text
-        when /\A([\?h]|help)\z/i
+        when %r{\A/([?？]|h|help)\z}i
           adapter.send_text(chat_id, COMMAND_HELP)
 
         when "/new", "/clear"
@@ -506,15 +506,18 @@ module Clacky
           list_sessions(adapter, chat_id)
 
         else
-          adapter.send_text(chat_id, "Unknown command. Type ? for help.")
+          adapter.send_text(chat_id, "Unknown command. Type /? for help.")
         end
       end
 
-      KNOWN_COMMAND = %r{\A/(new|clear|model|skills|bind|stop|unbind|status|list)\b}i
+      # "/?" is anchored with \z instead of \b because \b never matches after
+      # "?" (not a word character), which would let "/?extra" through.
+      # "？" is accepted too since Chinese IMEs produce the full-width form.
+      KNOWN_COMMAND = %r{\A/(?:[?？]\z|(?:h|help|new|clear|model|skills|bind|stop|unbind|status|list)\b)}i
 
       COMMAND_HELP = <<~HELP.strip
         Commands:
-          ? / h / help - show this help
+          /? / /h / /help - show this help
           /new / /clear - start a new session
           /model - show current model, cards & quick-switch list
           /model <n> - switch card by number

--- a/spec/clacky/server/channel/channel_manager_command_spec.rb
+++ b/spec/clacky/server/channel/channel_manager_command_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/channel"
+
+RSpec.describe Clacky::Channel::ChannelManager do
+  describe "KNOWN_COMMAND" do
+    subject(:regex) { described_class::KNOWN_COMMAND }
+
+    it "routes the slash-prefixed help aliases" do
+      ["/?", "/？", "/h", "/help", "/H", "/HELP"].each do |text|
+        expect(text).to match(regex)
+      end
+    end
+
+    it "routes the other built-in commands" do
+      ["/new", "/clear", "/model", "/model s1", "/skills", "/bind 2",
+       "/unbind", "/stop", "/status", "/list"].each do |text|
+        expect(text).to match(regex)
+      end
+    end
+
+    # Bare "?" and "h" are everyday chat characters; they must reach the agent
+    # as normal messages instead of printing the command list.
+    it "leaves bare help characters to the agent" do
+      ["?", "h", "help", "H", "what?", "why?", "h?", "？"].each do |text|
+        expect(text).not_to match(regex)
+      end
+    end
+
+    it "does not swallow longer words that merely start with a command prefix" do
+      ["/hello", "/helper", "/helps", "/hmm", "/skillfoo"].each do |text|
+        expect(text).not_to match(regex)
+      end
+    end
+
+    # "\b" never matches after "?", so "/?" needs an explicit end anchor.
+    it "requires /? to stand alone" do
+      ["/?", "/？"].each { |text| expect(text).to match(regex) }
+      ["/?extra", "/?x", "/？x"].each { |text| expect(text).not_to match(regex) }
+    end
+  end
+
+  describe "COMMAND_HELP" do
+    it "advertises the slash-prefixed help aliases" do
+      expect(described_class::COMMAND_HELP).to include("/? / /h / /help")
+    end
+
+    it "no longer advertises bare help characters" do
+      expect(described_class::COMMAND_HELP).not_to include("? / h / help")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Bare `?`, `h`, and `help` triggered the channel command list. The entry regex
carried the `i` flag, so `H` and `HELP` matched too. These are everyday chat
characters, so normal messages were swallowed and answered with a help menu
instead of reaching the agent.

## Fix

- Add `?` / `h` / `help` to `KNOWN_COMMAND` so help follows the same slash-prefix
  whitelist as every other command, and drop the bare-text bypass at the entry point.
- Anchor `?` with `\z` rather than `\b` — `\b` never matches after a non-word
  character, so `%r{/\?\b}` would miss `/?` while letting `/?extra` through.
- Accept the full-width `/？` as well; Chinese IMEs produce it by default, so
  requiring the half-width form would silently drop the command.
- Update both help texts: the command list now shows `/? / /h / /help`, and the
  unknown-command reply points at `/?`.

Command parsing lives only in `channel_manager.rb`; the adapters under
`server/channel/adapters/` contain none, so one change covers every IM platform.

## Test

- ✅ New `channel_manager_command_spec.rb` (7 examples) covers the slash aliases,
  the bare-text cases, prefix-lookalikes such as `/helper`, and the `/?` anchor.
- ✅ Reverse-verified twice: restoring the old constant and dropping full-width
  support each make 2 examples fail.
- ✅ 59-case routing probe against the real constants read from source — all pass.
- ✅ Full suite: 4070 examples, 0 failures.