### PR TITLE
fix(extension): complete the public session creation lifecycle

### DIFF
--- a/lib/clacky/extension/api_extension.rb
+++ b/lib/clacky/extension/api_extension.rb
@@ -272,9 +272,10 @@ module Clacky
     # controls the user-facing bubble shown in place of the raw prompt.
     # When `project_id` is given, the project's working_dir is inherited
     # (unless an explicit working_dir overrides it) and the session is
-    # associated with the project.
+    # associated with the project. `model_id` selects a configured model by
+    # its stable id; omitting it keeps the current default model.
     def create_session(name: nil, prompt: nil, working_dir: nil, profile: "general",
-                       source: :manual, display_message: nil, project_id: nil)
+                       source: :manual, display_message: nil, project_id: nil, model_id: nil)
       error!("server not ready", status: 503) unless @http_server
 
       src = source.to_s
@@ -290,6 +291,14 @@ module Clacky
       project = project_id ? project_manager&.find(project_id) : nil
       error!("Project not found", status: 404) if project_id && project.nil?
 
+      if model_id
+        model_id = model_id.to_s.strip
+        model_id = nil if model_id.empty?
+      end
+      if model_id && !agent_config.models.any? { |model| model["id"] == model_id }
+        error!("Model not found in configuration", status: 400)
+      end
+
       working_dir = File.expand_path(project[:working_dir]) if working_dir.nil? && project && project[:working_dir].to_s.strip != ""
 
       session_id = @http_server.send(
@@ -297,7 +306,8 @@ module Clacky
         name: name,
         working_dir: working_dir,
         profile: profile,
-        source: source
+        source: source,
+        model_id: model_id
       )
 
       if project_id
@@ -309,9 +319,11 @@ module Clacky
         end
       end
 
-      submit_task(session_id, prompt, display_message: display_message) if prompt && !prompt.strip.empty?
+      # Announce creation only after identity/placement metadata is persisted,
+      # and before submit_task can emit ordinary running-state updates.
+      @http_server.send(:broadcast_session_update, session_id, created: true)
 
-      @http_server.send(:broadcast_session_update, session_id)
+      submit_task(session_id, prompt, display_message: display_message) if prompt && !prompt.strip.empty?
 
       session_id
     end

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -1045,7 +1045,7 @@ module Clacky
           end
         end
 
-        broadcast_session_update(session_id)
+        broadcast_session_update(session_id, created: true)
         summary = @registry.session_summary(session_id)
         json_response(res, 201, { session: summary })
       end
@@ -4965,6 +4965,7 @@ module Clacky
 
         session_id = build_session(name: session_name, working_dir: working_dir, permission_mode: :auto_approve)
         @registry.update(session_id, pending_task: prompt, pending_working_dir: working_dir)
+        broadcast_session_update(session_id, created: true)
 
         json_response(res, 202, { ok: true, session: @registry.session_summary(session_id) })
       rescue => e
@@ -7315,7 +7316,7 @@ module Clacky
         return json_response(res, 404, { error: "Session not found" }) unless fork_data
 
         fork_id = fork_data[:session_id]
-        broadcast_session_update(fork_id)
+        broadcast_session_update(fork_id, created: true)
         json_response(res, 201, { session: @registry.snapshot(fork_id) })
       end
 
@@ -8036,12 +8037,16 @@ module Clacky
       end
 
       # Broadcast a session_update event to all clients so they can patch their
-      # local session list without needing a full session_list refresh.
-      def broadcast_session_update(session_id)
+      # local session list without needing a full session_list refresh. Creation
+      # paths set created: true after the initial snapshot is fully persisted so
+      # clients can insert the session without treating later updates as new rows.
+      def broadcast_session_update(session_id, created: false)
         session = @registry.snapshot(session_id)
         return unless session
 
-        broadcast_all(type: "session_update", session: session)
+        event = { type: "session_update", session: session }
+        event[:created] = true if created
+        broadcast_all(event)
       end
 
       # ── Helpers ───────────────────────────────────────────────────────────────

