### PR TITLE
fix(ext-studio): collapse extension actions into a ⋯ menu on narrow screens (C-5781)

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
+++ b/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
@@ -147,6 +147,7 @@
       "extlist.btn.disable": "Disable",
       "extlist.btn.enable": "Enable",
       "extlist.btn.delete": "Delete",
+      "extlist.btn.more": "More actions",
       "extlist.badge.disabled": "Disabled",
       "extlist.delete.confirm": "Delete local extension \"{{id}}\"? This cannot be undone.",
       "extlist.iterate.seed": "Iterate on extension {{id}}",
@@ -345,6 +346,7 @@
       "extlist.btn.disable": "禁止",
       "extlist.btn.enable": "启用",
       "extlist.btn.delete": "删除",
+      "extlist.btn.more": "更多操作",
       "extlist.badge.disabled": "已禁用",
       "extlist.delete.confirm": "确定要删除本地扩展「{{id}}」吗？此操作不可恢复。",
       "extlist.iterate.seed": "迭代扩展 {{id}}",
@@ -499,6 +501,76 @@
     });
     (children || []).forEach((c) => { if (c) node.appendChild(typeof c === "string" ? document.createTextNode(c) : c); });
     return node;
+  }
+
+  // ── Shared: overflow menu ──────────────────────────────────────────────
+  // Mirrors the session list's "⋯" menu so buttons collapsed on narrow screens
+  // stay reachable. Items proxy the real buttons rather than duplicating them,
+  // which keeps transient label/disabled state (e.g. "Packing…") in sync.
+  const OVERFLOW_ICON = `<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="2.5" cy="7" r="1.2" fill="currentColor"/><circle cx="7" cy="7" r="1.2" fill="currentColor"/><circle cx="11.5" cy="7" r="1.2" fill="currentColor"/></svg>`;
+
+  let overflowDismiss = null;
+  let overflowAnchor = null;
+
+  function closeOverflowMenu() {
+    if (overflowDismiss) {
+      document.removeEventListener("click", overflowDismiss, true);
+      overflowDismiss = null;
+    }
+    overflowAnchor = null;
+    const existing = document.querySelector(".studio-overflow-menu");
+    if (existing) existing.remove();
+  }
+
+  function openOverflowMenu(anchor, buttons) {
+    // Re-tapping the same "⋯" toggles; tapping a different card must switch to it
+    // rather than merely dismissing the menu that is already open.
+    if (overflowAnchor === anchor) { closeOverflowMenu(); return; }
+    closeOverflowMenu();
+    overflowAnchor = anchor;
+    const menu = el("div", { class: "session-actions-menu studio-overflow-menu" });
+    buttons.forEach((btn) => {
+      const item = el("div", { class: "session-actions-menu-item" }, [
+        el("span", { class: "session-actions-menu-label", text: btn.textContent }),
+      ]);
+      if (btn.classList.contains("studio-btn-danger")) item.classList.add("session-actions-menu-item--danger");
+      if (btn.disabled) {
+        item.classList.add("is-disabled");
+        const tip = btn.getAttribute("data-tooltip");
+        if (tip) item.setAttribute("data-tooltip", tip);
+      } else {
+        item.addEventListener("click", () => { closeOverflowMenu(); btn.click(); });
+      }
+      menu.appendChild(item);
+    });
+
+    // Take the menu out of normal flow before measuring: as a static block child
+    // of <body> it would stretch to the full body width, so mw would be the
+    // viewport width and the clamp below would fling the menu to the far edge.
+    menu.style.visibility = "hidden";
+    menu.style.position = "fixed";
+    menu.style.top = "0px";
+    menu.style.left = "0px";
+    document.body.appendChild(menu);
+    const rect = anchor.getBoundingClientRect();
+    const mw = menu.offsetWidth;
+    const mh = menu.offsetHeight;
+    let top = rect.bottom + 4;
+    let left = rect.left;
+    if (top + mh > window.innerHeight - 8) top = Math.max(8, rect.top - mh - 4);
+    if (left + mw > window.innerWidth - 8) left = Math.max(8, window.innerWidth - mw - 8);
+    menu.style.top = top + "px";
+    menu.style.left = left + "px";
+    menu.style.visibility = "";
+
+    // Capture phase runs before the anchor's own handler, so the anchor has to be
+    // excluded here or reopening would immediately close and reopen the menu.
+    overflowDismiss = (e) => {
+      const node = e.target instanceof Element ? e.target : null;
+      if (node && (node.closest(".studio-overflow-menu") || node.closest(".studio-actions-overflow"))) return;
+      closeOverflowMenu();
+    };
+    document.addEventListener("click", overflowDismiss, true);
   }
 
   // ── Shared: modal dialog ───────────────────────────────────────────────
