### PR TITLE
fix: restore aside width after closing file previews

### DIFF
--- a/lib/clacky/default_extensions/git/panels/git/view.js
+++ b/lib/clacky/default_extensions/git/panels/git/view.js
@@ -154,12 +154,11 @@
     return `${t("changes.save.prefix", "手动存档")} · ${stamp}`;
   }
 
-  // The diff pane needs horizontal room, so the aside is widened while a diff
-  // is open. The widening is deliberately NOT persisted to localStorage: it is
-  // borrowed space that restoreAsideWidth() gives back on close, otherwise the
-  // user's own width would be overwritten for every later session.
+  // The diff pane needs horizontal room, so borrow it from the host while a
+  // diff is open. The host coordinates overlapping panels and preserves any
+  // width the user chooses manually in the meantime.
   function ensureAsideWidth() {
-    if (releaseAsideWidth || !window.Clacky || !Clacky.Aside) return;
+    if (releaseAsideWidth || !window.Clacky || !Clacky.Aside || !Clacky.Aside.requestWidth) return;
     releaseAsideWidth = Clacky.Aside.requestWidth(DIFF_ASIDE_WIDTH);
   }
 

--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -3207,7 +3207,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  max-width: 9.375rem;
+  max-width: min(9.375rem, 100%);
   height: 1.625rem;
   padding: 0.1875rem 0.25rem 0.1875rem 0.5625rem;
   border: 1px solid transparent;
@@ -3225,7 +3225,7 @@ body {
   border-color: var(--color-border-secondary);
   font-weight: 500;
 }
-.wv-tab-label { overflow: hidden; text-overflow: ellipsis; }
+.wv-tab-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .wv-tab-dot {
   flex: none;
   width: 0.375rem;
@@ -3234,6 +3234,7 @@ body {
   background: var(--color-accent-primary);
 }
 .wv-tab-close {
+  flex: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/lib/clacky/web/core/aside.js
+++ b/lib/clacky/web/core/aside.js
@@ -26,6 +26,11 @@
   const maxW = () => Math.max(MIN_W, Math.round(window.innerWidth * 0.8));
   // Matches the CSS breakpoint where the aside becomes a fixed overlay drawer.
   const isNarrow = () => window.matchMedia("(max-width: 768px)").matches;
+  const widthRequests = new Map();
+  let nextWidthRequestId = 1;
+  let widthBeforeRequests = null;
+  let appliedRequestWidth = null;
+  let manuallyResizedWhileRequested = false;
 
   const $ = (id) => document.getElementById(id);
 
@@ -53,30 +58,59 @@
     if (aside) aside.style.setProperty("--session-aside-width", px + "px");
   }
 
+  // Reconcile temporary requests centrally so nested panels can close in any
+  // order. For example, closing a Files preview while an 860px Git diff is
+  // still open must not make the later Git release restore a stale 700px width.
+  function reconcileRequestedWidths() {
+    if (!$('session-aside')) return;
+    const width = currentWidth();
+
+    if (widthRequests.size === 0) {
+      if (!manuallyResizedWhileRequested && widthBeforeRequests !== null &&
+          appliedRequestWidth !== null && Math.round(width) === appliedRequestWidth) {
+        setWidth(widthBeforeRequests);
+      }
+      widthBeforeRequests = null;
+      appliedRequestWidth = null;
+      manuallyResizedWhileRequested = false;
+      return;
+    }
+
+    if (widthBeforeRequests === null) widthBeforeRequests = width;
+    if (manuallyResizedWhileRequested) return;
+    const requested = Math.min(maxW(), Math.max(...widthRequests.values()));
+    const desired = Math.max(widthBeforeRequests, requested);
+    if (Math.round(width) !== Math.round(desired)) setWidth(desired);
+    appliedRequestWidth = Math.round(desired);
+  }
+
   // Panels that need horizontal room (diff, file preview) ask for a wider
-  // aside. The request is clamped to maxW(): an unclamped target wider than
-  // the viewport would push the fixed-position mobile drawer off-screen,
-  // taking the tab bar and the close button with it.
-  //
-  // Returns a function that gives borrowed width back, or null when nothing
-  // was borrowed — so a caller can always call the result without tracking
-  // whether its request actually did anything.
+  // aside. Narrow layouts deliberately ignore temporary requests because the
+  // aside is a fixed mobile drawer there. Persistent requests remain available
+  // for legacy panels that intentionally update the user's preferred width.
   function requestWidth(px, opts) {
     const aside = $("session-aside");
     if (!aside || isNarrow()) return null;
-    const target = Math.min(maxW(), Math.max(MIN_W, px));
-    const previous = currentWidth();
-    if (previous >= target) return null;
-    setWidth(target);
+    const requested = Number(px);
+    if (!Number.isFinite(requested) || requested <= 0) return null;
+    const target = Math.min(maxW(), Math.max(MIN_W, requested));
     if (opts && opts.persist) {
-      try { localStorage.setItem(WIDTH_KEY, String(target)); } catch (_e) { /* non-fatal */ }
+      const preferred = Math.max(currentWidth(), target);
+      setWidth(preferred);
+      try { localStorage.setItem(WIDTH_KEY, String(preferred)); } catch (_e) { /* non-fatal */ }
+      if (widthRequests.size > 0) widthBeforeRequests = preferred;
       return null;
     }
-    // Only give the width back if it is still the one we set: the user may have
-    // dragged the handle, or another panel may have widened further, and their
-    // width wins.
+
+    const id = nextWidthRequestId++;
+    widthRequests.set(id, target);
+    reconcileRequestedWidths();
+    let released = false;
     return () => {
-      if (Math.round(currentWidth()) === Math.round(target)) setWidth(previous);
+      if (released) return;
+      released = true;
+      widthRequests.delete(id);
+      reconcileRequestedWidths();
     };
   }
 
@@ -183,6 +217,11 @@
       document.body.style.userSelect = "";
       const w = currentWidth();
       try { localStorage.setItem(WIDTH_KEY, w); } catch (_e) { /* ignore */ }
+      if (widthRequests.size > 0) {
+        widthBeforeRequests = w;
+        appliedRequestWidth = null;
+        manuallyResizedWhileRequested = true;
+      }
     });
   }
 