--- a/lib/clacky/web/sessions.js
+++ b/lib/clacky/web/sessions.js
@@ -37,6 +37,10 @@ const Sessions = (() => {
   // `findOrFetch`. Excluded from sidebar render and from the loadMore cursor
   // so the pagination of `_sessions` stays correct.
   const _extraSessions     = [];
+  // Unknown session_update rows can affect folded-group counts before their
+  // corresponding creation update arrives. Track those adjustments separately
+  // so promoting a cached row into `_sessions` stays idempotent.
+  const _countedExtraIds   = new Set();
   // Sessions that finished while the user was looking elsewhere. Holds a
   // transient "done" dot until the session is opened or DONE_DOT_TTL elapses,
   // so a completed background task is noticeable without a permanent marker.
@@ -3092,12 +3096,44 @@ const Sessions = (() => {
       _applyGroupStats(groups);
     },
 
-    /** Insert a newly created session into the local list. */
+    /** Insert or refresh a newly created session in the local list. */
     add(session) {
-      if (!_sessions.find(s => s.id === session.id)) {
-        _sessions.push(session);
-        const g = _groupOf(session);
-        if (g) g.count++;
+      if (!session || !session.id) return;
+
+      const existing  = _sessions.find(s => s.id === session.id);
+      const extraIdx  = _extraSessions.findIndex(s => s.id === session.id);
+      const extra     = extraIdx === -1 ? null : _extraSessions[extraIdx];
+      const extraWasCounted = _countedExtraIds.delete(session.id);
+
+      if (existing) {
+        const previousGroup = _groupOf(existing);
+        if (extra) {
+          if (extraWasCounted) {
+            const extraGroup = _groupOf(extra);
+            if (extraGroup) extraGroup.count = Math.max(0, extraGroup.count - 1);
+          }
+          Object.assign(existing, extra);
+          _extraSessions.splice(extraIdx, 1);
+        }
+        Object.assign(existing, session);
+
+        const nextGroup = _groupOf(existing);
+        if (previousGroup !== nextGroup) {
+          if (previousGroup) previousGroup.count = Math.max(0, previousGroup.count - 1);
+          if (nextGroup) nextGroup.count++;
+        }
+        return;
+      }
+
+      const inserted = extra ? { ...extra, ...session } : session;
+      const previousGroup = extra && extraWasCounted ? _groupOf(extra) : null;
+      if (extra) _extraSessions.splice(extraIdx, 1);
+      _sessions.push(inserted);
+
+      const nextGroup = _groupOf(inserted);
+      if (previousGroup !== nextGroup) {
+        if (previousGroup) previousGroup.count = Math.max(0, previousGroup.count - 1);
+        if (nextGroup) nextGroup.count++;
       }
     },
 
@@ -3128,8 +3164,8 @@ const Sessions = (() => {
     },
 
     /** Patch a single session's fields (from session_update event).
-     *  If the session is not in the list yet (e.g. just created by another tab),
-     *  prepend it so the sidebar shows it immediately. */
+     *  Unknown sessions stay in the extra cache until an explicit creation
+     *  update promotes them, preserving the paged sidebar boundary. */
     patch(id, fields) {
       const s = _sessions.find(s => s.id === id);
       const extra = _extraSessions.find(e => e.id === id);
@@ -3160,6 +3196,13 @@ const Sessions = (() => {
         const t = updated.updated_at || updated.created_at;
         if (t && (!isGroup.latestUpdatedAt || t > isGroup.latestUpdatedAt)) {
           isGroup.latestUpdatedAt = t;
+        }
+      }
+
+      if (!s) {
+        if (wasGroup !== isGroup) {
+          if (isGroup) _countedExtraIds.add(id);
+          else _countedExtraIds.delete(id);
         }
       }
     },

--- a/lib/clacky/web/ws-dispatcher.js
+++ b/lib/clacky/web/ws-dispatcher.js
@@ -368,7 +368,15 @@ function _dispatchEvent(ev) {
         if (ev.latency !== undefined) patch.latest_latency = ev.latency;
       }
       if (!sid) break;
-      Sessions.patch(sid, patch);
+      // A creation update is emitted only after the session's initial metadata
+      // has been persisted. Promote it into the canonical list; ordinary full
+      // snapshots remain patches so reconnects and old-session updates cannot
+      // disturb the pagination boundary.
+      if (ev.created && ev.session) {
+        Sessions.add(ev.session);
+      } else {
+        Sessions.patch(sid, patch);
+      }
       Sessions.renderList();
       Projects.renderSection();
       if (sid === Sessions.activeId) {

--- a/spec/clacky/default_extensions_spec.rb
+++ b/spec/clacky/default_extensions_spec.rb
@@ -133,12 +133,14 @@ RSpec.describe "ApiExtension#create_session with project_id" do
   let(:project_manager) { double("project_manager") }
   let(:registry) { double("registry") }
   let(:session_manager) { double("session_manager") }
+  let(:agent_config) { double("agent_config", models: []) }
   let(:agent) { double("agent") }
   let(:http_server) do
     server = double("http_server")
     allow(server).to receive(:instance_variable_get).with(:@registry).and_return(registry)
     allow(server).to receive(:instance_variable_get).with(:@session_manager).and_return(session_manager)
     allow(server).to receive(:instance_variable_get).with(:@project_manager).and_return(project_manager)
+    allow(server).to receive(:instance_variable_get).with(:@agent_config).and_return(agent_config)
     server
   end
 
@@ -155,17 +157,16 @@ RSpec.describe "ApiExtension#create_session with project_id" do
   it "inherits the project working_dir and persists agent.project_id" do
     project = { id: "p1", name: "Proj", working_dir: "/tmp/proj" }
     allow(project_manager).to receive(:find).with("p1").and_return(project)
-    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: File.expand_path("/tmp/proj"), profile: "general", source: :manual).and_return("sess-1")
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: File.expand_path("/tmp/proj"), profile: "general", source: :manual, model_id: nil).and_return("sess-1")
     allow(registry).to receive(:with_session).with("sess-1").and_yield({ agent: agent })
     allow(agent).to receive(:project_id=).with("p1")
     allow(agent).to receive(:to_session_data).and_return({ id: "sess-1" })
-    allow(session_manager).to receive(:save)
-    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-1")
+    expect(session_manager).to receive(:save).ordered
+    expect(http_server).to receive(:send).with(:broadcast_session_update, "sess-1", created: true).ordered
 
     result = instance.create_session(project_id: "p1")
     expect(result).to eq("sess-1")
     expect(agent).to have_received(:project_id=).with("p1")
-    expect(session_manager).to have_received(:save)
   end
 
   it "raises 404 when the project does not exist" do
@@ -181,12 +182,12 @@ RSpec.describe "ApiExtension#create_session with project_id" do
   it "does not override an explicit working_dir with the project's" do
     project = { id: "p1", name: "Proj", working_dir: "/tmp/proj" }
     allow(project_manager).to receive(:find).with("p1").and_return(project)
-    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: "/custom/dir", profile: "general", source: :manual).and_return("sess-2")
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: "/custom/dir", profile: "general", source: :manual, model_id: nil).and_return("sess-2")
     allow(registry).to receive(:with_session).with("sess-2").and_yield({ agent: agent })
     allow(agent).to receive(:project_id=).with("p1")
     allow(agent).to receive(:to_session_data).and_return({ id: "sess-2" })
     allow(session_manager).to receive(:save)
-    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-2")
+    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-2", created: true)
 
     result = instance.create_session(project_id: "p1", working_dir: "/custom/dir")
     expect(result).to eq("sess-2")
@@ -194,10 +195,36 @@ RSpec.describe "ApiExtension#create_session with project_id" do
   end
 
   it "accepts 'ext' so extension sessions land in the folded sidebar group" do
-    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: nil, profile: "general", source: :ext).and_return("sess-3")
-    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-3")
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: nil, profile: "general", source: :ext, model_id: nil).and_return("sess-3")
+    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-3", created: true)
 
     expect(instance.create_session(source: :ext)).to eq("sess-3")
+  end
+
+  it "broadcasts persisted creation before submitting the first task" do
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: nil, profile: "general", source: :manual, model_id: nil).and_return("sess-4")
+    expect(http_server).to receive(:send).with(:broadcast_session_update, "sess-4", created: true).ordered
+    expect(instance).to receive(:submit_task).with("sess-4", "start", display_message: "Starting").ordered
+
+    expect(instance.create_session(prompt: "start", display_message: "Starting")).to eq("sess-4")
+  end
+
+  it "passes a configured model_id through the public creation lifecycle" do
+    allow(agent_config).to receive(:models).and_return([{ "id" => "model-1" }])
+    allow(http_server).to receive(:send).with(:build_session, name: nil, working_dir: nil, profile: "general", source: :manual, model_id: "model-1").and_return("sess-5")
+    allow(http_server).to receive(:send).with(:broadcast_session_update, "sess-5", created: true)
+
+    expect(instance.create_session(model_id: "model-1")).to eq("sess-5")
+  end
+
+  it "rejects a model_id that is not configured" do
+    allow(agent_config).to receive(:models).and_return([{ "id" => "model-1" }])
+
+    expect {
+      instance.create_session(model_id: "missing")
+    }.to raise_error(Clacky::ApiExtension::Halt) { |halt|
+      expect(halt.status).to eq(400)
+    }
   end
 
   it "rejects sources outside the allowed list" do