@@ -1636,7 +1708,7 @@
 
       if (typeof Brand !== "undefined" && Brand.userLicensed) {
         const brandEntry = brandCloud.find((c) => c.id === ext.id);
-        const brandPub = el("button", { class: "studio-btn", text: t("extlist.btn.publishBrand") });
+        const brandPub = el("button", { class: "studio-btn studio-btn-collapsible", text: t("extlist.btn.publishBrand") });
         brandPub.disabled = !!ext.error_count;
         if (ext.error_count) brandPub.setAttribute("data-tooltip", t("extlist.verify.errors", { n: ext.error_count }));
         brandPub.addEventListener("click", () => doPublish(ext, brandEntry ? brandEntry.version : null, "self"));
@@ -1644,12 +1716,12 @@
       }
 
       actions.appendChild(el("button", { class: "studio-btn", text: t("extlist.btn.iterate"), onclick: () => createExtension(t("extlist.iterate.seed", { id: ext.id })) }));
-      const packBtn = el("button", { class: "studio-btn studio-btn-ghost", text: t("extlist.btn.pack") });
+      const packBtn = el("button", { class: "studio-btn studio-btn-ghost studio-btn-collapsible", text: t("extlist.btn.pack") });
       packBtn.addEventListener("click", () => doPack(ext, packBtn));
       actions.appendChild(packBtn);
 
       const toggleBtn = el("button", {
-        class: "studio-btn studio-btn-ghost",
+        class: "studio-btn studio-btn-ghost studio-btn-collapsible",
         text: ext.disabled ? t("extlist.btn.enable") : t("extlist.btn.disable"),
       });
       toggleBtn.addEventListener("click", () => doToggleDisabled(ext, toggleBtn));
@@ -1657,10 +1729,18 @@
       card.appendChild(actions);
 
       if (!published) {
-        const delBtn = el("button", { class: "studio-btn studio-btn-danger", text: t("extlist.btn.delete") });
+        const delBtn = el("button", { class: "studio-btn studio-btn-danger studio-btn-collapsible", text: t("extlist.btn.delete") });
         delBtn.addEventListener("click", () => doDelete(ext, delBtn));
         actions.appendChild(delBtn);
       }
+
+      const overflow = el("button", { class: "studio-btn studio-actions-overflow", "aria-label": t("extlist.btn.more"), title: t("extlist.btn.more") });
+      overflow.innerHTML = OVERFLOW_ICON;
+      overflow.addEventListener("click", (e) => {
+        e.stopPropagation();
+        openOverflowMenu(overflow, Array.from(actions.querySelectorAll(".studio-btn-collapsible")));
+      });
+      actions.appendChild(overflow);
       return card;
     }
 
@@ -2041,7 +2121,7 @@
     .studio-detail-desc { margin: 4px 0 0; font-size: 12px; color: var(--color-text-secondary); line-height: 1.5; }
     .studio-units { display: flex; flex-wrap: wrap; gap: 6px; }
     .studio-unit-chip { display: inline-flex; background: var(--color-bg-hover); color: var(--color-text-primary); border: 1px solid var(--color-border-primary); border-radius: var(--radius-sm); padding: 2px 8px; font-size: 12px; }
-    .studio-actions { display: flex; align-items: center; gap: 8px; margin: 12px 0 0; }
+    .studio-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: 12px 0 0; }
     .studio-skill-promo .studio-actions { margin: 12px 0 0; }
     .studio-btn { padding: 7px 14px; border-radius: var(--radius-sm); border: 1px solid var(--color-border-primary); background: transparent; color: var(--color-text-secondary); cursor: pointer; font-size: 13px; font-weight: 500; }
     .studio-btn:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
