### PR TITLE
Fix:billing tooltip ux (C-5778)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -13460,6 +13460,23 @@ body.setup-mode[data-theme="dark"] {
 .billing-trend-svg:hover .billing-trend-dot {
   opacity: 1;
 }
+.billing-trend-svg .billing-trend-dot.is-active {
+  opacity: 1;
+  transform-box: fill-box;
+  transform-origin: center;
+  transform: scale(1.5);
+  transition: none;
+}
+.billing-trend-crosshair {
+  stroke: var(--color-accent-primary);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  opacity: 0;
+  pointer-events: none;
+}
+.billing-trend-crosshair.is-visible {
+  opacity: 0.5;
+}
 
 /* ── Chart Card base ─────────────────────────────────────────────────── */
 .billing-chart-row { width: 100%; }
@@ -13598,6 +13615,13 @@ body.setup-mode[data-theme="dark"] {
   z-index: 1000;
   min-width: 200px;
   pointer-events: none;
+}
+/* 200px is wider than half the chart on a phone; let it shrink to fit. */
+@media (max-width: 768px) {
+  .billing-chart-tooltip {
+    min-width: 0;
+    max-width: calc(100vw - 16px);
+  }
 }
 .tooltip-header {
   display: flex;

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -13616,13 +13616,6 @@ body.setup-mode[data-theme="dark"] {
   min-width: 200px;
   pointer-events: none;
 }
-/* 200px is wider than half the chart on a phone; let it shrink to fit. */
-@media (max-width: 768px) {
-  .billing-chart-tooltip {
-    min-width: 0;
-    max-width: calc(100vw - 16px);
-  }
-}
 .tooltip-header {
   display: flex;
   justify-content: space-between;
@@ -15622,6 +15615,12 @@ body.setup-mode[data-theme="dark"] {
   #ns-skill-autocomplete {
     left: 16px;
     right: 16px;
+  }
+
+  /* 200px is wider than half the chart on a phone; let it shrink to fit. */
+  .billing-chart-tooltip {
+    min-width: 0;
+    max-width: calc(100vw - 16px);
   }
 }
 

--- a/lib/clacky/web/features/billing/view.js
+++ b/lib/clacky/web/features/billing/view.js
@@ -290,6 +290,20 @@ const BillingView = (() => {
 
   // ── Tooltips ─────────────────────────────────────────────────────────────────
 
+  // Measured while hidden so the real size is known before choosing a side.
+  // The clamp matters on narrow viewports: flipping a 200px-wide tooltip left of
+  // a cursor near the left edge would otherwise push it off-screen.
+  function _placeTooltip(tooltip, e) {
+    tooltip.style.display = "block";
+    tooltip.style.visibility = "hidden";
+    const rect = tooltip.getBoundingClientRect();
+    const ovfX = e.clientX + 15 + rect.width - window.innerWidth;
+    const ovfY = e.clientY - 10 + rect.height - window.innerHeight;
+    tooltip.style.left = ovfX > 0 ? `${Math.max(8, e.clientX - 15 - rect.width)}px` : `${e.clientX + 15}px`;
+    tooltip.style.top = ovfY > 0 ? `${Math.max(8, e.clientY - 10 - rect.height)}px` : `${e.clientY - 10}px`;
+    tooltip.style.visibility = "visible";
+  }
+
   function _bindChartTooltip() {
     const container = document.getElementById("billing-chart-container");
     const tooltip = document.getElementById("billing-tooltip");
@@ -334,14 +348,7 @@ const BillingView = (() => {
           <span class="tooltip-value">${output}</span>
         </div>
       `;
-      tooltip.style.display = "block";
-      tooltip.style.visibility = "hidden";
-      const rect = tooltip.getBoundingClientRect();
-      const ovfX = e.clientX + 15 + rect.width - window.innerWidth;
-      const ovfY = e.clientY - 10 + rect.height - window.innerHeight;
-      tooltip.style.left = ovfX > 0 ? `${e.clientX - 15 - rect.width}px` : `${e.clientX + 15}px`;
-      tooltip.style.top = ovfY > 0 ? `${e.clientY - 10 - rect.height}px` : `${e.clientY - 10}px`;
-      tooltip.style.visibility = "visible";
+      _placeTooltip(tooltip, e);
     });
 
     container.addEventListener("mouseleave", () => {
@@ -376,13 +383,12 @@ const BillingView = (() => {
           <span class="tooltip-value">${cell.dataset.cost}</span>
         </div>
       `;
-      tooltip.style.display = "block";
-      tooltip.style.left = `${e.clientX + 15}px`;
-      tooltip.style.top = `${e.clientY - 10}px`;
+      _placeTooltip(tooltip, e);
     });
 
     grid.addEventListener("mouseleave", () => {
       tooltip.style.display = "none";
+      tooltip.style.visibility = "";
     });
   }
 
@@ -406,13 +412,7 @@ const BillingView = (() => {
           <span class="tooltip-value">${dot.dataset.cost}</span>
         </div>
       `;
-      tooltip.style.display = "block";
-      tooltip.style.visibility = "hidden";
-      const rect = tooltip.getBoundingClientRect();
-      const ovf = e.clientX + 15 + rect.width - window.innerWidth;
-      tooltip.style.left = ovf > 0 ? `${e.clientX - 15 - rect.width}px` : `${e.clientX + 15}px`;
-      tooltip.style.top = `${e.clientY - 10}px`;
-      tooltip.style.visibility = "visible";
+      _placeTooltip(tooltip, e);
     });
 
     svg.addEventListener("mouseleave", () => {

--- a/lib/clacky/web/features/billing/view.js
+++ b/lib/clacky/web/features/billing/view.js
@@ -293,10 +293,27 @@ const BillingView = (() => {
   // Measured while hidden so the real size is known before choosing a side.
   // The clamp matters on narrow viewports: flipping a 200px-wide tooltip left of
   // a cursor near the left edge would otherwise push it off-screen.
-  function _placeTooltip(tooltip, e) {
+  //
+  // Below MOBILE_TOOLTIP_MAX_WIDTH the tooltip is as wide as 58%-73% of the chart,
+  // so following the pointer covers the data no matter which side it flips to.
+  // There it docks just outside `chart` instead, keeping the plot fully visible.
+  const MOBILE_TOOLTIP_MAX_WIDTH = 768;
+
+  function _placeTooltip(tooltip, e, chart) {
     tooltip.style.display = "block";
     tooltip.style.visibility = "hidden";
     const rect = tooltip.getBoundingClientRect();
+
+    if (chart && window.innerWidth <= MOBILE_TOOLTIP_MAX_WIDTH) {
+      const chartRect = chart.getBoundingClientRect();
+      const below = chartRect.bottom + 8;
+      const top = below + rect.height > window.innerHeight ? chartRect.top - 8 - rect.height : below;
+      tooltip.style.left = `${Math.max(8, Math.min(chartRect.left, window.innerWidth - 8 - rect.width))}px`;
+      tooltip.style.top = `${Math.max(8, top)}px`;
+      tooltip.style.visibility = "visible";
+      return;
+    }
+
     const ovfX = e.clientX + 15 + rect.width - window.innerWidth;
     const ovfY = e.clientY - 10 + rect.height - window.innerHeight;
     tooltip.style.left = ovfX > 0 ? `${Math.max(8, e.clientX - 15 - rect.width)}px` : `${e.clientX + 15}px`;
@@ -348,7 +365,7 @@ const BillingView = (() => {
           <span class="tooltip-value">${output}</span>
         </div>
       `;
-      _placeTooltip(tooltip, e);
+      _placeTooltip(tooltip, e, container);
     });
 
     container.addEventListener("mouseleave", () => {
@@ -383,7 +400,7 @@ const BillingView = (() => {
           <span class="tooltip-value">${cell.dataset.cost}</span>
         </div>
       `;
-      _placeTooltip(tooltip, e);
+      _placeTooltip(tooltip, e, grid);
     });
 
     grid.addEventListener("mouseleave", () => {
@@ -392,16 +409,49 @@ const BillingView = (() => {
     });
   }
 
+  // The dots are r="3" in viewBox units, which the responsive SVG scales down to
+  // under 5px on a phone — far too small to hit. Snap to the nearest point on the
+  // x axis instead so the whole column width is clickable.
+  function _nearestTrendDot(svg, clientX, clientY) {
+    const count = parseInt(svg.dataset.count, 10);
+    const xStep = parseFloat(svg.dataset.xStep);
+    const plotLeft = parseFloat(svg.dataset.plotLeft);
+    if (!count || !xStep) return null;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return null;
+    const point = svg.createSVGPoint();
+    point.x = clientX;
+    point.y = clientY;
+    const x = point.matrixTransform(ctm.inverse()).x;
+    const index = Math.max(0, Math.min(count - 1, Math.round((x - plotLeft) / xStep)));
+    return svg.querySelector(`.billing-trend-dot[data-index="${index}"]`);
+  }
+
   function _bindTrendTooltip() {
     const svg = document.querySelector(".billing-trend-svg");
     const tooltip = document.getElementById("billing-tooltip");
     if (!svg || !tooltip) return;
 
+    const crosshairX = svg.querySelector(".billing-trend-crosshair-x");
+    const crosshairY = svg.querySelector(".billing-trend-crosshair-y");
+
     svg.addEventListener("mousemove", (e) => {
-      const dot = e.target.closest(".billing-trend-dot");
+      const dot = _nearestTrendDot(svg, e.clientX, e.clientY);
       if (!dot) {
         tooltip.style.display = "none";
         return;
+      }
+      svg.querySelectorAll(".billing-trend-dot.is-active").forEach(d => d.classList.remove("is-active"));
+      dot.classList.add("is-active");
+      if (crosshairX && crosshairY) {
+        const cx = dot.getAttribute("cx");
+        const cy = dot.getAttribute("cy");
+        crosshairX.setAttribute("x1", cx);
+        crosshairX.setAttribute("x2", cx);
+        crosshairY.setAttribute("y1", cy);
+        crosshairY.setAttribute("y2", cy);
+        crosshairX.classList.add("is-visible");
+        crosshairY.classList.add("is-visible");
       }
       tooltip.innerHTML = `
         <div class="tooltip-header">
@@ -412,12 +462,14 @@ const BillingView = (() => {
           <span class="tooltip-value">${dot.dataset.cost}</span>
         </div>
       `;
-      _placeTooltip(tooltip, e);
+      _placeTooltip(tooltip, e, svg);
     });
 
     svg.addEventListener("mouseleave", () => {
       tooltip.style.display = "none";
       tooltip.style.visibility = "";
+      svg.querySelectorAll(".billing-trend-dot.is-active").forEach(d => d.classList.remove("is-active"));
+      svg.querySelectorAll(".billing-trend-crosshair").forEach(l => l.classList.remove("is-visible"));
     });
   }
 
@@ -641,7 +693,7 @@ const BillingView = (() => {
           <h4>${I18n.t("billing.costTrend") || "Cost Trend"}</h4>
         </div>
         <div class="billing-trend-chart">
-          <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" class="billing-trend-svg">
+          <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" class="billing-trend-svg" data-plot-left="${pad.left}" data-x-step="${xStep}" data-count="${costs.length}">
             ${yLabels.map(l => `
               <line x1="${pad.left}" y1="${l.y}" x2="${w - pad.right}" y2="${l.y}" class="billing-trend-grid-line" />
               <text x="${pad.left - 6}" y="${l.y + 4}" class="billing-trend-y-label">${currencySymbol}${_formatCost(l.val)}</text>
@@ -656,11 +708,13 @@ const BillingView = (() => {
               </linearGradient>
             </defs>
             <polygon points="${areaPoints}" fill="url(#billing-trend-grad)" class="billing-trend-area" />
+            <line class="billing-trend-crosshair billing-trend-crosshair-x" x1="0" y1="${pad.top}" x2="0" y2="${pad.top + plotH}" />
+            <line class="billing-trend-crosshair billing-trend-crosshair-y" x1="${pad.left}" y1="0" x2="${w - pad.right}" y2="0" />
             <polyline points="${points}" fill="none" class="billing-trend-line" />
             ${costs.map((c, i) => {
               const cx = pad.left + i * xStep;
               const cy = pad.top + plotH - ((c - minCost) / range) * plotH;
-              return `<circle cx="${cx}" cy="${cy}" r="3" class="billing-trend-dot" data-date="${days[i].date}" data-cost="${currencySymbol}${_formatCost(c)}" />`;
+              return `<circle cx="${cx}" cy="${cy}" r="3" class="billing-trend-dot" data-index="${i}" data-date="${days[i].date}" data-cost="${currencySymbol}${_formatCost(c)}" />`;
             }).join("")}
           </svg>
         </div>


### PR DESCRIPTION

<img width="1512" height="806" alt="Snapzy_2026-09-08_17-34-07_663" src="https://github.com/user-attachments/assets/0e0e932c-06ed-476c-b0c2-4ee09a7a8056" />

## Summary

Chart tooltips in the billing panel were unusable on phones. Two rounds of
fixes, one commit each: the first stops tooltips overflowing the viewport, the
second makes the cost-trend chart actually operable by touch.

## Problem

Measured in Chrome against a real 390px viewport:

| Issue | Desktop | 390px | 320px |
|---|---|---|---|
| Trend dot diameter | 10.1px | 4.7px | 3.7px |
| Plot width that responds to a pointer | 52% | 52% | 52% |
| Tooltip width as a share of the plot | 30% | 58% | 73% |

- Heatmap tooltips used a bare `clientX + 15` with no bounds check and were
  clipped by 26–158px from the third column onward.
- The trend chart required hitting a sub-5px dot; the space between dots did
  nothing. Against the 44/48px touch target Apple and Google recommend, this
  is off by an order of magnitude.
- The tooltip is wider than half the plot on a phone, so wherever it flipped
  it covered the data it was describing.
- With the tooltip open it was unclear which point it referred to.

## Changes

**`fix(billing): keep chart tooltips inside the viewport (C-5778)`**
- Extract a shared `_placeTooltip`; measure while hidden so the real size is
  known before picking a side, and clamp to a minimum of 8px — without it a
  flipped 200px tooltip lands at `left: -208px` on a narrow viewport.
- Reset `visibility` on `mouseleave` at all three call sites.

**`feat(billing): make chart tooltips usable on touch devices`**
- Snap the trend tooltip to the nearest point on the x axis, reusing the
  approach in `chat-navigator.js`. Hit area goes from the 10.1px dot to the
  full 19.5px column pitch on desktop and 4.7px → 9.2px at 390px (1.9x), with
  zero dead pixels.
- Convert coordinates with `getScreenCTM().inverse()`, not a width ratio.
- Add a crosshair tracking the highlighted point, spanning the plot box so
  values line up with the y axis. `pointer-events: none` is required or the
  guides intercept the pointer and snapping stops working.
- Dock the tooltip outside the chart below 768px (below the plot, flipping
  above when there is no room) and release the 200px `min-width` at the same
  breakpoint — the trend tooltip shrinks to 119.7px. Applies to all three
  charts, since they share one tooltip element.
- Raise the active-dot selector to `.billing-trend-svg .billing-trend-dot.is-active`
  and set `transition: none`. It previously tied
  `.billing-trend-svg:hover .billing-trend-dot` at 0,2,0 specificity, winning
  only on source order, and measured 0.036 opacity in practice.

## Verification

- **Node probes, functions eval'd from source**: 49/49 for placement (4
  viewports × 3 chart positions, full-plot pointer sweep asserting zero
  overlap and zero off-screen), 30/30 for snapping, 32/32 for the crosshair.
  Desktop placement compared point-by-point against the original algorithm:
  identical across 1000+ samples.
- **Reverse verification**: every new assertion was confirmed to fail when the
  behaviour is reverted — dropping the mobile dock puts the tooltip over the
  plot at 258/258 sampled points, reproducing the reported bug; restoring
  geometric hit-testing breaks 14; making the crosshair follow the pointer
  breaks 4; weakening the CSS selector breaks 1. Sources temporarily edited
  for these runs were restored byte-for-byte and checked.
- **Real Chrome**: 30/30 exact hits at three widths, 0 dead pixels, crosshair
  aligned to the data point within 0px, guide contrast 2.3 (light) / 2.44
  (dark).
- `bundle exec rspec` — 4087 examples, 0 failures.

## Not verified

The docked tooltip position and the crosshair's dash/opacity were **not
checked on a real narrow viewport**. `window.resizeTo` is blocked and the
viewport could not be overridden, and port 7070 serves the installed gem
rather than this working copy, so the mobile widths above come from applying
the rules manually via `getComputedStyle`. Worth a look on a device before
merge.