### PR TITLE
fix(web): replace undefined danger tokens with --color-error

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -3141,7 +3141,7 @@ body {
   font-size: 0.75rem;
   color: var(--color-text-secondary);
 }
-.wt-error { color: var(--color-danger, #d23); }
+.wt-error { color: var(--color-error); }
 
 /* ── Workspace viewer (file tree + tabbed preview, inside the Files tab) ── */
 .wv-root { flex: 1; min-height: 0; display: flex; }
@@ -7757,7 +7757,7 @@ body {
   font-size: 0.8125rem;
 }
 .dp-address-input.invalid {
-  box-shadow: inset 0 0 0 1px var(--color-text-danger, #ef4444);
+  box-shadow: inset 0 0 0 1px var(--color-error);
 }
 .dp-bc-menu {
   position: fixed;
@@ -7805,7 +7805,7 @@ body {
   font-size: 0.8125rem;
 }
 .dp-bc-menu-error {
-  color: var(--color-text-danger, #ef4444);
+  color: var(--color-error);
 }
 
 /* Column header */
@@ -7907,7 +7907,7 @@ body {
   color: var(--color-text-tertiary);
   font-size: 0.8125rem;
 }
-.dp-error { color: var(--color-text-danger, #ef4444); }
+.dp-error { color: var(--color-error); }
 
 /* Footer */
 .dp-footer {
@@ -9871,7 +9871,7 @@ body {
 /* Inline install-error tip (replaces alert dialog) */
 .brand-install-error {
   font-size: 0.75rem;
-  color: var(--color-danger, #f87171);
+  color: var(--color-error);
   margin-top: 0.375rem;
   line-height: 1.4;
 }
@@ -14004,7 +14004,7 @@ body.setup-mode[data-theme="dark"] {
   padding: 0.5rem 0;
 }
 .mcp-tools-error {
-  color: var(--color-danger, #c33);
+  color: var(--color-error);
 }
 .mcp-tools-header {
   font-size: 0.8125rem;


### PR DESCRIPTION
Six rules reference error tokens that are **not defined anywhere** in `app.css`, so every lookup silently falls through to its hardcoded fallback and those error states ignore the active theme:

| Token | Rules | Fallbacks in use |
|---|---|---|
| `--color-text-danger` (undefined) | `.dp-address-input.invalid` (inset ring), `.dp-bc-menu-error`, `.dp-error` | #ef4444 |
| `--color-danger` (undefined) | `.wt-error`, `.brand-install-error`, `.mcp-tools-error` | #d23 / #f87171 / #c33 — three different values for the same semantic role |

This PR switches all six to `var(--color-error)` — the semantic error token that **is** defined (light + all dark theme blocks) and already used by `.btn-danger` and `.badge-expired`.

Visual delta: near-nil in light theme (the fallbacks were all reds); intentional in dark theme, where the themed error red applies for the first time.

Also worth noting: the three `--color-danger` fallbacks disagreeing with each other (#d23 vs #f87171 vs #c33) is a small hint these were hand-typed per call site rather than sourced from a token.