@@ -2150,6 +2230,12 @@
     .studio-readme-preview pre code, .extension-readme-body pre code { background: none; padding: 0; }
     .studio-link-btn { background: none; border: none; padding: 0; font-size: 12px; color: var(--color-accent-primary); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
     .studio-link-btn:hover { color: var(--color-accent-hover); }
+    .studio-actions-overflow { display: none; align-items: center; justify-content: center; align-self: stretch; box-sizing: border-box; padding: 7px 12px; }
+    .studio-overflow-menu .session-actions-menu-item.is-disabled { opacity: 0.5; cursor: default; }
+    @media (max-width: 768px) {
+      .studio-actions > .studio-btn-collapsible { display: none; }
+      .studio-actions > .studio-actions-overflow { display: inline-flex; }
+    }
   `;
   document.head.appendChild(style);
 })();


### PR DESCRIPTION

<img width="1440" height="3120" alt="Screenshot_20260910_113354_Samsung Browser" src="https://github.com/user-attachments/assets/954f794e-ad02-48ba-a1b1-9c8bbcaa71ce" />

## Problem

On viewports ≤768px the extension card action row (Publish / Iterate / Pack /
Disable / Delete) overflowed its container. Buttons wrapped onto a second line
and the primary Publish/Update button got squeezed, making the card hard to use
on phones.

## Solution

Keep the primary action and Iterate inline; collapse the remaining secondary
actions into a "⋯" overflow menu, reusing the session list's menu styling. The
change is scoped to a single `@media (max-width: 768px)` block, so desktop
layout is untouched.

Menu items **proxy** the real buttons (reading `textContent` / `disabled` and
forwarding `click`) rather than duplicating them, so transient label changes
("Packing…") and disabled-state tooltips stay in sync automatically.

## Details

- `.studio-actions-overflow` is `display: none` by default and only becomes
  `inline-flex` inside the 768px block; `.studio-btn-collapsible` is hidden
  there. No new breakpoints were introduced.
- The ⋯ button uses `align-self: stretch` + `box-sizing: border-box` to match
  the row height instead of a hardcoded pixel value, so it stays aligned when
  the row wraps.
- The menu is switched to `position: fixed` **before** being inserted into the
  DOM. As a static block child of `<body>` it would stretch to the full body
  width, which made the measured width the viewport width and caused the
  horizontal clamp to fling the menu to the opposite screen edge.
- Menu placement flips above the anchor near the bottom edge and clamps
  horizontally near the right edge, with an 8px viewport margin.
- The anchor is tracked in `overflowAnchor`, so re-tapping the same ⋯ toggles
  the menu while tapping a different card switches to it instead of merely
  dismissing the open one.
- The dismiss listener runs in the capture phase and lets clicks on any
  `.studio-actions-overflow` through, leaving open/close ownership entirely to
  `openOverflowMenu`. It is detached on close.
- `aria-label` / `title` on the ⋯ button go through i18n (`extlist.btn.more`).

## Verification

- End-to-end probe in real headless Chrome at 390×844 (CDP, mobile emulation)
  driving the actual `openOverflowMenu` / `closeOverflowMenu` source with the
  extension's real extracted CSS: **47/47 assertions pass**. Menu width 170px
  (not body width), horizontal drift 0, vertical gap 0 across all cards.
  No layout or size values are mocked.
- Covers: popup sizing, anchor adjacency, upward flip and leftward clamp via
  edge-anchored anchors, four-edge viewport containment while scrolled to the
  bottom, click forwarding, card switching, toggling, outside-click dismissal,
  inner-label forwarding, listener cleanup (`liveDocListeners` returns to 0),
  and computed styles proving the ⋯ is hidden and collapsible buttons visible
  on desktop.
- Mutation testing: **13/13 injected regressions are caught**, including
  measuring while still static, dropping `position: fixed`, ignoring anchor
  identity, never clearing `overflowAnchor`, removing the flip or the clamp,
  a dismisser that eats inside clicks or blocks the anchor, the original
  bubble-phase `once` race, a leaked listener, dropping `align-self: stretch`,
  and both media-query declarations. Source restored byte-identical after
  each run.
- `bundle exec rspec` — 4106 examples, 0 failures.

## Known limitation

At ≤375px with English labels on an unpublished extension, `Iterate` can still
drop to a second line. `flex-wrap` on `.studio-actions` handles this gracefully
and no additional breakpoint was added.