### PR TITLE
fix(workspace): sniff binary content before text preview (C-5690)

### DIFF
--- a/lib/clacky/web/components/code-editor.js
+++ b/lib/clacky/web/components/code-editor.js
@@ -88,6 +88,11 @@
     "class","pyc","psd","ai","eps","indd","sketch","fig",
   ]);
 
+  // Sample size matches the server-side 512-byte sniff; the ratio tolerates a
+  // few stray replacement chars in otherwise valid text.
+  const SNIFF_SAMPLE_CHARS = 512;
+  const SNIFF_REPLACEMENT_RATIO = 0.1;
+
   function _fileKind(filename) {
     if (!filename) return "text";
     const ext = filename.split(".").pop().toLowerCase();
@@ -95,6 +100,22 @@
     if (PDF_EXTS.has(ext))   return "pdf";
     if (BINARY_EXTS.has(ext)) return "binary";
     return "text";
+  }
+
+  // BINARY_EXTS can only list what we thought of, so unlisted binaries still
+  // reach the text branch and render as noise. Mirrors the server-side sniff in
+  // Utils::FileProcessor.binary_file_path?: a NUL byte means "not text". Decoding
+  // already turned invalid sequences into U+FFFD, so a high density of those is
+  // the same signal for encodings that carry no NUL.
+  function _looksBinary(text) {
+    if (!text) return false;
+    const head = text.slice(0, SNIFF_SAMPLE_CHARS);
+    if (head.indexOf("\u0000") >= 0) return true;
+    let replacements = 0;
+    for (let i = 0; i < head.length; i++) {
+      if (head.charCodeAt(i) === 0xFFFD) replacements++;
+    }
+    return replacements / head.length > SNIFF_REPLACEMENT_RATIO;
   }
 
   function _detectLanguage(filename) {
@@ -330,6 +351,7 @@
     open,
     createInline,
     fileKind: _fileKind,
+    looksBinary: _looksBinary,
     detectLanguage: _detectLanguage,
     renderMarkdown: _renderMarkdownHtml,
   };

--- a/lib/clacky/web/features/workspace/view.js
+++ b/lib/clacky/web/features/workspace/view.js
@@ -933,7 +933,7 @@ const WorkspaceView = (() => {
           tab = await buildFallbackTab(entry);
         } else {
           const text = await Workspace.fetchFileText(entry);
-          tab = buildTextTab(entry, text);
+          tab = CodeEditor.looksBinary(text) ? await buildFallbackTab(entry) : buildTextTab(entry, text);
         }
       } catch (err) {
         console.error("preview failed:", err);


### PR DESCRIPTION
## Problem

Clicking a `.pptx` in the workspace Files panel opened it in CodeMirror as
plain text, showing raw zip bytes as unreadable noise.

`openTab` classifies a file by extension via `CodeEditor.fileKind`, and
anything not listed in `BINARY_EXTS` falls through to the text branch.
`ppt` / `pptx` were missing from that list on the reported version (v1.3.3),
so they took the text path.

The list has since been extended on `main` to cover the Office family, but
`git tag --contains` shows that commit is in no released tag — it landed a
day after v1.5.13 — so every published build still reproduces the bug.

Extending the list only fixes what we remembered to enumerate. Unlisted
binary formats (`.rtf`, `.epub`, `.apk`, `.heic`, `.ogg`, `.blend`, `.o`, …)
still reach the text branch and render as noise, which means the same issue
can be filed again for any format not on the list.

The server side already solved this: `Utils::FileProcessor.binary_file_path?`
falls back to sniffing the first 512 bytes for a NUL byte when the extension
misses. The web UI had no equivalent.

## Fix

Add the missing content sniff to the web UI, so detection no longer depends
on the extension list being exhaustive:

- `CodeEditor.looksBinary(text)` samples the leading 512 characters and
  reports binary on a NUL byte, mirroring the server-side heuristic. It also
  flags a high density of U+FFFD, since `Response.text()` has already
  replaced invalid sequences by the time the UI sees the content and the NUL
  signal may be gone.
- The text branch of `openTab` routes a positive result to the existing
  `buildFallbackTab`, the same pane binary files already use.

Sniffing lives in `code-editor.js` because that file already owns file-type
classification (`fileKind`, `detectLanguage`); the workspace view keeps only
the routing decision. `BINARY_EXTS` stays as the cheap fast path, with the
sniff as the safety net behind it, so no extra work is done for the common
case. Reusing `buildFallbackTab` means no new UI, strings, or CSS.

CSV is deliberately untouched: it is genuine text that currently opens,
edits, and saves correctly, and its lack of column alignment is a separate
readability concern rather than part of this bug.

## Test

- ✅ `node --check` passes on both changed files.
- ✅ 18 classification cases pass, with the function extracted from source at
  runtime rather than copied: real zip-structured `.pptx` / `.xlsx` / `.docx`
  detect as binary, while plain text, CSV, Ruby, JSON, CJK, emoji, markdown,
  and minified `codemirror.min.js` stay text.
- ✅ Boundaries covered: NUL inside the sample window, NUL just past it
  (character 513) correctly ignored, and a lone stray U+FFFD in long text not
  misclassified.
- ✅ Reverse-verified: stubbing the sniff to `return false` flips all three
  binary cases back to text, confirming the cases catch the regression.
- ✅ Full suite: 4087 examples, 0 failures.
- ⚠️ Not verified by clicking in a real browser — the project has no JS test
  setup (no `package.json`, `spec/` is Ruby only). Evidence above is the real
  function run over real file bytes under Node, not a live click.
- ℹ️ No code change for `ppt` / `pptx`: the `BINARY_EXTS` entries already on
  `main` start working once this ships in a tagged release.