### PR TITLE
fix(web): add :disabled state to .btn-secondary

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -8180,6 +8180,7 @@ body {
 .btn-secondary          { background: transparent; color: var(--color-text-secondary); border: 1px solid var(--color-border-primary); border-radius: var(--radius-sm); padding: 0.5rem 1.25rem; font-weight: 500; cursor: pointer; transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast); }
 .btn-secondary:hover    { background: var(--color-bg-hover); border-color: var(--color-border-strong); color: var(--color-text-primary); }
 [data-theme="dark"] .btn-secondary:hover { background: var(--color-bg-hover); }
+.btn-secondary:disabled { opacity: 0.6; cursor: not-allowed; }
 .btn-danger             { background: var(--color-error); color: #fff; border: none; border-radius: 0.375rem; padding: 0.5rem 1.25rem; cursor: pointer; }
 .btn-danger:hover       { background: var(--color-error); }
 


### PR DESCRIPTION
## Problem

`.btn-primary` has a `:disabled` style (L8179: `opacity: 0.6`), but `.btn-secondary` has none. A disabled secondary button currently renders identically to an enabled one.

This bites every flow that disables a secondary button while a request is in flight (modal confirm rows, extension panels retry/cancel buttons, etc.): the UI looks clickable but ignores the click, with zero visual feedback.

## Fix

One line, mirroring the existing `.btn-primary:disabled` pattern:

```css
.btn-secondary:disabled { opacity: 0.6; cursor: not-allowed; }
```

- `opacity: 0.6` matches `.btn-primary:disabled` exactly.
- `cursor: not-allowed` matches the specialized button classes (`.btn-settings-action`, `.btn-model-test`, ...) rather than `.btn-primary`'s `cursor: default` — happy to switch to `default` if you prefer strict consistency.

## Note

`[data-theme="dark"] .btn-secondary:hover` on the adjacent line is redundant (identical value to the rule above it, and the custom property already resolves per theme) — left untouched to keep this PR one line; can remove it separately if agreed.