### PR TITLE
fix(web): .btn-danger hover feedback + :disabled state

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -8181,7 +8181,8 @@ body {
 .btn-secondary:hover    { background: var(--color-bg-hover); border-color: var(--color-border-strong); color: var(--color-text-primary); }
 [data-theme="dark"] .btn-secondary:hover { background: var(--color-bg-hover); }
 .btn-danger             { background: var(--color-error); color: #fff; border: none; border-radius: 0.375rem; padding: 0.5rem 1.25rem; cursor: pointer; }
-.btn-danger:hover       { background: var(--color-error); }
+.btn-danger:hover       { background: color-mix(in srgb, var(--color-error) 85%, #fff); }
+.btn-danger:disabled    { opacity: 0.6; cursor: not-allowed; }
 
 /* ── Toast stack ─────────────────────────────────────────────────────────
    Non-blocking notifications anchored bottom-right. Stacks vertically.


### PR DESCRIPTION
Follow-up to #540 (kept separate as it touches hover behavior, not just a missing state).

Two gaps in `.btn-danger`:

**1. `:hover` is a no-op.** The hover rule repeats the base rule verbatim (`background: var(--color-error)` on both lines), so hovering a danger button gives zero feedback. This PR lightens the hover state by mixing 15% white (`color-mix(in srgb, var(--color-error) 85%, #fff)`), which reads correctly in both themes and mirrors the lighten-on-hover treatment used for danger buttons elsewhere.

**2. No `:disabled` state.** Same gap as `.btn-secondary` in #540: a disabled danger button renders identically to an enabled one. Added `opacity: 0.6; cursor: not-allowed;` — opacity matches `.btn-primary:disabled`, cursor matches the specialized button classes.

Net diff is +1 line / 1 line changed.