### PR TITLE
fix(extensions): forward brand marketplace sorting

### DIFF
--- a/lib/clacky/brand_config.rb
+++ b/lib/clacky/brand_config.rb
@@ -856,7 +856,7 @@ module Clacky
     # Requires an activated license. Returns { success:, extensions: [], error: }.
     # Each extension carries name + latest_version.download_url so
     # install_brand_extension! can consume it directly.
-    def fetch_brand_extensions!
+    def fetch_brand_extensions!(sort: nil)
       return { success: false, error: "License not activated", extensions: [] } unless activated?
 
       user_id   = parse_user_id_from_key(@license_key)
@@ -872,6 +872,7 @@ module Clacky
         nonce:     nonce,
         signature: OpenSSL::HMAC.hexdigest("SHA256", @license_key, message)
       }
+      payload[:sort] = sort if sort
 
       response = api_post("/api/v1/licenses/extensions", payload)
 

--- a/lib/clacky/server/http_server.rb
+++ b/lib/clacky/server/http_server.rb
@@ -699,7 +699,7 @@ module Clacky
         when ["POST",   "/api/onboard/skip-soul"] then api_onboard_skip_soul(req, res)
         when ["GET",    "/api/store/skills"]          then api_store_skills(res)
         when ["GET",    "/api/store/extensions"]          then api_store_extensions(req, res)
-        when ["GET",    "/api/store/extensions/brand"]   then api_store_extensions_brand(res)
+        when ["GET",    "/api/store/extensions/brand"]   then api_store_extensions_brand(req, res)
         when ["GET",    "/api/store/extensions/system"]   then api_store_extensions_system(res)
         when ["GET",    "/api/store/extensions/installed"] then api_store_extensions_installed(res)
         when ["GET",    "/api/store/extension"]       then api_store_extension_detail(req, res)
@@ -2710,7 +2710,7 @@ module Clacky
       # activated brand license. Returns extensions belonging to this brand via
       # BrandConfig#fetch_brand_extensions!.
       # Returns 403 when the license is not activated.
-      def api_store_extensions_brand(res)
+      def api_store_extensions_brand(req, res)
         brand = Clacky::BrandConfig.load
 
         unless brand.activated?
@@ -2718,7 +2718,9 @@ module Clacky
           return
         end
 
-        result = brand.fetch_brand_extensions!
+        sort = req.query["sort"].to_s
+        sort = "downloads" unless %w[downloads newest updated].include?(sort)
+        result = brand.fetch_brand_extensions!(sort: sort)
 
         if result[:success]
           installed = installed_extension_containers

--- a/lib/clacky/web/features/extensions/store.js
+++ b/lib/clacky/web/features/extensions/store.js
@@ -273,7 +273,10 @@ const ExtensionsStore = (() => {
       _error   = null;
       _emit("extensions:loading");
       try {
-        const res  = await fetch("/api/store/extensions/brand");
+        const params = new URLSearchParams();
+        if (_sort) params.set("sort", _sort);
+        const qs   = params.toString();
+        const res  = await fetch("/api/store/extensions/brand" + (qs ? "?" + qs : ""));
         const data = await res.json();
         const all  = data.extensions || [];
         const matched = _query

--- a/spec/clacky/brand_config_brand_extensions_spec.rb
+++ b/spec/clacky/brand_config_brand_extensions_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Clacky::BrandConfig, "brand extensions" do
       expect(fake_client).to receive(:post) do |path, payload|
         expect(path).to eq("/api/v1/licenses/extensions")
         expect(payload[:signature]).to be_a(String)
+        expect(payload[:sort]).to eq("updated")
         { success: true, data: {
           "status"     => "success",
           "extensions" => [{ "name" => "meeting", "latest_version" => { "version" => "1.0.0" } }],
@@ -66,7 +67,7 @@ RSpec.describe Clacky::BrandConfig, "brand extensions" do
         } }
       end
 
-      result = config.fetch_brand_extensions!
+      result = config.fetch_brand_extensions!(sort: "updated")
       expect(result[:success]).to be true
       ext = result[:extensions].first
       expect(ext["name"]).to eq("meeting")

--- a/spec/clacky/server/http_server_brand_extensions_spec.rb
+++ b/spec/clacky/server/http_server_brand_extensions_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/server/http_server"
+require "clacky/brand_config"
+
+RSpec.describe Clacky::Server::HttpServer, "GET /api/store/extensions/brand" do
+  let(:server) { described_class.allocate }
+  let(:response) { double("response").as_null_object }
+  let(:brand) { instance_double(Clacky::BrandConfig, activated?: true) }
+
+  before do
+    allow(Clacky::BrandConfig).to receive(:load).and_return(brand)
+    allow(server).to receive(:installed_extension_containers).and_return({})
+  end
+
+  it "forwards a supported sort order to the brand catalog" do
+    request = instance_double(WEBrick::HTTPRequest, query: { "sort" => "updated" })
+    expect(brand).to receive(:fetch_brand_extensions!)
+      .with(sort: "updated")
+      .and_return(success: true, extensions: [])
+
+    server.send(:api_store_extensions_brand, request, response)
+  end
+
+  it "falls back to downloads for an unsupported sort order" do
+    request = instance_double(WEBrick::HTTPRequest, query: { "sort" => "unexpected" })
+    expect(brand).to receive(:fetch_brand_extensions!)
+      .with(sort: "downloads")
+      .and_return(success: true, extensions: [])
+
+    server.send(:api_store_extensions_brand, request, response)
+  end
+end


### PR DESCRIPTION
## Summary

Fix the non-functional sorting controls in the brand extension marketplace.

## Changes

- Send the selected sort option when loading brand extensions.
- Forward the sort value through the local store API to the Platform license API.
- Support `downloads`, `newest`, and `updated`.
- Fall back to `downloads` for unsupported values.
- Preserve the existing search and installed-only filtering behavior.

## Verification

- Verified all three sorting options through the browser against a local Platform instance.
- Confirmed that only extensions included in the active brand distribution are returned.
- 49 targeted specs passed with 0 failures.
- JavaScript and Ruby syntax checks passed.