### PR TITLE
fix(settings): improve mobile tabs and model controls layout (C-5784)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -15371,6 +15371,26 @@ body.setup-mode[data-theme="dark"] {
     padding: 0.75rem 1rem;
     font-size: 0.9375rem;
   }
+  #settings-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0 0.5rem;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  #settings-tabs::-webkit-scrollbar {
+    display: none;
+  }
+  #settings-tabs .settings-tab {
+    flex: 0 0 auto;
+    padding: 0.625rem 0.875rem;
+    white-space: nowrap;
+  }
+  #ext-slot-settings-tabs,
+  #ext-slot-settings-tabs > div {
+    display: contents;
+  }
   #settings-body {
     padding: 1rem 1rem 5rem;
     gap: 1.5rem;
@@ -15389,8 +15409,35 @@ body.setup-mode[data-theme="dark"] {
     flex-wrap: wrap;
     gap: 0.5rem;
   }
+  .settings-tab-content[data-tab-content="models"] .settings-section-title {
+    align-items: stretch;
+  }
+  .settings-tab-content[data-tab-content="models"] .settings-section-title > span {
+    width: 100%;
+  }
+  .models-header-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(7rem, 7.5rem);
+    align-items: center;
+    flex: 1 0 100%;
+    width: 100%;
+  }
+  .model-search-box {
+    width: 100%;
+    max-width: none;
+  }
+  .model-provider-filter {
+    width: 100%;
+    max-width: none;
+  }
+  .model-provider-filter .custom-select-dropdown {
+    right: 0;
+    left: auto;
+    max-width: calc(100vw - 2rem);
+  }
   /* Add Model button: full width on mobile */
   .btn-settings-add {
+    grid-column: 1 / -1;
     width: 100%;
     justify-content: center;
   }


### PR DESCRIPTION

<img width="782" height="863" alt="Snapzy_2026-09-11_11-22-40_850" src="https://github.com/user-attachments/assets/d60753d1-a5e9-4b16-a7af-e55208adc552" />

## Problem

On narrow viewports, settings tabs could shrink and wrap onto multiple lines.
On the Models tab, the search field, provider filter, and Add Model button
competed for space and could overlap or become difficult to use.

## Fix

- Keep settings tabs on a single horizontally scrollable row below 768px.
- Prevent tab labels from shrinking or wrapping.
- Include extension-provided tabs in the same scrolling track.
- Place the Models heading on its own row.
- Arrange the search field and provider filter in a responsive grid.
- Place the Add Model button on a separate full-width row.
- Keep provider dropdowns inside the viewport.
- Scope all changes to the existing mobile breakpoint so desktop layout is unchanged.

## Test

- ✅ Verified in Chrome at 390×844: no overlap, 206px search field, 120px provider filter.
- ✅ Verified at 320×800: no overlap, 136px search field, 120px provider filter.
- ✅ Confirmed all six settings tabs remain on one horizontally scrollable row.
- ✅ Confirmed the provider dropdown remains inside the viewport.
- ✅ Confirmed the 1512px desktop layout retains its original flex layout and dimensions.
- ✅ `bundle exec rspec spec/clacky/web/syntax_spec.rb` — 19 examples, 0 failures.