--- a/spec/clacky/server/http_server_create_session_project_dir_spec.rb
+++ b/spec/clacky/server/http_server_create_session_project_dir_spec.rb
@@ -53,11 +53,18 @@ RSpec.describe Clacky::Server::HttpServer, "POST /api/sessions with a project" d
     with_server(agent_config: agent_config) do |server|
       project_dir = File.join(tmproot, "proj_ws")
       project = create_project(server, working_dir: project_dir)
+      events = []
+      allow(server).to receive(:broadcast_all) { |event| events << event }
 
       status, body = create_session(server, { name: "s1", project_id: project[:id] })
 
-      expect(status).to eq(201)
+      expect(status).to eq(201), body.inspect
       expect(body["session"]["working_dir"]).to eq(project_dir)
+      expect(events).to include(hash_including(
+        type: "session_update",
+        created: true,
+        session: hash_including(project_id: project[:id])
+      ))
     end
   end
 
@@ -69,7 +76,7 @@ RSpec.describe Clacky::Server::HttpServer, "POST /api/sessions with a project" d
       status, body = create_session(server,
         { name: "s2", project_id: project[:id], working_dir: explicit_dir })
 
-      expect(status).to eq(201)
+      expect(status).to eq(201), body.inspect
       expect(body["session"]["working_dir"]).to eq(explicit_dir)
     end
   end
