### PR TITLE
fix(directory-picker): improve mobile folder navigation (C-5783)

### DIFF
--- a/lib/clacky/web/app.css
+++ b/lib/clacky/web/app.css
@@ -7515,6 +7515,9 @@ body {
   overflow: hidden;
   border-radius: 10px;
 }
+.dp-mobile-header {
+  display: none;
+}
 
 /* Sidebar — quick-access places (favorites + locations) */
 .dp-sidebar {
@@ -15147,6 +15150,106 @@ body.setup-mode[data-theme="dark"] {
   }
   .has-chat-navigator > .chat-messages-scroll {
     padding-right: 1.25rem;
+  }
+
+  /* Directory picker: full-screen layout with horizontally scrollable places. */
+  .dp-overlay {
+    align-items: stretch;
+    padding: 0;
+  }
+  .dp-modal {
+    width: 100%;
+    max-width: none;
+    height: 100vh;
+    height: 100dvh;
+    max-height: none;
+    flex-direction: column;
+    border-radius: 0;
+  }
+  .dp-mobile-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-height: 3rem;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--color-border-primary);
+    background: var(--color-bg-secondary);
+    flex-shrink: 0;
+  }
+  .dp-mobile-title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-text-primary);
+    font-size: 0.9375rem;
+    font-weight: 500;
+  }
+  .dp-mobile-close {
+    flex-shrink: 0;
+  }
+  .dp-sidebar {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0.5rem 0.75rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border-primary);
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .dp-sidebar::-webkit-scrollbar {
+    display: none;
+  }
+  .dp-sidebar-label {
+    display: none;
+  }
+  .dp-sidebar > .dp-sidebar-item,
+  .dp-sidebar-favorite {
+    width: auto;
+    flex: 0 0 auto;
+    border: 1px solid var(--color-border-primary);
+    background: var(--color-bg-primary);
+  }
+  .dp-sidebar > .dp-sidebar-item {
+    padding: 0.4rem 0.625rem;
+  }
+  .dp-sidebar-favorite-open {
+    width: auto;
+    padding: 0.4rem 0.25rem 0.4rem 0.625rem;
+    border: 0;
+  }
+  .dp-sidebar-favorite-remove {
+    width: 28px;
+    height: 28px;
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .dp-main {
+    width: 100%;
+  }
+  .dp-toolbar {
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+  }
+  .dp-nav-btns {
+    flex-shrink: 0;
+  }
+  .dp-col-header {
+    padding-inline: 0.75rem;
+  }
+  .dp-footer {
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+  .dp-footer-actions,
+  .dp-newfolder-btn {
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   /* Tighten header padding */

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -5318,6 +5318,7 @@ const Sessions = (() => {
       // When no session exists yet (e.g. the New Session modal), browse the
       // real filesystem via /api/dirs instead of the session-scoped files API.
       const sessionLess = !sessionId;
+      const mobileLayout = window.matchMedia("(max-width: 768px)");
 
       let currentPath = currentDir;
       let selectedPath = currentDir;
@@ -5398,11 +5399,16 @@ const Sessions = (() => {
         row.appendChild(name);
         node.appendChild(row);
 
-        // Single-click: select this directory
+        // Mobile uses the conventional file-picker behavior: tap to enter.
+        // Desktop keeps single-click selection and double-click navigation.
         let clickTimer = null;
         row.addEventListener("click", (e) => {
           e.stopPropagation();
           if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
+          if (mobileLayout.matches) {
+            navigateTo(entry.absPath, true);
+            return;
+          }
           clickTimer = setTimeout(() => {
             clickTimer = null;
             listContainer.querySelectorAll(".dp-row.selected").forEach(el => el.classList.remove("selected"));
@@ -5414,6 +5420,7 @@ const Sessions = (() => {
         // Double-click: enter directory (navigate into it)
         row.addEventListener("dblclick", (e) => {
           e.stopPropagation();
+          if (mobileLayout.matches) return;
           if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
           navigateTo(entry.absPath, true);
         });
@@ -5426,11 +5433,35 @@ const Sessions = (() => {
 
       // Create modal overlay
       const overlay = document.createElement("div");
-      overlay.className = "modal-overlay";
+      overlay.className = "modal-overlay dp-overlay";
+
+      const cancelPicker = () => {
+        overlay.remove();
+        resolve(null);
+      };
 
       // Create modal content — Finder-style layout
       const modal = document.createElement("div");
       modal.className = "modal-content dp-modal";
+
+      // Mobile-only header — the desktop picker keeps its Finder-style layout.
+      const mobileHeader = document.createElement("div");
+      mobileHeader.className = "dp-mobile-header";
+
+      const mobileTitle = document.createElement("span");
+      mobileTitle.className = "dp-mobile-title";
+      mobileTitle.textContent = t("sessions.modal.dirpicker.title", "Select Working Directory");
+
+      const mobileCloseButton = document.createElement("button");
+      mobileCloseButton.type = "button";
+      mobileCloseButton.className = "dp-nav-btn dp-mobile-close";
+      mobileCloseButton.title = t("sib.dir.cancel", "Cancel");
+      mobileCloseButton.setAttribute("aria-label", mobileCloseButton.title);
+      mobileCloseButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+      mobileCloseButton.addEventListener("click", cancelPicker);
+
+      mobileHeader.appendChild(mobileTitle);
+      mobileHeader.appendChild(mobileCloseButton);
 
       // Left sidebar — quick-access places (favorites + locations)
       const sidebar = document.createElement("div");
@@ -5523,7 +5554,7 @@ const Sessions = (() => {
       const cancelButton = document.createElement("button");
       cancelButton.className = "btn btn-secondary";
       cancelButton.textContent = t("sib.dir.cancel", "取消");
-      cancelButton.onclick = () => { overlay.remove(); resolve(null); };
+      cancelButton.onclick = cancelPicker;
 
       const confirmButton = document.createElement("button");
       confirmButton.className = "btn btn-primary";
@@ -5536,6 +5567,7 @@ const Sessions = (() => {
       footer.appendChild(footerActions);
       main.appendChild(footer);
 
+      modal.appendChild(mobileHeader);
       modal.appendChild(sidebar);
       modal.appendChild(main);
 

--- a/spec/clacky/web/directory_picker_mobile_spec.rb
+++ b/spec/clacky/web/directory_picker_mobile_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe "Directory picker mobile layout" do
+  let(:web_dir) { File.expand_path("../../../lib/clacky/web", __dir__) }
+  let(:sessions) { File.read(File.join(web_dir, "sessions.js")) }
+  let(:styles) { File.read(File.join(web_dir, "app.css")) }
+
+  it "adds a picker-specific overlay and mobile close header" do
+    expect(sessions).to include('overlay.className = "modal-overlay dp-overlay";')
+    expect(sessions).to include('mobileHeader.className = "dp-mobile-header";')
+    expect(sessions).to include(
+      'mobileTitle.textContent = t("sessions.modal.dirpicker.title", "Select Working Directory");'
+    )
+    expect(sessions).to include('mobileCloseButton.addEventListener("click", cancelPicker);')
+  end
+
+  it "enters folders on a single tap in the mobile layout" do
+    expect(sessions).to include(
+      'const mobileLayout = window.matchMedia("(max-width: 768px)");'
+    )
+    expect(sessions).to match(
+      /row\.addEventListener\("click".*?if \(mobileLayout\.matches\) \{\s*navigateTo\(entry\.absPath, true\);\s*return;/m
+    )
+    expect(sessions).to match(
+      /row\.addEventListener\("dblclick".*?if \(mobileLayout\.matches\) return;.*?navigateTo\(entry\.absPath, true\);/m
+    )
+  end
+
+  it "uses a full-screen picker and horizontal places list at the mobile breakpoint" do
+    mobile_styles = styles.split("@media (max-width: 768px)", 2).last
+
+    expect(mobile_styles).to match(/\.dp-overlay \{.*?padding: 0;/m)
+    expect(mobile_styles).to match(/\.dp-modal \{.*?height: 100dvh;.*?flex-direction: column;/m)
+    expect(mobile_styles).to match(/\.dp-sidebar \{.*?overflow-x: auto;.*?overflow-y: hidden;/m)
+    expect(mobile_styles).to match(/\.dp-footer-actions,\s*\.dp-newfolder-btn \{.*?white-space: nowrap;/m)
+  end
+
+  it "keeps the mobile header hidden in the desktop layout" do
+    desktop_styles = styles.split("@media (max-width: 768px)", 2).first
+
+    expect(desktop_styles).to match(/\.dp-mobile-header \{\s*display: none;/m)
+  end
+end


### PR DESCRIPTION

<img width="1440" height="3120" alt="Screenshot_20260911_124115_Samsung Browser" src="https://github.com/user-attachments/assets/647cb79c-b0b3-4adc-bf18-99c88c715e28" />

## Problem

The desktop directory picker layout became compressed on mobile, and its single-click/select plus double-click/open interaction made folder navigation impractical on touchscreens.

## Fix

- Use a full-screen directory picker at the mobile breakpoint.
- Move quick-access locations into a horizontally scrollable row.
- Add a mobile title bar and close action.
- Make a single tap enter a folder on mobile.
- Keep the existing single-click selection and double-click navigation on desktop.
- Prevent the footer actions from wrapping or overflowing.

## Test

- ✅ 27 related automated examples passed.
- ✅ Verified multi-level folder navigation, back navigation, and path confirmation at 390×844.
- ✅ Verified desktop behavior remains single-click to select and double-click to enter.
- ✅ No browser console errors.