### PR TITLE
fix(brand): normalize homepage_url scheme on read (C-5666)

### DIFF
--- a/lib/clacky/brand_config.rb
+++ b/lib/clacky/brand_config.rb
@@ -53,7 +53,7 @@ module Clacky
     attr_reader :product_name, :package_name, :license_key, :license_activated_at,
                 :license_expires_at, :license_last_heartbeat, :device_id,
                 :logo_url, :support_contact, :license_user_id,
-                :support_qr_url, :theme_color, :homepage_url,
+                :support_qr_url, :theme_color,
                 :distribution_last_refreshed_at, :license_last_heartbeat_failure
 
     def initialize(attrs = {})
@@ -1649,6 +1649,17 @@ module Clacky
       # Non-fatal — metadata write failure should not break the upload flow
     end
 
+    # Vendors may configure a bare domain ("example.com"). Without a scheme the
+    # browser treats it as a relative path and resolves it against the local
+    # server, so normalize on read to cover every consumer at once.
+    def homepage_url
+      raw = @homepage_url.to_s.strip
+      return nil if raw.empty?
+      return raw if raw.match?(%r{\A[a-z][a-z0-9+.\-]*:}i)
+
+      "https://#{raw}"
+    end
+
     # Returns a hash representation for JSON serialization (e.g. /api/brand).
     def to_h
       {
@@ -1658,7 +1669,7 @@ module Clacky
         support_contact:    @support_contact,
         support_qr_url:     @support_qr_url,
         theme_color:        @theme_color,
-        homepage_url:       @homepage_url,
+        homepage_url:       homepage_url,
         branded:            branded?,
         activated:          activated?,
         expired:            expired?,

--- a/spec/clacky/brand_config_homepage_url_spec.rb
+++ b/spec/clacky/brand_config_homepage_url_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/brand_config"
+
+RSpec.describe Clacky::BrandConfig do
+  def config_with(url)
+    described_class.new("homepage_url" => url)
+  end
+
+  describe "#homepage_url" do
+    it "prepends https:// to a bare domain" do
+      expect(config_with("www.superjiujiu.top").homepage_url).to eq("https://www.superjiujiu.top")
+      expect(config_with("superjiujiu.top").homepage_url).to eq("https://superjiujiu.top")
+    end
+
+    it "keeps an existing scheme untouched" do
+      expect(config_with("https://www.superjiujiu.top").homepage_url).to eq("https://www.superjiujiu.top")
+      expect(config_with("http://example.com").homepage_url).to eq("http://example.com")
+    end
+
+    # A bare domain resolves as a relative path in the browser, which is what
+    # sent users to localhost:7070/<domain>; a path suffix must survive.
+    it "prepends https:// to a bare domain carrying a path or query" do
+      expect(config_with("example.com/buy?ref=1").homepage_url).to eq("https://example.com/buy?ref=1")
+    end
+
+    it "does not rewrite non-http schemes" do
+      expect(config_with("mailto:sales@example.com").homepage_url).to eq("mailto:sales@example.com")
+    end
+
+    it "returns nil when unset or blank" do
+      expect(config_with(nil).homepage_url).to be_nil
+      expect(config_with("").homepage_url).to be_nil
+      expect(config_with("   ").homepage_url).to be_nil
+    end
+
+    it "trims surrounding whitespace before normalizing" do
+      expect(config_with("  example.com  ").homepage_url).to eq("https://example.com")
+    end
+
+    it "exposes the normalized value through #to_h" do
+      expect(config_with("example.com").to_h[:homepage_url]).to eq("https://example.com")
+    end
+
+    # brand.yml must keep whatever the platform sent; normalization is a read
+    # concern, so a round-trip never rewrites the vendor's stored value.
+    it "persists the raw value in #to_yaml" do
+      expect(config_with("example.com").to_yaml).to include("homepage_url: example.com")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The brand homepage link in Settings pointed at the local server. With
`homepage_url` configured as a bare domain (`www.superjiujiu.top`), the
value went straight into `href` — and a string without a scheme is a
relative path, so the browser resolved it against the current page and
navigated to `http://localhost:7070/www.superjiujiu.top` (Not Found).

`homepage_url` was never normalized anywhere along the chain: it was
stored as received in `BrandConfig#initialize` / `#apply_distribution`,
exposed as received by `/api/brand` and `/api/brand/status`, and consumed
as received by the frontend.

The same raw value reached four other consumers with the same defect:

- the "get serial number" button (`window.open`, same base URL)
- share text and Weibo share (`share/store.js` → `share/view.js`)
- the share-card QR code (encodes the bare domain)
- the Discord `User-Agent` header (`DiscordBot ($url, $version)`)

Note `support_contact` already branches on its scheme (http vs mailto)
in the same settings view, so the need for normalization was established
in the codebase — `homepage_url` was simply missed.

## Fix

Normalize on read in `BrandConfig`, which is the single point every
consumer passes through:

- Drop `:homepage_url` from `attr_reader` and define an explicit reader
  that returns `nil` when blank, returns the value untouched when it
  already carries any scheme, and otherwise prepends `https://`.
- Point `#to_h` at the reader, since it is the `/api/brand` response body.
- Leave `#to_yaml` on the raw ivar: persistence must not rewrite what the
  platform sent, so normalization stays purely a read concern.

Why the reader rather than the write path: `@homepage_url` has three
assignment sites, so normalizing on write means three changes and still
leaves bare domains already persisted in `brand.yml` broken. Likewise the
three output sites would each need patching, and `discord/api_client.rb`
reads the attribute directly, bypassing them all. The reader covers every
caller at once, so all five consumers above are fixed with no frontend
changes.

The scheme test matches any scheme rather than whitelisting http/https,
so values like `mailto:` are not mangled. `https` is prepended rather
than `http` to default outbound links to TLS.

## Test

- ✅ New `spec/clacky/brand_config_homepage_url_spec.rb`, 8 examples:
  bare domain, existing scheme preserved, bare domain with path and
  query, `mailto:` left alone, nil/empty/whitespace → nil, whitespace
  trimmed, `#to_h` normalized, `#to_yaml` raw.
- ✅ Reverse-verified: restoring the plain `attr_reader` fails 5 of the 8
  examples, confirming they catch the regression.
- ✅ Full suite: 4071 examples, 0 failures.
- ✅ End-to-end check over seven inputs, comparing reader output against
  `URI.join("http://localhost:7070/", url)` — no input resolves to the
  local server any more.
- ⚠️ Not verified by clicking the link in a real browser: that requires
  writing a bare domain into `brand.yml` and hot-swapping the installed
  gem, which would touch live brand licensing config. The evidence above
  is Ruby-side plus `URI.join`, which follows the same relative-path
  resolution rules as the browser.