@@ -83,7 +90,7 @@ RSpec.describe Clacky::Server::HttpServer, "POST /api/sessions with a project" d
 
       status, body = create_session(server, { name: "s3", project_id: project[:id] })
 
-      expect(status).to eq(201)
+      expect(status).to eq(201), body.inspect
       expect(body["session"]["working_dir"]).to eq(custom_default)
     end
   end

--- a/spec/clacky/web/extension_architecture_spec.rb
+++ b/spec/clacky/web/extension_architecture_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe "WebUI extension architecture" do
 
   describe "ws-dispatcher session_update bridge normalization" do
     let(:ws_js) { File.read(File.join(web_dir, "ws-dispatcher.js")) }
+    let(:sessions_js) { File.read(File.join(web_dir, "sessions.js")) }
 
     it "normalizes session_update shape (1) (nested ev.session) by lifting session_id and status to the top level" do
       # http_server broadcast_session_update sends { type, session: { id, status, ... } }
@@ -156,6 +157,20 @@ RSpec.describe "WebUI extension architecture" do
       # so sessionId is never undefined for session_update subscribers.
       expect(ws_js).to match(/payload\.session_id\s*\|\|\s*\(ev\.session\s*&&\s*ev\.session\.id\)/),
         "bridge must fall back to ev.session.id when top-level session_id is absent"
+    end
+
+    it "adds persisted creation snapshots while ordinary updates remain patches" do
+      expect(ws_js).to match(/if\s*\(ev\.created\s*&&\s*ev\.session\)\s*\{\s*Sessions\.add\(ev\.session\)/m),
+        "created session_update snapshots must enter the canonical session list"
+      expect(ws_js).to match(/else\s*\{\s*Sessions\.patch\(sid,\s*patch\)/m),
+        "ordinary session_update snapshots must preserve pagination-safe patch behavior"
+    end
+
+    it "promotes a creation snapshot out of the extra-session cache" do
+      expect(sessions_js).to match(/_extraSessions\.findIndex\(s\s*=>\s*s\.id\s*===\s*session\.id\)/),
+        "Sessions.add must locate a matching cached extra session"
+      expect(sessions_js).to match(/_extraSessions\.splice\(extraIdx,\s*1\)/),
+        "Sessions.add must remove a promoted session from the extra cache"
     end
   end
 


### PR DESCRIPTION
## Problem

Extensions creating project-bound sessions through `ApiExtension#create_session` only emitted ordinary `session_update` events. Unknown sessions remained in the pagination-safe extra cache, so they did not appear in project lists until the page was refreshed.

The public helper also lacked `model_id`, forcing extensions that needed an explicit model to bypass the supported creation lifecycle.

## Fix

- Added an optional `created` marker to the existing `session_update` flow.
- Broadcast creation only after initial metadata, including `project_id`, has been persisted.
- Promoted creation snapshots into the canonical frontend session list while keeping ordinary updates pagination-safe.
- Made session insertion idempotent and merged matching extra-cache entries.
- Applied the lifecycle to native creation, extension creation, forks, and manually triggered scheduled sessions.
- Added optional validated `model_id` support to `ApiExtension#create_session`.

## Test

- ✅ 57 targeted examples passed.
- ✅ 4,206 full regression examples passed.
- ✅ Ruby and JavaScript syntax checks passed.
- ✅ Verified live project-session synchronization across two browser tabs.
- ✅ Verified no duplicate or regular-list entry was created.
- ✅ Verified project association survived a page reload.