### PR TITLE
fix(ext-studio): hide creator center for branded non-owners

### DIFF
--- a/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
+++ b/lib/clacky/default_extensions/ext-studio/panels/studio/view.js
@@ -2082,13 +2082,33 @@
     return item;
   }
 
+  let creatorNavItem = null;
+  let brandStatusReady = false;
+
+  function syncCreatorNavVisibility() {
+    if (!creatorNavItem) return;
+    const brandNonAdmin = typeof Brand !== "undefined" && Brand.branded && !Brand.userLicensed;
+    creatorNavItem.hidden = !brandStatusReady || brandNonAdmin;
+  }
+
+  if (typeof Brand !== "undefined") {
+    Brand.on("brand:status", function () {
+      brandStatusReady = true;
+      syncCreatorNavVisibility();
+    });
+  } else {
+    brandStatusReady = true;
+  }
+
   Clacky.ext.ui.registerWorkspace(WS_ID, {
     title: t("ws.title"),
     render(container) { renderWorkspace(container); },
   });
 
   Clacky.ext.ui.mount("sidebar.nav.bottom", function () {
-    return navRow("nav.entry", function () { Clacky.ext.ui.openWorkspace(WS_ID); });
+    creatorNavItem = navRow("nav.entry", function () { Clacky.ext.ui.openWorkspace(WS_ID); });
+    syncCreatorNavVisibility();
+    return creatorNavItem;
   }, { workspace: WS_ID });
 
   // Extension-developer session tools: debug + publish, as aside tabs. These

--- a/spec/clacky/default_extensions_ext_studio_spec.rb
+++ b/spec/clacky/default_extensions_ext_studio_spec.rb
@@ -56,3 +56,25 @@ RSpec.describe "ExtStudioExt API handler" do
     expect(File.read(manifest_path)).to eq(original)
   end
 end
+
+RSpec.describe "ExtStudioExt creator navigation" do
+  let(:view_source) do
+    File.read(File.expand_path(
+      "../../lib/clacky/default_extensions/ext-studio/panels/studio/view.js",
+      __dir__
+    ))
+  end
+
+  it "hides the creator center for branded non-owners using the existing permission flags" do
+    expect(view_source).to include(
+      'const brandNonAdmin = typeof Brand !== "undefined" && Brand.branded && !Brand.userLicensed;'
+    )
+    expect(view_source).to include("creatorNavItem.hidden = !brandStatusReady || brandNonAdmin;")
+  end
+
+  it "updates the navigation after brand status is resolved" do
+    expect(view_source).to include('Brand.on("brand:status", function () {')
+    expect(view_source).to include("brandStatusReady = true;")
+    expect(view_source).to include("syncCreatorNavVisibility();")
+  end
+end


### PR DESCRIPTION
## Summary

Hide the Creator Center sidebar entry when running a branded installation without an owner license.

## Changes

- Reuse the existing `Brand.branded && !Brand.userLicensed` permission check.
- Hide the entry for unactivated and regular branded users.
- Keep the entry visible for brand owners and non-branded users.
- React to brand status changes without requiring a page refresh.
- Keep the entry hidden while brand status is loading to prevent visual flashing.

## Testing

- Added regression coverage for visibility and brand status updates.
- Passed 43 relevant specs with 0 failures.
- Verified on port 7070 that the entry is hidden for a regular branded user without leaving empty sidebar space.
- Confirmed no browser console errors.