@@ -196,7 +235,6 @@
     fullscreen: (on) => setFullscreen(on !== false),
     requestWidth: requestWidth,
   });
-
   if (window.Clacky) Clacky.Aside = publicApi();
 
   function init() {

--- a/lib/clacky/web/features/workspace/view.js
+++ b/lib/clacky/web/features/workspace/view.js
@@ -536,11 +536,7 @@ const WorkspaceView = (() => {
 
   // ── Inline tabbed viewer ────────────────────────────────────────────────
 
-  // The tree + viewer split needs horizontal room; widen the aside once when
-  // the first file is opened (still user-resizable afterwards).
-  function ensureAsideWidth() {
-    if (window.Clacky && Clacky.Aside) Clacky.Aside.requestWidth(620, { persist: true });
-  }
+  const VIEWER_ASIDE_WIDTH = 700;
 
   // Active viewer instance (one per mounted Files tab). Kept at module level
   // so openFile() — called from chat file:// link clicks — can reach the
@@ -555,7 +551,20 @@ const WorkspaceView = (() => {
   function createViewer(onTabsChanged, onToggleTree, onShowMobileTree) {
     const tabs = [];
     let activeId = null;
+    let releaseAsideWidth = null;
     const notify = () => { if (onTabsChanged) onTabsChanged({ count: tabs.length, activeId }); };
+
+    function ensureAsideWidth() {
+      if (releaseAsideWidth || !window.Clacky || !Clacky.Aside || !Clacky.Aside.requestWidth) return;
+      releaseAsideWidth = Clacky.Aside.requestWidth(VIEWER_ASIDE_WIDTH);
+    }
+
+    function restoreAsideWidth() {
+      if (!releaseAsideWidth) return;
+      const release = releaseAsideWidth;
+      releaseAsideWidth = null;
+      release();
+    }
 
     const root = el("div", "wv-viewer");
 
@@ -748,6 +757,7 @@ const WorkspaceView = (() => {
       } else {
         rebuildTabbar();
       }
+      if (tabs.length === 0) restoreAsideWidth();
       notify();
     }
 
@@ -942,7 +952,6 @@ const WorkspaceView = (() => {
     }
 
     async function openTab(entry) {
-      ensureAsideWidth();
       const existing = tabs.find((x) => x.id === entry.path);
       if (existing) {
         activate(existing.id);
@@ -970,6 +979,7 @@ const WorkspaceView = (() => {
         Modal.toast(t("workspace.previewFailed") + ": " + err.message, "error");
         return;
       }
+      if (tabs.length === 0) ensureAsideWidth();
       tabs.push(tab);
       content.appendChild(tab.el);
       activate(tab.id);
@@ -1000,6 +1010,7 @@ const WorkspaceView = (() => {
     });
 
     function destroy() {
+      restoreAsideWidth();
       tabs.forEach((tab) => {
         if (tab.editor) tab.editor.destroy();
         if (tab.imageUrl) URL.revokeObjectURL(tab.imageUrl);

--- a/spec/clacky/web/extension_architecture_spec.rb
+++ b/spec/clacky/web/extension_architecture_spec.rb
@@ -257,12 +257,40 @@ RSpec.describe "WebUI extension architecture" do
       "Workspace"      => "features/workspace/store.js",
       "WorkspaceStore" => "features/workspace/store.js",
       "Backup"         => "features/backup/store.js",
+      "Aside"          => "core/aside.js",
     }.each do |name, rel|
       it "exposes Clacky.#{name} in #{rel}" do
         src = File.read(File.join(web_dir, rel))
         expect(src).to include("Clacky.#{name} = "),
           "#{rel} must assign `Clacky.#{name} = #{name};` so extensions can reach it via the Clacky namespace"
       end
+    end
+  end
+
+  describe "aside temporary width contract" do
+    let(:aside_js) { File.read(File.join(web_dir, "core", "aside.js")) }
+    let(:workspace_view_js) { File.read(File.join(web_dir, "features", "workspace", "view.js")) }
+    let(:git_view_js) do
+      File.read(File.expand_path("../../../lib/clacky/default_extensions/git/panels/git/view.js", __dir__))
+    end
+
+    it "keeps temporary width ownership in the host facade" do
+      expect(aside_js).to include("requestWidth: requestWidth")
+      expect(aside_js).to include("const widthRequests = new Map()")
+      expect(aside_js).to include("widthRequests.delete(id)")
+      expect(aside_js).to include('window.matchMedia("(max-width: 768px)").matches')
+    end
+
+    it "makes Files release its borrowed width after the final tab and on teardown" do
+      expect(workspace_view_js).to include("Clacky.Aside.requestWidth(VIEWER_ASIDE_WIDTH)")
+      expect(workspace_view_js).to include("if (tabs.length === 0) restoreAsideWidth()")
+      expect(workspace_view_js).to match(/function destroy\(\) \{\s*restoreAsideWidth\(\)/)
+      expect(workspace_view_js).not_to include("requestWidth(VIEWER_ASIDE_WIDTH, { persist: true })")
+    end
+
+    it "keeps the Git diff on the same host-managed contract" do
+      expect(git_view_js).to include("Clacky.Aside.requestWidth(DIFF_ASIDE_WIDTH)")
+      expect(git_view_js).to include("const release = releaseAsideWidth")
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add a host-managed temporary width mechanism for the session aside.
- Expand the Files panel when a file preview is opened.
- Restore the previous aside width after the final file preview is closed.
- Migrate Git diff previews to the same width-management mechanism.
- Correctly handle overlapping file and Git previews.
- Preserve user-selected widths when the aside is manually resized.
- Keep close buttons visible when previewing files with long names.
- Release temporary width state during panel teardown and session changes.

## Validation

- Full test suite: 4,163 examples, 0 failures.
- Verified on the source build running at port 7070.
- Confirmed file preview opening, multi-tab closing, width restoration, long filenames, and overlapping Git diff/file preview behavior.